### PR TITLE
feat(get web service metrics):CloudWatch metrics job

### DIFF
--- a/client/jobs_operations.go
+++ b/client/jobs_operations.go
@@ -59,3 +59,22 @@ func (r *RunnerClient) UpsertJobHeartbeat(jobID string) (bool, error) {
 	}
 	return reply.Stopping, nil
 }
+
+func (r *RunnerClient) UpdateJobOutputs(jobOutputs []jobs.UpdateJobOutputDtoV1) error {
+	if !r.isConnected {
+		return ErrConnection
+	}
+	args := jobs.UpdateJobOutputArgsV1{}
+	args.OrganizationID = r.GetComputedOrganizationID()
+	args.Token = r.token
+	args.Jobs = jobOutputs
+	var reply jobs.UpdateJobOutputReplyV1
+	err := r.c.Call("Jobs.UpdateOutputV1", args, &reply)
+	if err != nil {
+		return err
+	}
+	if !reply.Done {
+		return fmt.Errorf("error receiving done from the server")
+	}
+	return nil
+}

--- a/entrypoints/common/common.go
+++ b/entrypoints/common/common.go
@@ -6,6 +6,7 @@ import (
 	goShutdownHook "github.com/ankit-arora/go-utils/go-shutdown-hook"
 	"github.com/deployment-io/deployment-runner-kit/enums/cpu_architecture_enums"
 	"github.com/deployment-io/deployment-runner-kit/enums/os_enums"
+	"github.com/deployment-io/deployment-runner-kit/enums/parameters_enums"
 	"github.com/deployment-io/deployment-runner-kit/enums/runner_enums"
 	"github.com/deployment-io/deployment-runner-kit/jobs"
 	"github.com/deployment-io/deployment-runner-kit/types"
@@ -61,6 +62,8 @@ func executeJobs(jobsStream <-chan jobs.PendingJobDtoV1, noOfWorkers int, mode r
 				for pendingJob := range jobsStream {
 					func(pendingJob jobs.PendingJobDtoV1) {
 						parameters := pendingJob.Parameters
+						//add job id in parameters
+						_ = jobs.SetParameterValue(parameters, parameters_enums.JobID, pendingJob.JobID)
 						logger, err := loggers.Get(parameters)
 						if err != nil {
 							result := getJobResult(pendingJob, err.Error())

--- a/go.mod
+++ b/go.mod
@@ -7,10 +7,11 @@ toolchain go1.22.0
 require (
 	github.com/ankit-arora/go-utils v0.0.0-20230703175629-90641e500c7c
 	github.com/ankit-arora/ipnets v0.0.0-20230525113803-5d737bfe484b
-	github.com/aws/aws-sdk-go-v2 v1.26.1
+	github.com/aws/aws-sdk-go-v2 v1.27.2
 	github.com/aws/aws-sdk-go-v2/config v1.27.11
 	github.com/aws/aws-sdk-go-v2/service/acm v1.25.4
 	github.com/aws/aws-sdk-go-v2/service/cloudfront v1.36.0
+	github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.38.6
 	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.35.1
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.156.0
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.27.4
@@ -20,7 +21,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.53.1
 	github.com/aws/aws-sdk-go-v2/service/sts v1.28.6
 	github.com/aws/smithy-go v1.20.2
-	github.com/deployment-io/deployment-runner-kit v0.0.0-20240505162332-2a19cabb4dcb
+	github.com/deployment-io/deployment-runner-kit v0.0.0-20240618072435-ca6d3ea0894c
 	github.com/docker/docker v25.0.1+incompatible
 	github.com/joho/godotenv v1.5.1
 	go.mongodb.org/mongo-driver v1.14.0
@@ -32,8 +33,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.2 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.11 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.1 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.5 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.5 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.9 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.9 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.0 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.3.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/autoscaling v1.40.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/aws/aws-sdk-go-v2 v1.26.1 h1:5554eUqIYVWpU0YmeeYZ0wU64H2VLBs8TlhRB2L+EkA=
-github.com/aws/aws-sdk-go-v2 v1.26.1/go.mod h1:ffIFB97e2yNsv4aTSGkqtHnppsIJzw7G7BReUZ3jCXM=
+github.com/aws/aws-sdk-go-v2 v1.27.2 h1:pLsTXqX93rimAOZG2FIYraDQstZaaGVVN4tNw65v0h8=
+github.com/aws/aws-sdk-go-v2 v1.27.2/go.mod h1:ffIFB97e2yNsv4aTSGkqtHnppsIJzw7G7BReUZ3jCXM=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.2 h1:x6xsQXGSmW6frevwDA+vi/wqhp1ct18mVXYN08/93to=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.2/go.mod h1:lPprDr1e6cJdyYeGXnRaJoP4Md+cDBvi2eOj00BlGmg=
 github.com/aws/aws-sdk-go-v2/config v1.27.11 h1:f47rANd2LQEYHda2ddSCKYId18/8BhSRM4BULGmfgNA=
@@ -27,10 +27,10 @@ github.com/aws/aws-sdk-go-v2/credentials v1.17.11 h1:YuIB1dJNf1Re822rriUOTxopaHH
 github.com/aws/aws-sdk-go-v2/credentials v1.17.11/go.mod h1:AQtFPsDH9bI2O+71anW6EKL+NcD7LG3dpKGMV4SShgo=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.1 h1:FVJ0r5XTHSmIHJV6KuDmdYhEpvlHpiSd38RQWhut5J4=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.1/go.mod h1:zusuAeqezXzAB24LGuzuekqMAEgWkVYukBec3kr3jUg=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.5 h1:aw39xVGeRWlWx9EzGVnhOR4yOjQDHPQ6o6NmBlscyQg=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.5/go.mod h1:FSaRudD0dXiMPK2UjknVwwTYyZMRsHv3TtkabsZih5I=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.5 h1:PG1F3OD1szkuQPzDw3CIQsRIrtTlUC3lP84taWzHlq0=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.5/go.mod h1:jU1li6RFryMz+so64PpKtudI+QzbKoIEivqdf6LNpOc=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.9 h1:cy8ahBJuhtM8GTTSyOkfy6WVPV1IE+SS5/wfXUYuulw=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.9/go.mod h1:CZBXGLaJnEZI6EVNcPd7a6B5IC5cA/GkRWtu9fp3S6Y=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.9 h1:A4SYk07ef04+vxZToz9LWvAXl9LW0NClpPpMsi31cz0=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.9/go.mod h1:5jJcHuwDagxN+ErjQ3PU3ocf6Ylc/p9x+BLO/+X4iXw=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.0 h1:hT8rVHwugYE2lEfdFE0QWVo81lF7jMrYJVDWI+f+VxU=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.0/go.mod h1:8tu/lYfQfFe6IGnaOdrpVgEL2IrrDOf6/m9RQum4NkY=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.3.5 h1:81KE7vaZzrl7yHBYHVEzYB8sypz11NMOZ40YlWvPxsU=
@@ -41,6 +41,8 @@ github.com/aws/aws-sdk-go-v2/service/autoscaling v1.40.5 h1:vhdJymxlWS2qftzLiuCj
 github.com/aws/aws-sdk-go-v2/service/autoscaling v1.40.5/go.mod h1:ZErgk/bPaaZIpj+lUWGlwI1A0UFhSIscgnCPzTLnb2s=
 github.com/aws/aws-sdk-go-v2/service/cloudfront v1.36.0 h1:KbT1H0KXc26/M6km03gBWz5v1M5aOq4Cwo+aXJ2BpfM=
 github.com/aws/aws-sdk-go-v2/service/cloudfront v1.36.0/go.mod h1:Pphkts8iBnexoEpcMti5fUvN3/yoGRLtl2heOeppF70=
+github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.38.6 h1:UVjxYe8VGpwXYcmBcciBHlQrNssdEvntXCPWmnRR15U=
+github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.38.6/go.mod h1:4V6VDA0kZavRn71+sLpVna75oobnlG+gwtnNcBwZhu4=
 github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.35.1 h1:suWu59CRsDNhw2YXPpa6drYEetIUUIMUhkzHmucbCf8=
 github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.35.1/go.mod h1:tZiRxrv5yBRgZ9Z4OOOxwscAZRFk5DgYhEcjX1QpvgI=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.156.0 h1:TFK9GeUINErClL2+A+GLYhjiChVdaXCgIUiCsS/UQrE=
@@ -82,8 +84,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deployment-io/deployment-runner-kit v0.0.0-20240505162332-2a19cabb4dcb h1:WGj+6zZQul7gtXJxqyJaCQdmomuEco6RmIENx9sAIxM=
-github.com/deployment-io/deployment-runner-kit v0.0.0-20240505162332-2a19cabb4dcb/go.mod h1:7XM0DnB7Dri4bC4o9/yTwZIlBdujvnCcb3q/pXMI/0A=
+github.com/deployment-io/deployment-runner-kit v0.0.0-20240618072435-ca6d3ea0894c h1:BE/LWxQq3F/mHJno9x1/qyUvSwfnLoTWr6DhO8t+QtI=
+github.com/deployment-io/deployment-runner-kit v0.0.0-20240618072435-ca6d3ea0894c/go.mod h1:RIGreui95gssPI1IiEM6OBSeyniiHVSLUsxoXaDnD4Q=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/docker/docker v25.0.1+incompatible h1:k5TYd5rIVQRSqcTwCID+cyVA0yRg86+Pcrz1ls0/frA=

--- a/jobs/commands/list_cloudwatch_metrics_aws_web_service.go
+++ b/jobs/commands/list_cloudwatch_metrics_aws_web_service.go
@@ -1,0 +1,135 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
+	cloudwatch_types "github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+	"github.com/deployment-io/deployment-runner-kit/cloud_api_clients"
+	"github.com/deployment-io/deployment-runner-kit/enums/parameters_enums"
+	"github.com/deployment-io/deployment-runner-kit/jobs"
+	"io"
+	"time"
+)
+
+// ListCloudWatchMetricsAwsEcsWebService sends only CPU and memory utilization for now
+type ListCloudWatchMetricsAwsEcsWebService struct {
+}
+
+func (l *ListCloudWatchMetricsAwsEcsWebService) Run(parameters map[string]interface{}, logsWriter io.Writer) (newParameters map[string]interface{}, err error) {
+	io.WriteString(logsWriter, fmt.Sprintf("Listing cloudwatch metrics for web service\n"))
+	cloudwatchClient, err := cloud_api_clients.GetCloudwatchClient(parameters)
+	if err != nil {
+		return parameters, err
+	}
+	ecsClusterName, err := jobs.GetParameterValue[string](parameters, parameters_enums.EcsClusterName)
+	if err != nil {
+		return parameters, nil
+	}
+	ecsServiceName, err := getEcsServiceName(parameters)
+	if err != nil {
+		return parameters, err
+	}
+	now := time.Now()
+	before := now.Add(-10 * time.Minute)
+	getMetricDataOutput, err := cloudwatchClient.GetMetricData(context.TODO(), &cloudwatch.GetMetricDataInput{
+		EndTime: &now,
+		MetricDataQueries: []cloudwatch_types.MetricDataQuery{
+			{
+				Id: aws.String("cpu1"),
+				MetricStat: &cloudwatch_types.MetricStat{
+					Metric: &cloudwatch_types.Metric{
+						Dimensions: []cloudwatch_types.Dimension{
+							{
+								Name:  aws.String("ServiceName"),
+								Value: aws.String(ecsServiceName),
+							},
+							{
+								Name:  aws.String("ClusterName"),
+								Value: aws.String(ecsClusterName),
+							},
+						},
+						MetricName: aws.String("CPUUtilization"),
+						Namespace:  aws.String("AWS/ECS"),
+					},
+					Period: aws.Int32(60),
+					Stat:   aws.String("Average"),
+					Unit:   cloudwatch_types.StandardUnitPercent,
+				},
+				ReturnData: aws.Bool(true),
+			},
+			{
+				Id: aws.String("mem1"),
+				MetricStat: &cloudwatch_types.MetricStat{
+					Metric: &cloudwatch_types.Metric{
+						Dimensions: []cloudwatch_types.Dimension{
+							{
+								Name:  aws.String("ServiceName"),
+								Value: aws.String(ecsServiceName),
+							},
+							{
+								Name:  aws.String("ClusterName"),
+								Value: aws.String(ecsClusterName),
+							},
+						},
+						MetricName: aws.String("MemoryUtilization"),
+						Namespace:  aws.String("AWS/ECS"),
+					},
+					Period: aws.Int32(60),
+					Stat:   aws.String("Average"),
+					Unit:   cloudwatch_types.StandardUnitPercent,
+				},
+				ReturnData: aws.Bool(true),
+			},
+		},
+		StartTime: &before,
+	})
+
+	if err != nil {
+		return parameters, err
+	}
+
+	var latestCpuValue float64
+	var latestCpuTimestamp time.Time
+	var latestMemoryValue float64
+	var latestMemoryTimestamp time.Time
+	for _, metricDataResult := range getMetricDataOutput.MetricDataResults {
+		if *metricDataResult.Id == "cpu1" {
+			for i, timestamp := range metricDataResult.Timestamps {
+				if latestCpuTimestamp.IsZero() || timestamp.After(latestCpuTimestamp) {
+					latestCpuTimestamp = timestamp
+					latestCpuValue = metricDataResult.Values[i]
+				}
+			}
+		}
+		if *metricDataResult.Id == "mem1" {
+			for i, timestamp := range metricDataResult.Timestamps {
+				if latestMemoryTimestamp.IsZero() || timestamp.After(latestMemoryTimestamp) {
+					latestMemoryTimestamp = timestamp
+					latestMemoryValue = metricDataResult.Values[i]
+				}
+			}
+		}
+	}
+
+	shouldSendChatOutput, err := jobs.GetParameterValue[bool](parameters, parameters_enums.ShouldSendChatOutput)
+	if err != nil {
+		return parameters, err
+	}
+
+	if shouldSendChatOutput {
+		//send the results back
+		jobID, err := jobs.GetParameterValue[string](parameters, parameters_enums.JobID)
+		if err != nil {
+			return parameters, err
+		}
+		updateJobOutputPipeline.Add(updateJobOutputsKey, jobs.UpdateJobOutputDtoV1{
+			ID: jobID,
+			Output: fmt.Sprintf("Cpu utilization from Cloudwatch: %f%% at %s\n"+
+				"Memory utilization from Cloudwatch: %f%% at %s\n", latestCpuValue, latestCpuTimestamp, latestMemoryValue, latestMemoryTimestamp),
+		})
+	}
+
+	return parameters, err
+}


### PR DESCRIPTION
The AWS SDK version has been updated in the go.mod file. In addition, a new job has been added to list CloudWatch metrics for an AWS ECS web service. The new job retrieves CPU and memory utilization metrics from CloudWatch for a given ECS service and sends the details to the chat output if the `ShouldSendChatOutput` flag is set in the job parameters.