### PR TITLE
Refactor parameter extraction for deletion jobs

### DIFF
--- a/jobs/commands/delete_aws_web_service.go
+++ b/jobs/commands/delete_aws_web_service.go
@@ -24,6 +24,28 @@ type DeleteAwsWebService struct {
 func (d *DeleteAwsWebService) Run(parameters map[string]interface{}, logsWriter io.Writer) (newParameters map[string]interface{}, err error) {
 	//stop service //delete service
 	io.WriteString(logsWriter, fmt.Sprintf("Deleting web service\n"))
+	deploymentID, err := jobs.GetParameterValue[string](parameters, parameters_enums.DeploymentID)
+	if err != nil {
+		return parameters, err
+	}
+	var organizationIdFromJob string
+	organizationIdFromJob, err = jobs.GetParameterValue[string](parameters, parameters_enums.OrganizationIdFromJob)
+	if err != nil {
+		return parameters, err
+	}
+	if !isPreview(parameters) {
+		//update deployment to deleted and delete domain
+		updateDeploymentsPipeline.Add(organizationIdFromJob, deployments.UpdateDeploymentDtoV1{
+			ID:            deploymentID,
+			DeletionState: deployment_enums.DeletionInProcess,
+		})
+	} else {
+		previewID := deploymentID
+		updatePreviewsPipeline.Add(organizationIdFromJob, previews.UpdatePreviewDtoV1{
+			ID:            previewID,
+			DeletionState: deployment_enums.DeletionInProcess,
+		})
+	}
 	clusterArn, err := jobs.GetParameterValue[string](parameters, parameters_enums.EcsClusterArn)
 	if err != nil {
 		return parameters, err
@@ -165,15 +187,6 @@ func (d *DeleteAwsWebService) Run(parameters map[string]interface{}, logsWriter 
 		return parameters, err
 	}
 
-	deploymentID, err := jobs.GetParameterValue[string](parameters, parameters_enums.DeploymentID)
-	if err != nil {
-		return parameters, err
-	}
-	var organizationIdFromJob string
-	organizationIdFromJob, err = jobs.GetParameterValue[string](parameters, parameters_enums.OrganizationIdFromJob)
-	if err != nil {
-		return parameters, err
-	}
 	if !isPreview(parameters) {
 		//update deployment to deleted and delete domain
 		updateDeploymentsPipeline.Add(organizationIdFromJob, deployments.UpdateDeploymentDtoV1{


### PR DESCRIPTION
Moved the extraction of deployment parameters and organization IDs earlier in the deletion process for both static sites and web services. This restructuring reduces repeated code and ensures parameters are consistently handled before proceeding with deletion operations.