### PR TITLE
Add Bloom filter for deduplication in log processing

### DIFF
--- a/automation/tools/get_application_logs/get_application_logs.go
+++ b/automation/tools/get_application_logs/get_application_logs.go
@@ -436,9 +436,9 @@ func (t *Tool) Call(ctx context.Context, input string) (string, error) {
 	out := string(outBytes)
 	if t.CallbacksHandler != nil {
 		smallOut := out
-		if len(smallOut) > 200 {
-			smallOut = smallOut[:200] + "..."
-		}
+		//if len(smallOut) > 200 {
+		//	smallOut = smallOut[:200] + "..."
+		//}
 		info := fmt.Sprintf("Exiting get application logs with output: %s : original logs count: %d : "+
 			"filtered logs count: %d", smallOut, originalLogsCount, filteredLogsCount)
 		t.CallbacksHandler.HandleToolEnd(ctx, info)


### PR DESCRIPTION
Introduced a Bloom filter with configurable parameters to enhance log deduplication and reduce processing overhead. Updated log retrieval methods to integrate shingled Bloom filter checks, ensuring similar log messages are skipped. Adjusted dependencies in `go.mod` and `go.sum` to include required libraries.