### PR TITLE
Update threshold for log filtering to 0.9

### DIFF
--- a/automation/tools/get_application_logs/get_application_logs.go
+++ b/automation/tools/get_application_logs/get_application_logs.go
@@ -407,7 +407,7 @@ func (t *Tool) Call(ctx context.Context, input string) (string, error) {
 	numHashFunctions := math.Ceil((float64(m) / float64(numElements)) * math.Log(2))
 	filter := bloom.New(m, uint(numHashFunctions))
 	k := 4
-	threshold := 0.7
+	threshold := 0.9
 	if len(searchPattern) > 0 {
 		logs, err = getFilteredEventLogs(cloudwatchLogsClient, logGroupName, logStreamPrefix, searchPattern,
 			endTimeInMilliseconds, startTimeInMilliSeconds, t.LogsWriter, filter, k, threshold)


### PR DESCRIPTION
Increased the threshold from 0.7 to 0.9 to refine the log filtering process. This adjustment aims to enhance the accuracy of event log retrieval based on the specified search pattern.