### PR TITLE
Remove output truncation in get_application_logs tool

### DIFF
--- a/automation/tools/get_application_logs/get_application_logs.go
+++ b/automation/tools/get_application_logs/get_application_logs.go
@@ -436,9 +436,9 @@ func (t *Tool) Call(ctx context.Context, input string) (string, error) {
 	out := string(outBytes)
 	if t.CallbacksHandler != nil {
 		smallOut := out
-		if len(smallOut) > 200 {
-			smallOut = smallOut[:200] + "..."
-		}
+		//if len(smallOut) > 200 {
+		//	smallOut = smallOut[:200] + "..."
+		//}
 		info := fmt.Sprintf("Exiting get application logs with output: %s : original logs count: %d : "+
 			"filtered logs count: %d", smallOut, originalLogsCount, filteredLogsCount)
 		t.CallbacksHandler.HandleToolEnd(ctx, info)


### PR DESCRIPTION
Disabled the logic that truncates the output to 200 characters. This ensures the full log output is passed to the CallbacksHandler for better debugging and clarity.