### PR TITLE
Add DebugOpenAICalls flag to tools for enhanced logging control

### DIFF
--- a/automation/tools/get_application_logs/get_application_logs.go
+++ b/automation/tools/get_application_logs/get_application_logs.go
@@ -24,6 +24,7 @@ type Tool struct {
 	LogsWriter       io.Writer
 	CallbacksHandler callbacks.Handler
 	Entities         []automation_enums.Entity
+	DebugOpenAICalls bool
 }
 
 func (t *Tool) entitiesString() string {
@@ -436,9 +437,12 @@ func (t *Tool) Call(ctx context.Context, input string) (string, error) {
 	out := string(outBytes)
 	if t.CallbacksHandler != nil {
 		smallOut := out
-		//if len(smallOut) > 200 {
-		//	smallOut = smallOut[:200] + "..."
-		//}
+		if !t.DebugOpenAICalls {
+			//show all logs only in debug mode
+			if len(smallOut) > 200 {
+				smallOut = smallOut[:200] + "..."
+			}
+		}
 		info := fmt.Sprintf("Exiting get application logs with output: %s : original logs count: %d : "+
 			"filtered logs count: %d", smallOut, originalLogsCount, filteredLogsCount)
 		t.CallbacksHandler.HandleToolEnd(ctx, info)

--- a/automation/tools/tools.go
+++ b/automation/tools/tools.go
@@ -22,7 +22,8 @@ func GetToolFromType(toolType automation_enums.ToolType, options Options) (tools
 			Entities:         toolType.GetEntities(),
 		}, nil
 	case automation_enums.SendEmail:
-		tool, err := send_email.NewTool(options.Parameters, options.LogsWriter, options.CallbacksHandler)
+		tool, err := send_email.NewTool(options.Parameters, options.LogsWriter, options.CallbacksHandler,
+			options.DebugOpenAICalls)
 		if err != nil {
 			return nil, err
 		}
@@ -33,6 +34,7 @@ func GetToolFromType(toolType automation_enums.ToolType, options Options) (tools
 			LogsWriter:       options.LogsWriter,
 			CallbacksHandler: options.CallbacksHandler,
 			Entities:         toolType.GetEntities(),
+			DebugOpenAICalls: options.DebugOpenAICalls,
 		}, nil
 	default:
 		return nil, fmt.Errorf("tool type %s not supported", toolType.String())
@@ -43,6 +45,7 @@ type Options struct {
 	Parameters       map[string]interface{}
 	LogsWriter       io.Writer
 	CallbacksHandler callbacks.Handler
+	DebugOpenAICalls bool
 }
 
 func GetToolWrappedOnAgent(agentTools []tools.Tool, agentName, agentGoal, agentBackstory, llm string,


### PR DESCRIPTION
This commit introduces the `DebugOpenAICalls` flag across several tools, enabling fine-grained control over log verbosity. When disabled, long logs are truncated to improve readability, while full logs are preserved in debug mode. Changes include updates to tool initialization, struct definitions, and callback handling to support this functionality.