### PR TITLE
Add debug logging to `GetDeploymentLogsAws` and improve visibility in…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.31.1
 	github.com/aws/aws-sdk-go-v2/service/sts v1.28.6
 	github.com/aws/smithy-go v1.22.2
-	github.com/deployment-io/deployment-runner-kit v0.0.0-20260323084551-e5d1c0470aab
+	github.com/deployment-io/deployment-runner-kit v0.0.0-20260324043447-e3e1d37a31f9
 	github.com/deployment-io/team-ai v0.0.0-20250917084912-bdbad6a834e1
 	github.com/docker/docker v27.3.0+incompatible
 	github.com/go-git/go-billy/v5 v5.6.0

--- a/go.sum
+++ b/go.sum
@@ -151,8 +151,8 @@ github.com/cyphar/filepath-securejoin v0.2.5/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxG
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deployment-io/deployment-runner-kit v0.0.0-20260323084551-e5d1c0470aab h1:QtwUzZtz3KYdJDTekdVnG8zuIJl1g3sRTZNMuJTt5L8=
-github.com/deployment-io/deployment-runner-kit v0.0.0-20260323084551-e5d1c0470aab/go.mod h1:OEoIfAAL2cUkK4Rf0rpW32YqHw7Mgx2aaC7o07IGAhQ=
+github.com/deployment-io/deployment-runner-kit v0.0.0-20260324043447-e3e1d37a31f9 h1:s/MTDV367wB+yWDQOScfZt+9hLLNmDHX4i2dg+6eyPU=
+github.com/deployment-io/deployment-runner-kit v0.0.0-20260324043447-e3e1d37a31f9/go.mod h1:OEoIfAAL2cUkK4Rf0rpW32YqHw7Mgx2aaC7o07IGAhQ=
 github.com/deployment-io/team-ai v0.0.0-20250917084912-bdbad6a834e1 h1:gfeNqym19IiO38sQ84WPMmZXrdDisu64qQP3Xs0N2RM=
 github.com/deployment-io/team-ai v0.0.0-20250917084912-bdbad6a834e1/go.mod h1:B0fxmLJICi0qP2R2m3I2tR1uRIKQxn4ekK67lyBRHjw=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=

--- a/jobs/commands/get_deployment_logs_aws.go
+++ b/jobs/commands/get_deployment_logs_aws.go
@@ -49,11 +49,17 @@ func (g *GetDeploymentLogsAws) Run(parameters map[string]interface{}, logsWriter
 	// Log stream prefix is optional — databases and deployments without builds won't have one
 	logStreamPrefix, _ := utils.GetApplicationLogStreamPrefix(parameters)
 
+	debug, _ := jobs.GetParameterValue[bool](parameters, parameters_enums.DebugGetDeploymentLogs)
+	if debug {
+		fmt.Printf("[DEBUG] logGroupName=%s logStreamPrefix=%s startTimeMs=%d endTimeMs=%d searchPattern=%s\n",
+			logGroupName, logStreamPrefix, startTimeMs, endTimeMs, searchPattern)
+	}
+
 	var logs []map[string]interface{}
 	if len(searchPattern) > 0 {
-		logs, err = getFilteredLogs(cloudwatchLogsClient, logGroupName, logStreamPrefix, searchPattern, startTimeMs, endTimeMs)
+		logs, err = getFilteredLogs(cloudwatchLogsClient, logGroupName, logStreamPrefix, searchPattern, startTimeMs, endTimeMs, debug)
 	} else {
-		logs, err = getLogs(cloudwatchLogsClient, logGroupName, logStreamPrefix, startTimeMs, endTimeMs)
+		logs, err = getLogs(cloudwatchLogsClient, logGroupName, logStreamPrefix, startTimeMs, endTimeMs, debug)
 	}
 	if err != nil {
 		return parameters, err
@@ -81,7 +87,7 @@ func (g *GetDeploymentLogsAws) Run(parameters map[string]interface{}, logsWriter
 }
 
 func getLogs(client *cloudwatchlogs.Client, logGroupName, logStreamPrefix string,
-	startTimeMs, endTimeMs int64) ([]map[string]interface{}, error) {
+	startTimeMs, endTimeMs int64, debug bool) ([]map[string]interface{}, error) {
 
 	// Find the most recent log stream matching the prefix (or any stream if prefix is empty)
 	describeInput := &cloudwatchlogs.DescribeLogStreamsInput{
@@ -97,10 +103,16 @@ func getLogs(client *cloudwatchlogs.Client, logGroupName, logStreamPrefix string
 		return nil, fmt.Errorf("failed to describe log streams: %w", err)
 	}
 	if len(describeOutput.LogStreams) == 0 {
+		if debug {
+			fmt.Printf("[DEBUG] No log streams found for logGroup=%s prefix=%s\n", logGroupName, logStreamPrefix)
+		}
 		return nil, nil
 	}
 
 	logStreamName := aws.ToString(describeOutput.LogStreams[0].LogStreamName)
+	if debug {
+		fmt.Printf("[DEBUG] Using log stream: %s\n", logStreamName)
+	}
 	var allEvents []cwTypes.OutputLogEvent
 	var nextToken *string
 	for {
@@ -114,6 +126,9 @@ func getLogs(client *cloudwatchlogs.Client, logGroupName, logStreamPrefix string
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to get log events: %w", err)
+		}
+		if debug {
+			fmt.Printf("[DEBUG] getLogs: page returned %d events\n", len(output.Events))
 		}
 		allEvents = append(allEvents, output.Events...)
 		if len(allEvents) >= maxLogLines {
@@ -130,7 +145,7 @@ func getLogs(client *cloudwatchlogs.Client, logGroupName, logStreamPrefix string
 }
 
 func getFilteredLogs(client *cloudwatchlogs.Client, logGroupName, logStreamPrefix, filterPattern string,
-	startTimeMs, endTimeMs int64) ([]map[string]interface{}, error) {
+	startTimeMs, endTimeMs int64, debug bool) ([]map[string]interface{}, error) {
 
 	filterInput := &cloudwatchlogs.FilterLogEventsInput{
 		LogGroupName:  aws.String(logGroupName),
@@ -141,6 +156,10 @@ func getFilteredLogs(client *cloudwatchlogs.Client, logGroupName, logStreamPrefi
 	if len(logStreamPrefix) > 0 {
 		filterInput.LogStreamNamePrefix = aws.String(logStreamPrefix)
 	}
+	if debug {
+		fmt.Printf("[DEBUG] getFilteredLogs: logGroup=%s prefix=%s filterPattern=%%%s%% startTimeMs=%d endTimeMs=%d\n",
+			logGroupName, logStreamPrefix, filterPattern, startTimeMs, endTimeMs)
+	}
 
 	var allEvents []cwTypes.FilteredLogEvent
 	var nextToken *string
@@ -149,6 +168,9 @@ func getFilteredLogs(client *cloudwatchlogs.Client, logGroupName, logStreamPrefi
 		output, err := client.FilterLogEvents(context.TODO(), filterInput)
 		if err != nil {
 			return nil, fmt.Errorf("failed to filter log events: %w", err)
+		}
+		if debug {
+			fmt.Printf("[DEBUG] getFilteredLogs: page returned %d events\n", len(output.Events))
 		}
 		allEvents = append(allEvents, output.Events...)
 		if len(allEvents) >= maxLogLines {


### PR DESCRIPTION
…to log fetch operations

- Adds a `debug` parameter to `getLogs` and `getFilteredLogs`, printing detailed debug information during log fetching.
- Helps diagnose issues with log stream selection and event retrieval.