### PR TITLE
Tasks: prefer pr_title from agent; surface turns count

### DIFF
--- a/jobs/commands/commit_and_push.go
+++ b/jobs/commands/commit_and_push.go
@@ -315,6 +315,13 @@ type agentOutput struct {
 	// to the dashboard so users can suggest allowlist additions
 	// without parsing container logs. Empty when no denies happened.
 	DeniedHosts []string `json:"denied_hosts,omitempty"`
+	// PRTitle is the agent-produced short title for the resulting PR.
+	// Distinct from ChangesSummary so OpenPullRequest can pick a clean
+	// title instead of taking the first line of a long single-line
+	// narrative. Empty when the agentbox image predates the pr_title
+	// field; OpenPullRequest falls back to truncated first line of
+	// ChangesSummary in that case.
+	PRTitle string `json:"pr_title,omitempty"`
 }
 
 // mergeRepositoriesIntoJobOutput reads existing JobOutput JSON (any prior

--- a/jobs/commands/commit_and_push.go
+++ b/jobs/commands/commit_and_push.go
@@ -308,7 +308,14 @@ type jobOutputData struct {
 type agentOutput struct {
 	ChangesSummary string     `json:"changes_summary,omitempty"`
 	TokenUsage     tokenUsage `json:"token_usage"`
-	ExitCode       int        `json:"exit_code,omitempty"`
+	// Turns is the per-run turn count agentbox writes to /result.json.
+	// Surfaced on the JobOutput envelope so app-server's projection
+	// can populate AgentRunSummary.Turns for completed runs — the
+	// dashboard prefers this over LiveProgress when the run is in a
+	// terminal state, because a run that finishes faster than agentbox's
+	// progress.json writer interval (~5s) leaves LiveProgress at zero.
+	Turns    int `json:"turns,omitempty"`
+	ExitCode int `json:"exit_code,omitempty"`
 	// DeniedHosts is the dedup-sorted list of hostnames the agentbox
 	// proxy refused due to allowlist mismatches during this Step run.
 	// Populated by RunAgentStep from agentbox's /result.json. Surfaced

--- a/jobs/commands/open_pull_request.go
+++ b/jobs/commands/open_pull_request.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/deployment-io/deployment-runner-kit/enums/parameters_enums"
 	"github.com/deployment-io/deployment-runner-kit/jobs"
@@ -58,6 +59,7 @@ func (opr *OpenPullRequest) Run(parameters map[string]interface{}, logsWriter io
 		logsWriter:   logsWriter,
 		deniedHosts:  deniedHosts,
 		agentSummary: readAgentSummaryFromJobOutput(parameters),
+		agentPRTitle: readAgentPRTitleFromJobOutput(parameters),
 	}
 	prOutputs, err := opener.openAll(hasChangesByIndex)
 	if err != nil {
@@ -84,6 +86,11 @@ type taskOpenPR struct {
 	logsWriter   io.Writer
 	deniedHosts  []string
 	agentSummary string // agent.changes_summary from /result.json; "" when missing
+	// agentPRTitle is the agent-produced short PR title from /result.json
+	// (newer agentbox images that emit pr_title). Empty when the agentbox
+	// image predates the field — subjectAndLeadIn falls through to the
+	// truncated-first-line-of-changes_summary path.
+	agentPRTitle string
 }
 
 // openAll iterates the Job's repositories. Skips repos where
@@ -138,21 +145,16 @@ func (opr *taskOpenPR) openOne(idx int, entry tasks.RepositoryEntry) (repoOutput
 	}, nil
 }
 
-// buildPRTitleAndBody mirrors CommitAndPush's commit-message shape so
-// the PR description matches the commit:
+// buildPRTitleAndBody assembles the PR subject + body. Subject source
+// is decided by subjectAndLeadIn (agent pr_title > changes_summary
+// first line > generic fallback; see that function for the policy).
 //
-//   - When the agent produced a changes_summary, the first line becomes
-//     the PR title and the remainder becomes the PR body lead-in
-//     (matches the commit subject/body split).
-//   - Without a summary, falls back to "Tasks Step <N>: <title>" with no
-//     lead-in (Step ran but didn't produce one, or runtime pre-dates
-//     the RunAgentStep producer).
-//
-// Trailer block + denied-hosts section are uniform across both cases.
-// When the Step had allowlist denies, an additional section lists the
-// blocked hostnames so the PR reviewer can see what the agent tried
-// to reach. Helps diagnose "agent gave up because it couldn't fetch X"
-// scenarios without digging through the runner's container logs.
+// Body composition: lead-in first (when present) so reviewers see the
+// agent's narrative before metadata, then the trailer block, then the
+// optional denied-hosts section. When the Step had allowlist denies,
+// the section lists the blocked hostnames so the PR reviewer can see
+// what the agent tried to reach — helps diagnose "agent gave up
+// because it couldn't fetch X" without digging through container logs.
 func (opr *taskOpenPR) buildPRTitleAndBody() (string, string) {
 	subject, leadIn := opr.subjectAndLeadIn()
 	var sb strings.Builder
@@ -176,19 +178,61 @@ func (opr *taskOpenPR) buildPRTitleAndBody() (string, string) {
 	return subject, sb.String()
 }
 
-// subjectAndLeadIn mirrors taskCommitPush.subjectAndBody so the PR
-// title/lead-in matches the commit subject/body. Returns the agent's
-// changes_summary first-line as subject and remainder as lead-in when
-// present; falls back to the generic "Tasks Step N: <title>" subject
-// with empty lead-in otherwise.
+// subjectAndLeadIn picks the PR subject + body lead-in from whichever
+// source is available, with defensive truncation against agents that
+// ignore the 72-char instruction:
+//
+//   1. Newer agentbox (v1.x+ with pr_title): use agentPRTitle, capped
+//      at 72 chars. Full changes_summary becomes the lead-in body.
+//   2. Older agentbox (no pr_title): split changes_summary at its
+//      first newline. Short first line → use as-is; long first line →
+//      cap AND keep the full narrative as the body so reviewers don't
+//      lose context.
+//   3. No agent output at all: generic "Tasks Step N: <title>".
+//
+// Bug 2 fix: the pre-fix code emitted the entire first line as the PR
+// title regardless of length. A 119-char single-line narrative ended
+// up as the literal PR title. capTitle prevents that recurrence even
+// if the agent doesn't follow the instruction.
 func (opr *taskOpenPR) subjectAndLeadIn() (string, string) {
+	if len(opr.agentPRTitle) > 0 {
+		return capTitle(opr.agentPRTitle, prTitleMaxRunes), strings.TrimSpace(opr.agentSummary)
+	}
 	if len(opr.agentSummary) > 0 {
-		if idx := strings.Index(opr.agentSummary, "\n"); idx > 0 {
-			return strings.TrimSpace(opr.agentSummary[:idx]), strings.TrimSpace(opr.agentSummary[idx+1:])
+		first, rest := splitFirstLine(opr.agentSummary)
+		if utf8.RuneCountInString(first) <= prTitleMaxRunes {
+			return first, rest
 		}
-		return strings.TrimSpace(opr.agentSummary), ""
+		return capTitle(first, prTitleMaxRunes), strings.TrimSpace(opr.agentSummary)
 	}
 	return fmt.Sprintf("Tasks Step %d: %s", opr.ctx.StepIndex+1, opr.ctx.TaskTitle), ""
+}
+
+// prTitleMaxRunes is the defensive cap on PR title length. Matches the
+// instruction agentbox gives the agent in its system prompt (72 chars
+// = Conventional Commits + GitHub PR title soft limit). Counted in
+// runes, not bytes, so multi-byte titles aren't double-counted.
+const prTitleMaxRunes = 72
+
+// capTitle truncates s to at most n runes (not bytes — respects
+// multi-byte chars). Appends "…" when truncation occurred so the title
+// visibly signals that it was clipped.
+func capTitle(s string, n int) string {
+	s = strings.TrimSpace(s)
+	if utf8.RuneCountInString(s) <= n {
+		return s
+	}
+	runes := []rune(s)
+	return string(runes[:n-1]) + "…"
+}
+
+// splitFirstLine returns (firstLine, rest), both trimmed of surrounding
+// whitespace. When s has no newline, returns (trimmed s, "").
+func splitFirstLine(s string) (string, string) {
+	if idx := strings.IndexByte(s, '\n'); idx >= 0 {
+		return strings.TrimSpace(s[:idx]), strings.TrimSpace(s[idx+1:])
+	}
+	return strings.TrimSpace(s), ""
 }
 
 // mergeIntoJobOutput reads the existing JobOutput (with CommitAndPush's
@@ -229,6 +273,26 @@ func readDeniedHostsFromJobOutput(parameters map[string]interface{}) ([]string, 
 		return nil, nil
 	}
 	return data.Agent.DeniedHosts, nil
+}
+
+// readAgentPRTitleFromJobOutput pulls the agent.pr_title field that
+// RunAgentStep populated from agentbox's /result.json. Returns "" on
+// missing/malformed payloads so the caller's fallback path (truncated
+// first line of changes_summary) fires — keeps backward-compat with
+// older agentbox images that didn't emit pr_title.
+func readAgentPRTitleFromJobOutput(parameters map[string]interface{}) string {
+	existing, err := jobs.GetParameterValue[string](parameters, parameters_enums.JobOutput)
+	if err != nil || len(existing) == 0 {
+		return ""
+	}
+	var data jobOutputData
+	if err := json.Unmarshal([]byte(existing), &data); err != nil {
+		return ""
+	}
+	if data.Agent == nil {
+		return ""
+	}
+	return data.Agent.PRTitle
 }
 
 // readHasChangesFromJobOutput pulls the per-repo HasChanges flags that

--- a/jobs/commands/open_pull_request_test.go
+++ b/jobs/commands/open_pull_request_test.go
@@ -7,11 +7,25 @@ import (
 	commandUtils "github.com/deployment-io/deployment-runner/jobs/commands/utils"
 )
 
-// TestTaskOpenPR_SubjectAndLeadIn pins the PR title/body source: when
-// the agent produced a changes_summary, the first line is the PR title
-// and the rest is the lead-in. Without a summary, falls back to
-// "Tasks Step N: <title>" with empty lead-in. Symmetric with
-// taskCommitPush.subjectAndBody so commit + PR shapes match.
+// TestTaskOpenPR_SubjectAndLeadIn pins the Bug 2 fix's subject/body
+// policy. Five branches:
+//
+//  1. Newer agentbox (pr_title set, short): pr_title is the subject,
+//     full changes_summary is the lead-in. Prefer the agent-produced
+//     title even when changes_summary has a usable first line.
+//  2. Newer agentbox (pr_title set, long): defensive 72-rune cap with
+//     ellipsis. Guards against an agent that ignores the system-prompt
+//     instruction.
+//  3. Older agentbox (no pr_title, short first line of summary):
+//     first line is the subject, rest is the lead-in. Matches pre-fix
+//     behavior so a mixed-version production fleet stays sensible.
+//  4. Older agentbox (no pr_title, long first line — the original Bug
+//     2 case): cap the first line, preserve the FULL narrative as the
+//     lead-in. Previously the entire 119-char line landed as the PR
+//     title; now reviewers see a tidy title + the full context in the
+//     body.
+//  5. No agent output at all: generic "Tasks Step N: <title>" subject,
+//     empty lead-in.
 func TestTaskOpenPR_SubjectAndLeadIn(t *testing.T) {
 	ctx := commandUtils.TaskJobContext{
 		OrganizationID: "org-1",
@@ -20,26 +34,55 @@ func TestTaskOpenPR_SubjectAndLeadIn(t *testing.T) {
 		StepIndex:      0, // → "Tasks Step 1" fallback
 	}
 
+	// 119-char single-line narrative — the exact shape that produced
+	// the production bug. Asserting it gets capped here pins the fix.
+	longFirstLine := "Updated `scripts.build` in `/work/0-deployment-io/dashboard/package.json:8` — single-line change, no other fields touched."
+
 	cases := []struct {
 		name        string
+		prTitle     string
 		summary     string
 		wantSubject string
 		wantLeadIn  string
 	}{
 		{
-			name:        "multi-line summary splits",
+			name:        "newer agentbox: short pr_title is preferred over summary first line",
+			prTitle:     "Add OAuth login to auth-service",
+			summary:     "Add OAuth login\n\nDetailed description across lines.",
+			wantSubject: "Add OAuth login to auth-service",
+			wantLeadIn:  "Add OAuth login\n\nDetailed description across lines.",
+		},
+		{
+			name:        "newer agentbox: long pr_title is defensively capped",
+			prTitle:     "This agent ignored the 72-char instruction and produced a wildly overlong title that goes on and on and on",
+			summary:     "Body text.",
+			wantSubject: "This agent ignored the 72-char instruction and produced a wildly overlo…",
+			wantLeadIn:  "Body text.",
+		},
+		{
+			name:        "older agentbox: short multi-line summary splits at newline",
+			prTitle:     "",
 			summary:     "Add OAuth login\n\nDetailed description across lines.",
 			wantSubject: "Add OAuth login",
 			wantLeadIn:  "Detailed description across lines.",
 		},
 		{
-			name:        "single-line summary yields empty lead-in",
+			name:        "older agentbox: single-line short summary yields empty lead-in",
+			prTitle:     "",
 			summary:     "Add OAuth login",
 			wantSubject: "Add OAuth login",
 			wantLeadIn:  "",
 		},
 		{
-			name:        "absent summary falls back",
+			name:        "older agentbox: long first line is capped AND preserved as lead-in (Bug 2 production case)",
+			prTitle:     "",
+			summary:     longFirstLine,
+			wantSubject: "Updated `scripts.build` in `/work/0-deployment-io/dashboard/package.jso…",
+			wantLeadIn:  longFirstLine,
+		},
+		{
+			name:        "no agent output at all: generic fallback",
+			prTitle:     "",
 			summary:     "",
 			wantSubject: "Tasks Step 1: My Task",
 			wantLeadIn:  "",
@@ -47,13 +90,66 @@ func TestTaskOpenPR_SubjectAndLeadIn(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			opr := &taskOpenPR{ctx: ctx, agentSummary: tc.summary}
+			opr := &taskOpenPR{ctx: ctx, agentPRTitle: tc.prTitle, agentSummary: tc.summary}
 			subject, leadIn := opr.subjectAndLeadIn()
 			if subject != tc.wantSubject {
 				t.Errorf("subject = %q, want %q", subject, tc.wantSubject)
 			}
 			if leadIn != tc.wantLeadIn {
 				t.Errorf("leadIn = %q, want %q", leadIn, tc.wantLeadIn)
+			}
+		})
+	}
+}
+
+// TestCapTitle pins the rune-aware truncation behavior. Multi-byte
+// titles can't be byte-counted without breaking glyphs; capTitle uses
+// utf8.RuneCountInString and slices runes, not bytes.
+func TestCapTitle(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		n    int
+		want string
+	}{
+		{"under limit returns as-is", "hello", 10, "hello"},
+		{"equal to limit returns as-is", "hello", 5, "hello"},
+		{"over limit truncates with ellipsis", "hello world", 7, "hello …"},
+		{"trims surrounding whitespace before measuring", "  hello  ", 10, "hello"},
+		{"multi-byte runes are not byte-counted", "héllo wörld", 7, "héllo …"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := capTitle(tc.in, tc.n); got != tc.want {
+				t.Errorf("capTitle(%q, %d) = %q, want %q", tc.in, tc.n, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSplitFirstLine pins the (firstLine, rest) split semantics. Both
+// sides are trimmed; no-newline input returns ("input", "").
+func TestSplitFirstLine(t *testing.T) {
+	cases := []struct {
+		name      string
+		in        string
+		wantFirst string
+		wantRest  string
+	}{
+		{"no newline", "single line only", "single line only", ""},
+		{"newline with body", "first\nrest of body", "first", "rest of body"},
+		{"blank line between subject and body", "first\n\nbody", "first", "body"},
+		{"trims surrounding whitespace on both halves", "  first  \n  rest  ", "first", "rest"},
+		{"empty input", "", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			first, rest := splitFirstLine(tc.in)
+			if first != tc.wantFirst {
+				t.Errorf("first = %q, want %q", first, tc.wantFirst)
+			}
+			if rest != tc.wantRest {
+				t.Errorf("rest = %q, want %q", rest, tc.wantRest)
 			}
 		})
 	}

--- a/jobs/commands/run_agent_step.go
+++ b/jobs/commands/run_agent_step.go
@@ -685,9 +685,16 @@ type agentResult struct {
 	AgentVersion   string     `json:"agent_version,omitempty"`
 	ChangesSummary string     `json:"changes_summary,omitempty"`
 	TokenUsage     tokenUsage `json:"token_usage"`
-	TurnCount      int        `json:"turn_count,omitempty"`
-	Error          string     `json:"error,omitempty"`
-	DeniedHosts    []string   `json:"denied_hosts,omitempty"`
+	// Turns is agentbox's per-run turn count (internal/result.Outcome.Turns,
+	// emitted as "turns"). The runner previously declared this as TurnCount
+	// with json:"turn_count" — neither name matched agentbox's wire shape,
+	// so the field always parsed as zero and the dashboard rendered
+	// "Turn 0" on completed runs even when liveProgress had been replaced
+	// by the final result.json. Carried through to agentOutput by
+	// mergeAgentResultIntoJobOutput so app-server's projection picks it up.
+	Turns       int      `json:"turns,omitempty"`
+	Error       string   `json:"error,omitempty"`
+	DeniedHosts []string `json:"denied_hosts,omitempty"`
 	// PRTitle is the agent-produced short title for the resulting
 	// pull request. Distinct from ChangesSummary (longer, what + why).
 	PRTitle string `json:"pr_title,omitempty"`
@@ -747,6 +754,7 @@ func mergeAgentResultIntoJobOutput(parameters map[string]interface{}, result age
 	data.Agent = &agentOutput{
 		ChangesSummary: result.ChangesSummary,
 		TokenUsage:     result.TokenUsage,
+		Turns:          result.Turns,
 		ExitCode:       result.ExitCode,
 		DeniedHosts:    result.DeniedHosts,
 		PRTitle:        result.PRTitle,

--- a/jobs/commands/run_agent_step.go
+++ b/jobs/commands/run_agent_step.go
@@ -670,6 +670,12 @@ type agentResult struct {
 	TurnCount      int      `json:"turn_count,omitempty"`
 	Error          string   `json:"error,omitempty"`
 	DeniedHosts    []string `json:"denied_hosts,omitempty"`
+	// PRTitle is the agent-produced short title for the resulting
+	// pull request. Distinct from ChangesSummary (longer, what + why).
+	// Empty when the agentbox image predates the pr_title field —
+	// downstream OpenPullRequest falls back to a truncated first line
+	// of ChangesSummary in that case.
+	PRTitle string `json:"pr_title,omitempty"`
 }
 
 func readAgentResult(workDirHost string) (agentResult, error) {
@@ -703,6 +709,7 @@ func mergeAgentResultIntoJobOutput(parameters map[string]interface{}, result age
 		TokenUsage:     result.TokenUsage,
 		ExitCode:       result.ExitCode,
 		DeniedHosts:    result.DeniedHosts,
+		PRTitle:        result.PRTitle,
 	}
 	merged, err := json.Marshal(data)
 	if err != nil {

--- a/jobs/commands/run_agent_step_test.go
+++ b/jobs/commands/run_agent_step_test.go
@@ -1,10 +1,14 @@
 package commands
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/deployment-io/deployment-runner-kit/enums/parameters_enums"
+	"github.com/deployment-io/deployment-runner-kit/jobs"
 )
 
 func TestResolveContainerLimits_Defaults(t *testing.T) {
@@ -85,7 +89,7 @@ func TestReadAgentResult_TokenUsageObjectShape(t *testing.T) {
 		"agent_type": "claude-code",
 		"agent_version": "2.1.141",
 		"changes_summary": "edited 1 file",
-		"turn_count": 3,
+		"turns": 3,
 		"token_usage": {
 			"input_tokens": 1234,
 			"output_tokens": 567,
@@ -103,6 +107,9 @@ func TestReadAgentResult_TokenUsageObjectShape(t *testing.T) {
 	}
 	if got.Status != "success" {
 		t.Errorf("status = %q, want %q", got.Status, "success")
+	}
+	if got.Turns != 3 {
+		t.Errorf("Turns = %d, want 3", got.Turns)
 	}
 	if got.TokenUsage.InputTokens != 1234 {
 		t.Errorf("InputTokens = %d, want 1234", got.TokenUsage.InputTokens)
@@ -180,5 +187,42 @@ func TestReadAgentResult_ZeroValueTokenUsage(t *testing.T) {
 	}
 	if got.TokenUsage != (tokenUsage{}) {
 		t.Errorf("TokenUsage = %+v, want zero value", got.TokenUsage)
+	}
+}
+
+// TestMergeAgentResultIntoJobOutput_TurnsCarryThrough pins that the
+// turn count read from agentbox's result.json lands on the JobOutput
+// envelope's agent block. Earlier the field existed on agentResult
+// but was dropped on the merge — the dashboard then rendered "Turn 0"
+// for completed runs that finished too fast for the LiveProgress
+// heartbeat to land. Mirrors the carry-through assertion the
+// app-server side relies on in extractAgentTurns.
+func TestMergeAgentResultIntoJobOutput_TurnsCarryThrough(t *testing.T) {
+	params := map[string]interface{}{}
+	err := mergeAgentResultIntoJobOutput(params, agentResult{
+		Status:         "success",
+		ChangesSummary: "edited 1 file",
+		Turns:          7,
+		TokenUsage:     tokenUsage{InputTokens: 100, OutputTokens: 50, CacheReadTokens: 25},
+	})
+	if err != nil {
+		t.Fatalf("mergeAgentResultIntoJobOutput: %v", err)
+	}
+	raw, err := jobs.GetParameterValue[string](params, parameters_enums.JobOutput)
+	if err != nil {
+		t.Fatalf("GetParameterValue: %v", err)
+	}
+	var got jobOutputData
+	if err := json.Unmarshal([]byte(raw), &got); err != nil {
+		t.Fatalf("unmarshal envelope: %v", err)
+	}
+	if got.Agent == nil {
+		t.Fatal("agent block missing")
+	}
+	if got.Agent.Turns != 7 {
+		t.Errorf("agent.turns = %d, want 7", got.Agent.Turns)
+	}
+	if got.Agent.TokenUsage.InputTokens != 100 {
+		t.Errorf("agent.token_usage.input_tokens = %d, want 100", got.Agent.TokenUsage.InputTokens)
 	}
 }


### PR DESCRIPTION
## Summary
- **Prefer `pr_title` from agent** (3a56fe2): `open_pull_request.subjectAndLeadIn` now uses the agent's `pr_title` field (newer agentbox) when present, capped at 72 chars as defense in depth. Falls back to first line of `changes_summary` (also capped) for older agentbox versions. Fixes the bug where a 119-char single-line narrative became the PR title.
- **Surface turns count from agentbox result.json** (3fe5599): consume the runner-observed turn count from agentbox's structured output so app-server can project it onto `AgentRunSummary.turns` for terminal-state runs.

## Test plan
- [ ] Tasks against new agentbox image (with `pr_title`) produce short imperative PR titles
- [ ] Tasks against older agentbox still get reasonable titles (truncated from `changes_summary`)
- [ ] Terminal-state runs surface non-zero turn counts in the dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)