### PR TITLE
logs: suppress git checkout progress and image-pull line

### DIFF
--- a/jobs/commands/run_agent_step.go
+++ b/jobs/commands/run_agent_step.go
@@ -186,7 +186,7 @@ func (rs *RunAgentStep) Run(parameters map[string]interface{}, logsWriter io.Wri
 	if err != nil {
 		return parameters, fmt.Errorf("agentbox image missing: %s", err)
 	}
-	if err := pullAgentboxImage(imageRef, logsWriter); err != nil {
+	if err := pullAgentboxImage(imageRef); err != nil {
 		return parameters, fmt.Errorf("error pulling agentbox image: %s", err)
 	}
 	workDirHost := commandUtils.GetTaskRepositoriesBaseDir(ctx.OrganizationID, ctx.TaskID)
@@ -227,7 +227,7 @@ func (rs *RunAgentStep) Run(parameters map[string]interface{}, logsWriter io.Wri
 // layer-extraction conflicts.
 var agentboxImagePullLock sync.Mutex
 
-func pullAgentboxImage(imageRef string, logsWriter io.Writer) error {
+func pullAgentboxImage(imageRef string) error {
 	agentboxImagePullLock.Lock()
 	defer agentboxImagePullLock.Unlock()
 	dockerCtx, cancel := context.WithTimeout(context.Background(), defaultImagePullTimeout)
@@ -237,7 +237,6 @@ func pullAgentboxImage(imageRef string, logsWriter io.Writer) error {
 		return err
 	}
 	defer cli.Close()
-	io.WriteString(logsWriter, fmt.Sprintf("Pulling agentbox image: %s\n", imageRef))
 	reader, err := cli.ImagePull(dockerCtx, imageRef, image.PullOptions{})
 	if err != nil {
 		return err

--- a/jobs/commands/utils/repository.go
+++ b/jobs/commands/utils/repository.go
@@ -109,7 +109,6 @@ func FetchRepository(repository *git.Repository, repoProviderToken, repoGitProvi
 			Password: repoProviderToken,
 		},
 		RemoteName: "origin",
-		Progress:   logsWriter,
 		Force:      true,
 	})
 
@@ -214,8 +213,7 @@ func CloneRepository(repoDirectoryPath, repoCloneUrlWithToken, repoProviderToken
 	username := GetUsernameForProvider(repoGitProvider)
 
 	repository, err := git.PlainClone(repoDirectoryPath, false, &git.CloneOptions{
-		URL:      repoCloneUrlWithToken,
-		Progress: logsWriter,
+		URL: repoCloneUrlWithToken,
 		Auth: &http.BasicAuth{
 			Username: username,
 			Password: repoProviderToken,


### PR DESCRIPTION
## Summary
- Removes the `Progress: logsWriter` option from `git.PlainClone` and `repository.Fetch`, eliminating the "Counting objects / Compressing objects" percentage flood. The informative "Checking out repo X into Y" line is retained.
- Removes the "Pulling agentbox image: ..." log line and drops the now-unused `logsWriter` parameter from `pullAgentboxImage`.

## Test plan
- [ ] Build passes (`go build ./...`)
- [ ] Run a task; checkout logs are concise and no image-pull line appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)