### PR TITLE
Branch from existing PR head on first-Step re-runs (Q15)

### DIFF
--- a/client/oauth_operations.go
+++ b/client/oauth_operations.go
@@ -20,6 +20,43 @@ func (r *RunnerClient) RefreshGitToken(installationID string, organizationID str
 	return refreshTokenDto.Token, nil
 }
 
+// GetOpenPullRequestForBranch asks the deployment-server whether there
+// is an open PR on the user's git provider for the given (repo, branch)
+// — used by the Tasks re-run flow (Q15 in PLAN_tasks_verification.md)
+// to decide the agent's checkout base. The runner doesn't need to know
+// provider details; deployment-server dispatches on the installation's
+// configured provider.
+//
+// repoName follows the same provider-side identifier convention as
+// OpenPullRequest below.
+//
+// Returns the structured DTO so the caller can distinguish:
+//   - Found=false                   → no PR has ever existed
+//   - Found=true,  State=="open"    → iterate (branch from PR head)
+//   - Found=true,  State=="closed", Merged=true   → fail loudly
+//   - Found=true,  State=="closed", Merged=false  → start over from base
+//
+// The caller is expected to treat *any* error (RPC failure, provider
+// not supporting the optional interface, transient network) as "no PR
+// info available, fall back to the default base-branch path." Same
+// effective behavior as before Q15 — graceful degrade.
+func (r *RunnerClient) GetOpenPullRequestForBranch(organizationID, installationID, repoName, headBranch string) (oauth.GetOpenPullRequestForBranchDtoV1, error) {
+	var dto oauth.GetOpenPullRequestForBranchDtoV1
+	if !r.isConnected {
+		return dto, ErrConnection
+	}
+	args := oauth.GetOpenPullRequestForBranchArgsV1{}
+	args.OrganizationID = r.GetComputedOrganizationID(organizationID)
+	args.Token = r.token
+	args.InstallationID = installationID
+	args.RepoName = repoName
+	args.HeadBranch = headBranch
+	if err := r.c.Call("Oauth.GetOpenPullRequestForBranchV1", args, &dto); err != nil {
+		return dto, err
+	}
+	return dto, nil
+}
+
 // OpenPullRequest asks the deployment-server to open a PR/MR via the
 // user's git provider for the given installation. Provider dispatch
 // (GitHub/GitLab/BitBucket) and REST calls happen server-side; the

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.31.1
 	github.com/aws/aws-sdk-go-v2/service/sts v1.28.6
 	github.com/aws/smithy-go v1.22.2
-	github.com/deployment-io/deployment-runner-kit v0.0.0-20260514201659-3db143409f58
+	github.com/deployment-io/deployment-runner-kit v0.0.0-20260603022437-7bf9ab98a750
 	github.com/deployment-io/team-ai v0.0.0-20250917084912-bdbad6a834e1
 	github.com/docker/docker v27.3.0+incompatible
 	github.com/go-git/go-git/v5 v5.12.0

--- a/go.sum
+++ b/go.sum
@@ -153,6 +153,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/deployment-io/deployment-runner-kit v0.0.0-20260514201659-3db143409f58 h1:hN+TsKDzkoDhVPdoKQS/X+JrNHo7MZ5DlqV0ENqc7Ek=
 github.com/deployment-io/deployment-runner-kit v0.0.0-20260514201659-3db143409f58/go.mod h1:OEoIfAAL2cUkK4Rf0rpW32YqHw7Mgx2aaC7o07IGAhQ=
+github.com/deployment-io/deployment-runner-kit v0.0.0-20260603022437-7bf9ab98a750 h1:mEuXp/WZ7q8mfhYUZPfIJjJ69SAz17nYcYMnm8oqxfk=
+github.com/deployment-io/deployment-runner-kit v0.0.0-20260603022437-7bf9ab98a750/go.mod h1:OEoIfAAL2cUkK4Rf0rpW32YqHw7Mgx2aaC7o07IGAhQ=
 github.com/deployment-io/team-ai v0.0.0-20250917084912-bdbad6a834e1 h1:gfeNqym19IiO38sQ84WPMmZXrdDisu64qQP3Xs0N2RM=
 github.com/deployment-io/team-ai v0.0.0-20250917084912-bdbad6a834e1/go.mod h1:B0fxmLJICi0qP2R2m3I2tR1uRIKQxn4ekK67lyBRHjw=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=

--- a/jobs/commands/checkout_repository_for_task.go
+++ b/jobs/commands/checkout_repository_for_task.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	"github.com/deployment-io/deployment-runner-kit/tasks"
+	"github.com/deployment-io/deployment-runner/client"
 	commandUtils "github.com/deployment-io/deployment-runner/jobs/commands/utils"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
@@ -77,6 +78,36 @@ func (tc *taskCheckout) refreshToken(installationID string) (string, error) {
 	return token, nil
 }
 
+// shouldUseExistingTaskBranch decides whether the first Step of a Task
+// should iterate on an existing PR (Q15) or branch off base from scratch.
+// Asks deployment-server for the most recent PR matching this repo's
+// task branch:
+//   - Open PR exists → true (caller should fetchAndCheckoutTaskBranch,
+//     so the agent's commits stack on the PR's existing tip and the
+//     push fast-forwards).
+//   - Merged PR     → returns an error (re-running a merged Task is
+//     semantically nonsense; the work is already in base).
+//   - Closed-unmerged or never-existed PR → false (caller should
+//     branch off base — true first-run path).
+//
+// Any RPC failure (deployment-server older than this PR's deploy,
+// provider not supporting the optional interface, transient network)
+// degrades gracefully to false. Same effective behavior as before Q15,
+// just less informative. Logged so the runner-side ops can see when
+// the new path falls back.
+func (tc *taskCheckout) shouldUseExistingTaskBranch(entry tasks.RepositoryEntry) (bool, error) {
+	result, err := client.Get().GetOpenPullRequestForBranch(tc.ctx.OrganizationID, entry.InstallationID, entry.Name, tc.ctx.BranchName)
+	if err != nil {
+		io.WriteString(tc.logsWriter, fmt.Sprintf("Could not check existing PR for %s (falling back to base): %s\n", entry.Name, err))
+		return false, nil
+	}
+	if result.Found && result.State == "closed" && result.Merged {
+		return false, fmt.Errorf("cannot re-run task: PR #%d for %s is merged (%s); create a new task to extend it further",
+			result.PRNumber, entry.Name, result.URL)
+	}
+	return result.Found && result.State == "open", nil
+}
+
 // checkoutOne clones one repo and positions it on the right branch for the
 // current Step.
 func (tc *taskCheckout) checkoutOne(repoDir string, entry tasks.RepositoryEntry) error {
@@ -93,8 +124,26 @@ func (tc *taskCheckout) checkoutOne(repoDir string, entry tasks.RepositoryEntry)
 		return fmt.Errorf("error getting worktree: %s", err)
 	}
 	if tc.ctx.StepIndex == 0 {
-		if err := checkoutBaseBranchAndCreateTaskBranch(worktree, entry.BaseBranch, tc.ctx.BranchName); err != nil {
+		// First-Step path. For a fresh first run, branch off base and
+		// create the task branch locally. For a re-run, the dashboard
+		// has already pushed a PR for the task branch — the agent
+		// should iterate on it, not start over from base (Q15 in
+		// PLAN_tasks_verification.md). Branching from base when an
+		// open PR exists leads to sibling commits and a
+		// non-fast-forward push that silently drops the agent's
+		// verified work.
+		useExisting, err := tc.shouldUseExistingTaskBranch(entry)
+		if err != nil {
 			return err
+		}
+		if useExisting {
+			if err := tc.fetchAndCheckoutTaskBranch(repository, worktree, entry, token); err != nil {
+				return err
+			}
+		} else {
+			if err := checkoutBaseBranchAndCreateTaskBranch(worktree, entry.BaseBranch, tc.ctx.BranchName); err != nil {
+				return err
+			}
 		}
 	} else {
 		if err := tc.fetchAndCheckoutTaskBranch(repository, worktree, entry, token); err != nil {


### PR DESCRIPTION
## Summary

Step **4 of 4** — closes the Q15 loop in [PLAN_tasks_verification.md](https://github.com/deployment-io/plans/blob/master/PLAN_tasks_verification.md).

| # | Repo | Status |
|---|---|---|
| 1 | kit (provider impl) | ✅ [#164](https://github.com/deployment-io/kit/pull/164) merged |
| 2 | deployment-runner-kit (RPC args/dto) | ✅ [#35](https://github.com/deployment-io/deployment-runner-kit/pull/35) merged |
| 3 | deployment-server (RPC method) | ✅ [#21](https://github.com/deployment-io/deployment-server/pull/21) merged + deployed |
| 4 | **deployment-runner (this PR)** | ⏳ in review |

## What was broken

The runner's \`CheckoutRepoForTask.checkoutOne\` always branched off base on \`StepIndex == 0\`. On a dashboard re-run (with or without feedback), the agent's new commits became siblings of the original push (both descend from base), the push failed as \`non-fast-forward update\`, and the agent's successfully-verified work was silently discarded. Observed in [task 6a1eea32](https://app.deployment.io/dashboard/tasks/6a1eea3262de39dc49da9a63).

## What this PR does

\`checkoutOne\`'s first-Step path now asks deployment-server's new \`Oauth.GetOpenPullRequestForBranchV1\` whether an open PR exists for the task branch on each in-Step repo:

| Provider response | Runner action |
|---|---|
| Open PR exists | \`fetchAndCheckoutTaskBranch\` — agent commits stack on the PR's existing tip; push fast-forwards; existing PR auto-updates |
| Merged PR | Error: re-running a merged Task is semantically nonsense (the change is already in base); message points the user at "create a new task to extend it further" |
| Closed-unmerged or never existed | Existing \`checkoutBaseBranchAndCreateTaskBranch\` path — true first-run behavior |

## Graceful degradation

Any RPC failure — deployment-server hasn't deployed this PR yet, provider doesn't implement the optional \`GetOpenPullRequestForBranchR\` interface (GitLab + BitBucket pre-extension), transient network — degrades to "no PR found" and falls back to the base-branch path. **Same effective behavior as before Q15** — just less informative. Logged so ops can see when the new path degrades.

## Idempotent OpenPullRequest comes along for free

kit#164 made GitHub's provider-level \`OpenPullRequest\` catch \`422 "already exists"\` and re-fetch the existing PR. The existing \`OpenPullRequest\` RPC method consumes that transparently — **no runner-side commit/push wiring change needed**. The runner can call \`OpenPullRequest\` unconditionally on every Step without threading "create vs no-op" state.

## Dependency bump

\`\`\`
github.com/deployment-io/deployment-runner-kit  v0.0.0-20260514201659-3db143409f58  →  v0.0.0-20260603022437-7bf9ab98a750
\`\`\`

Pseudo-version pinned to the merge commit of deployment-runner-kit#35.

## Test plan

- [x] \`GOWORK=off go build ./...\` — green (the parent workspace go.work still points its \`./deployment-runner-kit/feature_tasks\` use directive at a worktree without the new types; CI / production builds don't have this issue because they use go.mod)
- [x] \`GOWORK=off go vet ./jobs/commands/... ./client/...\` — clean
- [x] \`GOWORK=off go test ./jobs/commands/... ./client/...\` — existing tests pass; new helper currently tested only by integration (dashboard re-run flow)
- [ ] After merge: deploy + re-run a previously-failed dashboard task to confirm fast-forward path works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)