### PR TITLE
Forward CODEX_VERSION to agentbox for Codex Step Jobs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.31.1
 	github.com/aws/aws-sdk-go-v2/service/sts v1.28.6
 	github.com/aws/smithy-go v1.22.2
-	github.com/deployment-io/deployment-runner-kit v0.0.0-20260603022437-7bf9ab98a750
+	github.com/deployment-io/deployment-runner-kit v0.0.0-20260603122019-0f1b04df5bc0
 	github.com/deployment-io/team-ai v0.0.0-20250917084912-bdbad6a834e1
 	github.com/docker/docker v27.3.0+incompatible
 	github.com/go-git/go-git/v5 v5.12.0

--- a/go.sum
+++ b/go.sum
@@ -155,6 +155,8 @@ github.com/deployment-io/deployment-runner-kit v0.0.0-20260514201659-3db143409f5
 github.com/deployment-io/deployment-runner-kit v0.0.0-20260514201659-3db143409f58/go.mod h1:OEoIfAAL2cUkK4Rf0rpW32YqHw7Mgx2aaC7o07IGAhQ=
 github.com/deployment-io/deployment-runner-kit v0.0.0-20260603022437-7bf9ab98a750 h1:mEuXp/WZ7q8mfhYUZPfIJjJ69SAz17nYcYMnm8oqxfk=
 github.com/deployment-io/deployment-runner-kit v0.0.0-20260603022437-7bf9ab98a750/go.mod h1:OEoIfAAL2cUkK4Rf0rpW32YqHw7Mgx2aaC7o07IGAhQ=
+github.com/deployment-io/deployment-runner-kit v0.0.0-20260603122019-0f1b04df5bc0 h1:7LllIXNskg2Etl/KNsML9gZWkEMMoqL+3569tGDlinw=
+github.com/deployment-io/deployment-runner-kit v0.0.0-20260603122019-0f1b04df5bc0/go.mod h1:OEoIfAAL2cUkK4Rf0rpW32YqHw7Mgx2aaC7o07IGAhQ=
 github.com/deployment-io/team-ai v0.0.0-20250917084912-bdbad6a834e1 h1:gfeNqym19IiO38sQ84WPMmZXrdDisu64qQP3Xs0N2RM=
 github.com/deployment-io/team-ai v0.0.0-20250917084912-bdbad6a834e1/go.mod h1:B0fxmLJICi0qP2R2m3I2tR1uRIKQxn4ekK67lyBRHjw=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=

--- a/jobs/commands/run_agent_step.go
+++ b/jobs/commands/run_agent_step.go
@@ -348,6 +348,9 @@ func buildAgentSpawnEnvVars(parameters map[string]interface{}) ([]string, error)
 	if v, err := jobs.GetParameterValue[string](parameters, parameters_enums.ClaudeCodeVersion); err == nil && v != "" {
 		env["CLAUDE_CODE_VERSION"] = v
 	}
+	if v, err := jobs.GetParameterValue[string](parameters, parameters_enums.CodexVersion); err == nil && v != "" {
+		env["CODEX_VERSION"] = v
+	}
 	if v, err := jobs.GetParameterValue[int64](parameters, parameters_enums.MaxTurns); err == nil && v > 0 {
 		env["MAX_TURNS"] = strconv.FormatInt(v, 10)
 	}
@@ -539,7 +542,7 @@ func createAgentboxContainer(ctx context.Context, cli *client.Client, spec agent
 		})
 	}
 	hostCfg := &container.HostConfig{
-		Mounts: mounts,
+		Mounts:         mounts,
 		CapDrop:        []string{"ALL"},
 		ReadonlyRootfs: true,
 		Tmpfs: map[string]string{


### PR DESCRIPTION
Part of the **CODEX_VERSION override** follow-up (`feature/tasks_codex_version`).

Mirrors the `CLAUDE_CODE_VERSION` forwarding: when a Step Job carries a `CodexVersion` param (stamped by kit for Codex Tasks), pass it as the `CODEX_VERSION` env on the agentbox container. Only one of the two version params is present per Job, so the two forwarding blocks are mutually exclusive.

⚠️ **Depends on the deployment-runner-kit PR** (`parameters_enums.CodexVersion`). CI is red until that merges and this repo's `go.mod` dr-kit version is bumped; the affected `jobs/commands` package builds + vets locally via go.work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
