### PR TITLE
Log when a job/Step is stopping

### DIFF
--- a/entrypoints/common/common.go
+++ b/entrypoints/common/common.go
@@ -120,7 +120,7 @@ func executeJobs(jobsStream <-chan pendingJobType, noOfWorkers int, mode runner_
 						// LiveProgress on the heartbeat, server skips the
 						// progress write.
 						var liveProgress atomic.Pointer[jobs.LiveProgressV1]
-						stopJobSignal := getJobStopSignal(pendingJob, jobDoneSignal, c, &liveProgress)
+						stopJobSignal := getJobStopSignal(pendingJob, jobDoneSignal, c, &liveProgress, logsWriter)
 						for _, commandEnum := range pendingJob.commandEnums {
 							select {
 							case <-stopJobSignal:
@@ -239,7 +239,7 @@ func executeJobs(jobsStream <-chan pendingJobType, noOfWorkers int, mode runner_
 // Consumers don't need to change — `case <-jobStopSignal:` reads the
 // zero value from a closed channel just as it would have read the
 // sent struct{}{}. Both fire the case identically.
-func getJobStopSignal(job pendingJobType, jobDoneSignal <-chan struct{}, c *client.RunnerClient, liveProgress *atomic.Pointer[jobs.LiveProgressV1]) <-chan struct{} {
+func getJobStopSignal(job pendingJobType, jobDoneSignal <-chan struct{}, c *client.RunnerClient, liveProgress *atomic.Pointer[jobs.LiveProgressV1], logsWriter io.Writer) <-chan struct{} {
 	jobStopSignal := make(chan struct{})
 	go func() {
 		defer close(jobStopSignal)
@@ -251,6 +251,11 @@ func getJobStopSignal(job pendingJobType, jobDoneSignal <-chan struct{}, c *clie
 				//ignoring error in client
 				isStopping, _ := c.UpsertJobHeartbeat(job.jobID, job.organizationID, liveProgress.Load())
 				if isStopping {
+					// Surface the stop in the job's log stream so the user sees
+					// the runner acting on their request (a Task Step SIGTERMs
+					// its agent; a build aborts) instead of the stream going
+					// quiet until the cancelled result lands.
+					io.WriteString(logsWriter, "Stop requested by user. Stopping...\n")
 					return // deferred close broadcasts to all readers
 				}
 			}


### PR DESCRIPTION
Adds a visible log line when the runner detects a stop request, so stopping a Task Step (or a build/deployment) shows up in the job's logs instead of the stream going quiet until the cancelled result lands.

`getJobStopSignal` is the single stop-detection point (heartbeat reports `Stopping`) shared by every job type, so one line in there covers Task Steps and builds/deployments alike:

```
Stop requested by user. Stopping...
```

`logsWriter` is threaded in from `executeJobs` (already in scope). Verified: `GOWORK=off go build/vet ./entrypoints/...` green.

Note: this is the visibility half. The related state-accuracy gap you spotted — the **task still shows `Running` while the job is `Stopping`** — is the same issue as pending→running and folds into the task-state fix (the runner-reported-state approach, mirroring builds); not in this PR.