### PR TITLE
Report Task Step started at checkout (UpdateTasksPipeline)

### DIFF
--- a/client/tasks_operations.go
+++ b/client/tasks_operations.go
@@ -1,0 +1,29 @@
+package client
+
+import (
+	"fmt"
+
+	"github.com/deployment-io/deployment-runner-kit/tasks"
+)
+
+// UpdateTasks reports a batch of Task Step "started" events to the control
+// plane (Jobs.MarkTaskStepRunningV1), which flips each Task -> Running and
+// Step -> StepRunning. Mirrors UpdateBuilds.
+func (r *RunnerClient) UpdateTasks(updates []tasks.UpdateTaskStepRunningDtoV1, organizationID string) error {
+	if !r.isConnected {
+		return ErrConnection
+	}
+	args := tasks.UpdateTaskStepRunningArgsV1{}
+	args.OrganizationID = r.GetComputedOrganizationID(organizationID)
+	args.Token = r.token
+	args.Updates = updates
+	var reply tasks.UpdateTaskStepRunningReplyV1
+	err := r.c.Call("Jobs.MarkTaskStepRunningV1", args, &reply)
+	if err != nil {
+		return err
+	}
+	if !reply.Done {
+		return fmt.Errorf("error receiving done from the server")
+	}
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.31.1
 	github.com/aws/aws-sdk-go-v2/service/sts v1.28.6
 	github.com/aws/smithy-go v1.22.2
-	github.com/deployment-io/deployment-runner-kit v0.0.0-20260603122019-0f1b04df5bc0
+	github.com/deployment-io/deployment-runner-kit v0.0.0-20260604192551-041034e71df3
 	github.com/deployment-io/team-ai v0.0.0-20250917084912-bdbad6a834e1
 	github.com/docker/docker v27.3.0+incompatible
 	github.com/go-git/go-git/v5 v5.12.0

--- a/go.sum
+++ b/go.sum
@@ -157,6 +157,8 @@ github.com/deployment-io/deployment-runner-kit v0.0.0-20260603022437-7bf9ab98a75
 github.com/deployment-io/deployment-runner-kit v0.0.0-20260603022437-7bf9ab98a750/go.mod h1:OEoIfAAL2cUkK4Rf0rpW32YqHw7Mgx2aaC7o07IGAhQ=
 github.com/deployment-io/deployment-runner-kit v0.0.0-20260603122019-0f1b04df5bc0 h1:7LllIXNskg2Etl/KNsML9gZWkEMMoqL+3569tGDlinw=
 github.com/deployment-io/deployment-runner-kit v0.0.0-20260603122019-0f1b04df5bc0/go.mod h1:OEoIfAAL2cUkK4Rf0rpW32YqHw7Mgx2aaC7o07IGAhQ=
+github.com/deployment-io/deployment-runner-kit v0.0.0-20260604192551-041034e71df3 h1:sjXeI3nY2oWj7qccVCkh8lBrwB/imKNM8nhkkqwNigU=
+github.com/deployment-io/deployment-runner-kit v0.0.0-20260604192551-041034e71df3/go.mod h1:OEoIfAAL2cUkK4Rf0rpW32YqHw7Mgx2aaC7o07IGAhQ=
 github.com/deployment-io/team-ai v0.0.0-20250917084912-bdbad6a834e1 h1:gfeNqym19IiO38sQ84WPMmZXrdDisu64qQP3Xs0N2RM=
 github.com/deployment-io/team-ai v0.0.0-20250917084912-bdbad6a834e1/go.mod h1:B0fxmLJICi0qP2R2m3I2tR1uRIKQxn4ekK67lyBRHjw=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=

--- a/jobs/commands/checkout_repository_for_task.go
+++ b/jobs/commands/checkout_repository_for_task.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/deployment-io/deployment-runner-kit/enums/parameters_enums"
+	"github.com/deployment-io/deployment-runner-kit/jobs"
 	"github.com/deployment-io/deployment-runner-kit/tasks"
 	"github.com/deployment-io/deployment-runner/client"
 	commandUtils "github.com/deployment-io/deployment-runner/jobs/commands/utils"
@@ -27,6 +29,17 @@ func (cr *CheckoutRepository) runForTask(parameters map[string]interface{}, logs
 	if err != nil {
 		return parameters, err
 	}
+	// Report the Step as started — the runner has begun this Step, so flip the
+	// Task -> Running and Step -> StepRunning now (mirrors how builds report
+	// build_enums.Running at checkout), replacing the premature "Running at job
+	// creation". Best-effort + batched; the control-plane update is gated, so a
+	// no-op (already advanced / cancelled) is harmless.
+	jobID, _ := jobs.GetParameterValue[string](parameters, parameters_enums.JobID)
+	commandUtils.UpdateTasksPipeline.Add(ctx.OrganizationID, tasks.UpdateTaskStepRunningDtoV1{
+		TaskID:    ctx.TaskID,
+		StepIndex: int(ctx.StepIndex),
+		JobID:     jobID,
+	})
 	tc := &taskCheckout{
 		ctx:        ctx,
 		tokenCache: make(map[string]string),

--- a/jobs/commands/utils/init.go
+++ b/jobs/commands/utils/init.go
@@ -15,11 +15,13 @@ import (
 	"github.com/deployment-io/deployment-runner-kit/jobs"
 	"github.com/deployment-io/deployment-runner-kit/notifications"
 	"github.com/deployment-io/deployment-runner-kit/previews"
+	"github.com/deployment-io/deployment-runner-kit/tasks"
 	"github.com/deployment-io/deployment-runner-kit/vpcs"
 	"github.com/deployment-io/deployment-runner/client"
 )
 
 var UpdateBuildsPipeline *goPipeline.Pipeline[string, builds.UpdateBuildDtoV1]
+var UpdateTasksPipeline *goPipeline.Pipeline[string, tasks.UpdateTaskStepRunningDtoV1]
 var UpdatePreviewsPipeline *goPipeline.Pipeline[string, previews.UpdatePreviewDtoV1]
 var SendNotificationPipeline *goPipeline.Pipeline[string, notifications.SendNotificationDtoV1]
 var UpdateDeploymentsPipeline *goPipeline.Pipeline[string, deployments.UpdateDeploymentDtoV1]
@@ -31,6 +33,7 @@ var UpdateAutomationOutputPipeline *goPipeline.Pipeline[string, automations.Upda
 var UpdateAgentOutputPipeline *goPipeline.Pipeline[string, agentTypes.UpdateResponseDtoV1]
 
 func Shutdown() {
+	UpdateTasksPipeline.Shutdown()
 	UpdateBuildsPipeline.Shutdown()
 	UpdatePreviewsPipeline.Shutdown()
 	UpdateDeploymentsPipeline.Shutdown()
@@ -45,6 +48,19 @@ func Shutdown() {
 
 func Init() {
 	c := client.Get()
+	UpdateTasksPipeline, _ = goPipeline.NewPipeline(5, 10*time.Second,
+		func(organizationId string, updates []tasks.UpdateTaskStepRunningDtoV1) {
+			e := true
+			for e {
+				err := c.UpdateTasks(updates, organizationId)
+				if err != nil {
+					fmt.Println(err)
+					time.Sleep(2 * time.Second)
+					continue
+				}
+				e = false
+			}
+		})
 	UpdateBuildsPipeline, _ = goPipeline.NewPipeline(5, 10*time.Second,
 		func(organizationId string, builds []builds.UpdateBuildDtoV1) {
 			e := true


### PR DESCRIPTION
Phase 1 of the Task lifecycle state-machine fix (`plans/PLAN_tasks_lifecycle_state.md`) — the **runner side** of the start report.

`runForTask` (the Task checkout command) now reports the Step has **started** the moment the runner begins it — mirroring how `checkout_repository.go` reports `build_enums.Running` at checkout. deployment-server's `Jobs.MarkTaskStepRunningV1` (PR #24) flips **Task → Running** + **Step → StepRunning**, so the card reflects 'agent actually running' instead of 'Running at job creation'.

- **`client.UpdateTasks`** — the RPC call (`Jobs.MarkTaskStepRunningV1`), mirroring `UpdateBuilds`.
- **`UpdateTasksPipeline`** — batched flush, mirroring `UpdateBuildsPipeline` (init.go + Shutdown).
- **`runForTask`** — `Add` the `{TaskID, StepIndex, JobID}` report right after parsing the Task context, *before* the checkout loop, so the Step shows Running as soon as work begins (even if a later repo checkout is slow or fails → then the completion hook takes it Running→Failed, which is more honest than Pending→Failed).

Best-effort + batched; the server-side `MarkRunning` is **gated**, so a re-delivered or post-cancel report is a harmless no-op. Bumps **dr-kit** (#37 wire types).

Depends on deployment-server #24 (the handler). After both land+deploy, a final **kit** PR drops the premature `Running` in `job_creation_utils` so the runner report becomes the sole Running-setter. Verified: `GOWORK=off go build/vet/test` green.