### PR TITLE
Assistant session bridge: RunAssistantSession command

### DIFF
--- a/client/sessions_operations.go
+++ b/client/sessions_operations.go
@@ -47,3 +47,23 @@ func (r *RunnerClient) GetSessionInput(jobID string, afterTs int64, organization
 	}
 	return reply.Messages, nil
 }
+
+// UpdateSessionSpec forwards the latest structured task-spec the planning agent
+// emitted to deployment-server, which persists it to Session.StructuredSpec.
+func (r *RunnerClient) UpdateSessionSpec(spec sessions.UpdateSpecDtoV1, organizationID string) error {
+	if !r.isConnected {
+		return ErrConnection
+	}
+	args := sessions.UpdateSpecArgsV1{Spec: spec}
+	args.OrganizationID = r.GetComputedOrganizationID(organizationID)
+	args.Token = r.token
+	var reply sessions.UpdateSpecReplyV1
+	err := r.c.Call("Sessions.UpdateSpecV1", args, &reply)
+	if err != nil {
+		return err
+	}
+	if !reply.Done {
+		return fmt.Errorf("error receiving done from the server")
+	}
+	return nil
+}

--- a/client/sessions_operations.go
+++ b/client/sessions_operations.go
@@ -1,0 +1,49 @@
+package client
+
+import (
+	"fmt"
+
+	"github.com/deployment-io/deployment-runner-kit/sessions"
+)
+
+// UpdateSessionMessages streams a batch of assistant-message deltas for an
+// interactive Assistant session to deployment-server, which appends them to the
+// session thread's message_stream (driving the SSE the browser tails).
+func (r *RunnerClient) UpdateSessionMessages(messages []sessions.AppendMessageDtoV1, organizationID string) error {
+	if !r.isConnected {
+		return ErrConnection
+	}
+	args := sessions.AppendMessageArgsV1{}
+	args.OrganizationID = r.GetComputedOrganizationID(organizationID)
+	args.Token = r.token
+	args.Messages = messages
+	var reply sessions.AppendMessageReplyV1
+	err := r.c.Call("Sessions.AppendMessageV1", args, &reply)
+	if err != nil {
+		return err
+	}
+	if !reply.Done {
+		return fmt.Errorf("error receiving done from the server")
+	}
+	return nil
+}
+
+// GetSessionInput pulls the session thread's user turns newer than afterTs so
+// the runner can feed them to the live agent. Returns oldest-first.
+func (r *RunnerClient) GetSessionInput(jobID string, afterTs int64, organizationID string) ([]sessions.UserMessageDtoV1, error) {
+	if !r.isConnected {
+		return nil, ErrConnection
+	}
+	args := sessions.GetInputArgsV1{
+		JobID:   jobID,
+		AfterTs: afterTs,
+	}
+	args.OrganizationID = r.GetComputedOrganizationID(organizationID)
+	args.Token = r.token
+	var reply sessions.GetInputReplyV1
+	err := r.c.Call("Sessions.GetInputV1", args, &reply)
+	if err != nil {
+		return nil, err
+	}
+	return reply.Messages, nil
+}

--- a/entrypoints/common/common.go
+++ b/entrypoints/common/common.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"os"
 	"runtime"
 	"strings"
 	"sync"
@@ -96,7 +97,9 @@ func executeJobs(jobsStream <-chan pendingJobType, noOfWorkers int, mode runner_
 							})
 							//if job is a build type it will be marked done; if it's a Task
 							//Step Job the per-Task working dir is cleaned up instead
-							if commandUtils.IsTasksMode(parameters) {
+							if commandUtils.IsSessionMode(parameters) {
+								cleanupSessionWorkDir(parameters)
+							} else if commandUtils.IsTasksMode(parameters) {
 								<-commands.MarkStepDone(parameters, err)
 							} else {
 								<-commands.MarkDeploymentDone(parameters, err)
@@ -134,7 +137,9 @@ func executeJobs(jobsStream <-chan pendingJobType, noOfWorkers int, mode runner_
 								resultsStream <- result
 								//if job is a deployment/build/preview type, this will be marked them done;
 								//if it's a Task Step Job, the per-Task working dir is cleaned up instead
-								if commandUtils.IsTasksMode(parameters) {
+								if commandUtils.IsSessionMode(parameters) {
+									cleanupSessionWorkDir(parameters)
+								} else if commandUtils.IsTasksMode(parameters) {
 									<-commands.MarkStepDone(parameters, errStoppedByUser)
 								} else {
 									<-commands.MarkDeploymentDone(parameters, errStoppedByUser)
@@ -195,7 +200,9 @@ func executeJobs(jobsStream <-chan pendingJobType, noOfWorkers int, mode runner_
 						// extended. Non-Tasks jobs handle their own
 						// completion bookkeeping inside the build/preview
 						// commands themselves.
-						if commandUtils.IsTasksMode(parameters) {
+						if commandUtils.IsSessionMode(parameters) {
+							cleanupSessionWorkDir(parameters)
+						} else if commandUtils.IsTasksMode(parameters) {
 							<-commands.MarkStepDone(parameters, nil)
 						}
 						handleLogEnd(nil, pendingJob.jobID, logsWriter)
@@ -208,6 +215,20 @@ func executeJobs(jobsStream <-chan pendingJobType, noOfWorkers int, mode runner_
 		wg.Wait()
 	}()
 	return resultsStream
+}
+
+// cleanupSessionWorkDir removes an interactive Assistant session's cloned repo
+// and agentbox IO dirs under /tmp/<org>/sessions/<jobID>. A session is neither a
+// deployment nor a Task Step, so neither MarkDeploymentDone nor MarkStepDone
+// applies; this is the session analog of MarkStepDone's per-Task cleanup, keyed
+// by OrganizationIDNamespace to match where runForSession cloned.
+func cleanupSessionWorkDir(parameters map[string]interface{}) {
+	orgID, _ := jobs.GetParameterValue[string](parameters, parameters_enums.OrganizationIDNamespace)
+	jobID, _ := jobs.GetParameterValue[string](parameters, parameters_enums.JobID)
+	if len(orgID) == 0 || len(jobID) == 0 {
+		return
+	}
+	_ = os.RemoveAll(commandUtils.GetSessionRepositoriesBaseDir(orgID, jobID))
 }
 
 // getJobStopSignal polls UpsertJobHeartbeat every 5 seconds and returns

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.31.1
 	github.com/aws/aws-sdk-go-v2/service/sts v1.28.6
 	github.com/aws/smithy-go v1.22.2
-	github.com/deployment-io/deployment-runner-kit v0.0.0-20260604192551-041034e71df3
+	github.com/deployment-io/deployment-runner-kit v0.0.0-20260610033908-2ecde01ee036
 	github.com/deployment-io/team-ai v0.0.0-20250917084912-bdbad6a834e1
 	github.com/docker/docker v27.3.0+incompatible
 	github.com/go-git/go-git/v5 v5.12.0

--- a/go.sum
+++ b/go.sum
@@ -151,14 +151,8 @@ github.com/cyphar/filepath-securejoin v0.2.5/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxG
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deployment-io/deployment-runner-kit v0.0.0-20260514201659-3db143409f58 h1:hN+TsKDzkoDhVPdoKQS/X+JrNHo7MZ5DlqV0ENqc7Ek=
-github.com/deployment-io/deployment-runner-kit v0.0.0-20260514201659-3db143409f58/go.mod h1:OEoIfAAL2cUkK4Rf0rpW32YqHw7Mgx2aaC7o07IGAhQ=
-github.com/deployment-io/deployment-runner-kit v0.0.0-20260603022437-7bf9ab98a750 h1:mEuXp/WZ7q8mfhYUZPfIJjJ69SAz17nYcYMnm8oqxfk=
-github.com/deployment-io/deployment-runner-kit v0.0.0-20260603022437-7bf9ab98a750/go.mod h1:OEoIfAAL2cUkK4Rf0rpW32YqHw7Mgx2aaC7o07IGAhQ=
-github.com/deployment-io/deployment-runner-kit v0.0.0-20260603122019-0f1b04df5bc0 h1:7LllIXNskg2Etl/KNsML9gZWkEMMoqL+3569tGDlinw=
-github.com/deployment-io/deployment-runner-kit v0.0.0-20260603122019-0f1b04df5bc0/go.mod h1:OEoIfAAL2cUkK4Rf0rpW32YqHw7Mgx2aaC7o07IGAhQ=
-github.com/deployment-io/deployment-runner-kit v0.0.0-20260604192551-041034e71df3 h1:sjXeI3nY2oWj7qccVCkh8lBrwB/imKNM8nhkkqwNigU=
-github.com/deployment-io/deployment-runner-kit v0.0.0-20260604192551-041034e71df3/go.mod h1:OEoIfAAL2cUkK4Rf0rpW32YqHw7Mgx2aaC7o07IGAhQ=
+github.com/deployment-io/deployment-runner-kit v0.0.0-20260610033908-2ecde01ee036 h1:2D8c5JTnomSltXVEMtxZtbcTbiTExsSilGHaBqzr4NY=
+github.com/deployment-io/deployment-runner-kit v0.0.0-20260610033908-2ecde01ee036/go.mod h1:OEoIfAAL2cUkK4Rf0rpW32YqHw7Mgx2aaC7o07IGAhQ=
 github.com/deployment-io/team-ai v0.0.0-20250917084912-bdbad6a834e1 h1:gfeNqym19IiO38sQ84WPMmZXrdDisu64qQP3Xs0N2RM=
 github.com/deployment-io/team-ai v0.0.0-20250917084912-bdbad6a834e1/go.mod h1:B0fxmLJICi0qP2R2m3I2tR1uRIKQxn4ekK67lyBRHjw=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=

--- a/jobs/commands/checkout_repository.go
+++ b/jobs/commands/checkout_repository.go
@@ -62,6 +62,12 @@ func addRootDirectory(parameters map[string]interface{}, repoDirectoryPath strin
 // path (runForTask) and bypass MarkDeploymentDone since Tasks aren't
 // deployments.
 func (cr *CheckoutRepository) Run(parameters map[string]interface{}, logsWriter io.Writer) (newParameters map[string]interface{}, err error) {
+	if commandUtils.IsSessionMode(parameters) {
+		// Interactive Assistant session: read-only single-repo clone. No
+		// MarkDeploymentDone / MarkStepDone — a session is neither a deployment
+		// nor a Task Step; the outer loop cleans up the session work dir.
+		return cr.runForSession(parameters, logsWriter)
+	}
 	if commandUtils.IsTasksMode(parameters) {
 		defer func() {
 			if err != nil {

--- a/jobs/commands/checkout_repository_for_session.go
+++ b/jobs/commands/checkout_repository_for_session.go
@@ -1,0 +1,103 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/deployment-io/deployment-runner-kit/enums/parameters_enums"
+	"github.com/deployment-io/deployment-runner-kit/jobs"
+	"github.com/deployment-io/deployment-runner-kit/tasks"
+	commandUtils "github.com/deployment-io/deployment-runner/jobs/commands/utils"
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+)
+
+// runForSession is the Assistant-session entrypoint for CheckoutRepository. It
+// read-only-clones the session's single repo at its base branch into the
+// session work dir, which RunAssistantSession then bind-mounts as /work. Unlike
+// runForTask there is no task branch, no PR lookup, and no commit — a session
+// plans against the code, it doesn't modify it. v1 is single-repo; the agent's
+// cwd is the repo root.
+func (cr *CheckoutRepository) runForSession(parameters map[string]interface{}, logsWriter io.Writer) (map[string]interface{}, error) {
+	orgID, err := jobs.GetParameterValue[string](parameters, parameters_enums.OrganizationIDNamespace)
+	if err != nil {
+		return parameters, fmt.Errorf("organization id missing: %s", err)
+	}
+	jobID, err := jobs.GetParameterValue[string](parameters, parameters_enums.JobID)
+	if err != nil {
+		return parameters, fmt.Errorf("job id missing: %s", err)
+	}
+	repositoriesJSON, err := jobs.GetParameterValue[string](parameters, parameters_enums.Repositories)
+	if err != nil {
+		return parameters, fmt.Errorf("repositories missing: %s", err)
+	}
+	var entries []tasks.RepositoryEntry
+	if err := json.Unmarshal([]byte(repositoriesJSON), &entries); err != nil {
+		return parameters, fmt.Errorf("error unmarshalling repositories: %s", err)
+	}
+	if len(entries) == 0 {
+		return parameters, fmt.Errorf("session has no repositories")
+	}
+	repoDir := commandUtils.GetSessionRepositoriesBaseDir(orgID, jobID)
+	if err := cloneSessionRepoReadOnly(repoDir, entries[0], orgID, logsWriter); err != nil {
+		return parameters, fmt.Errorf("error checking out repo %s: %s", entries[0].Name, err)
+	}
+	return parameters, nil
+}
+
+// cloneSessionRepoReadOnly clones one repo at its base branch into repoDir for an
+// interactive session, retrying once with a refreshed token on auth failure
+// (mirrors the Task clone). Chowns the tree to the agentbox `agent` user so the
+// UID-1000 container can read it through the bind mount.
+func cloneSessionRepoReadOnly(repoDir string, entry tasks.RepositoryEntry, orgID string, logsWriter io.Writer) error {
+	// Start from a clean dir so a re-picked-up session Job (crash recovery)
+	// doesn't clone into a non-empty path.
+	_ = os.RemoveAll(repoDir)
+	token, err := commandUtils.RefreshGitTokenForInstallation(entry.InstallationID, orgID)
+	if err != nil {
+		return fmt.Errorf("error getting installation token: %s", err)
+	}
+	io.WriteString(logsWriter, fmt.Sprintf("Cloning %s (%s) read-only into %s\n", entry.Name, entry.BaseBranch, repoDir))
+	repository, token, err := cloneSessionWithRetry(repoDir, entry, token, orgID, logsWriter)
+	if err != nil {
+		return err
+	}
+	worktree, err := repository.Worktree()
+	if err != nil {
+		return fmt.Errorf("error getting worktree: %s", err)
+	}
+	baseRef := plumbing.NewRemoteReferenceName("origin", entry.BaseBranch)
+	if err := worktree.Checkout(&git.CheckoutOptions{Branch: baseRef}); err != nil {
+		return fmt.Errorf("error checking out base branch %s: %s", entry.BaseBranch, err)
+	}
+	return chownTreeToAgentbox(repoDir)
+}
+
+// cloneSessionWithRetry runs the clone, refreshing the token + retrying once on
+// go-git's "authentication required" error. Returns the (possibly-refreshed)
+// token used for the successful clone.
+func cloneSessionWithRetry(repoDir string, entry tasks.RepositoryEntry, token, orgID string, logsWriter io.Writer) (*git.Repository, string, error) {
+	cloneURL, err := commandUtils.GetRepoUrlWithToken(entry.Provider, token, entry.CloneURL)
+	if err != nil {
+		return nil, token, err
+	}
+	repository, err := commandUtils.CloneRepository(repoDir, cloneURL, token, entry.Provider, logsWriter)
+	if err == nil {
+		return repository, token, nil
+	}
+	if !commandUtils.IsErrorAuthenticationRequired(err) {
+		return nil, token, err
+	}
+	token, err = commandUtils.RefreshGitTokenForInstallation(entry.InstallationID, orgID)
+	if err != nil {
+		return nil, token, err
+	}
+	cloneURL, err = commandUtils.GetRepoUrlWithToken(entry.Provider, token, entry.CloneURL)
+	if err != nil {
+		return nil, token, err
+	}
+	repository, err = commandUtils.CloneRepository(repoDir, cloneURL, token, entry.Provider, logsWriter)
+	return repository, token, err
+}

--- a/jobs/commands/checkout_repository_for_session.go
+++ b/jobs/commands/checkout_repository_for_session.go
@@ -15,11 +15,12 @@ import (
 )
 
 // runForSession is the Assistant-session entrypoint for CheckoutRepository. It
-// read-only-clones the session's single repo at its base branch into the
-// session work dir, which RunAssistantSession then bind-mounts as /work. Unlike
+// read-only-clones each of the session's repos at its base branch into
+// <baseDir>/<idx>-<name>, and RunAssistantSession bind-mounts the base dir as
+// /work (the agent's cwd; each repo is an <idx>-<name> subdirectory). Unlike
 // runForTask there is no task branch, no PR lookup, and no commit — a session
-// plans against the code, it doesn't modify it. v1 is single-repo; the agent's
-// cwd is the repo root.
+// plans against the code, it doesn't modify it. Layout mirrors runForTask so
+// single- and multi-repo sessions are identical.
 func (cr *CheckoutRepository) runForSession(parameters map[string]interface{}, logsWriter io.Writer) (map[string]interface{}, error) {
 	orgID, err := jobs.GetParameterValue[string](parameters, parameters_enums.OrganizationIDNamespace)
 	if err != nil {
@@ -40,9 +41,20 @@ func (cr *CheckoutRepository) runForSession(parameters map[string]interface{}, l
 	if len(entries) == 0 {
 		return parameters, fmt.Errorf("session has no repositories")
 	}
-	repoDir := commandUtils.GetSessionRepositoriesBaseDir(orgID, jobID)
-	if err := cloneSessionRepoReadOnly(repoDir, entries[0], orgID, logsWriter); err != nil {
-		return parameters, fmt.Errorf("error checking out repo %s: %s", entries[0].Name, err)
+	// Start from a clean base so a re-picked-up session Job (crash recovery)
+	// doesn't clone into stale repo dirs. The agentbox IO dirs are created
+	// later by RunAssistantSession (after checkout), so wiping here is safe.
+	baseDir := commandUtils.GetSessionRepositoriesBaseDir(orgID, jobID)
+	_ = os.RemoveAll(baseDir)
+	// Cache tokens per installation so multi-repo sessions sharing one GitHub
+	// App installation don't trigger redundant refresh RPCs.
+	tokenCache := map[string]string{}
+	for idx, entry := range entries {
+		repoDir := commandUtils.GetSessionRepositoryDir(orgID, jobID, idx, entry.Name)
+		io.WriteString(logsWriter, fmt.Sprintf("Cloning %s (%s) read-only into %s\n", entry.Name, entry.BaseBranch, repoDir))
+		if err := cloneSessionRepoReadOnly(repoDir, entry, orgID, tokenCache, logsWriter); err != nil {
+			return parameters, fmt.Errorf("error checking out repo %s: %s", entry.Name, err)
+		}
 	}
 	return parameters, nil
 }
@@ -50,17 +62,14 @@ func (cr *CheckoutRepository) runForSession(parameters map[string]interface{}, l
 // cloneSessionRepoReadOnly clones one repo at its base branch into repoDir for an
 // interactive session, retrying once with a refreshed token on auth failure
 // (mirrors the Task clone). Chowns the tree to the agentbox `agent` user so the
-// UID-1000 container can read it through the bind mount.
-func cloneSessionRepoReadOnly(repoDir string, entry tasks.RepositoryEntry, orgID string, logsWriter io.Writer) error {
-	// Start from a clean dir so a re-picked-up session Job (crash recovery)
-	// doesn't clone into a non-empty path.
-	_ = os.RemoveAll(repoDir)
-	token, err := commandUtils.RefreshGitTokenForInstallation(entry.InstallationID, orgID)
+// UID-1000 container can read it through the bind mount. The caller wipes the
+// base dir once, so this doesn't remove repoDir itself.
+func cloneSessionRepoReadOnly(repoDir string, entry tasks.RepositoryEntry, orgID string, tokenCache map[string]string, logsWriter io.Writer) error {
+	token, err := sessionToken(tokenCache, entry.InstallationID, orgID)
 	if err != nil {
 		return fmt.Errorf("error getting installation token: %s", err)
 	}
-	io.WriteString(logsWriter, fmt.Sprintf("Cloning %s (%s) read-only into %s\n", entry.Name, entry.BaseBranch, repoDir))
-	repository, token, err := cloneSessionWithRetry(repoDir, entry, token, orgID, logsWriter)
+	repository, _, err := cloneSessionWithRetry(repoDir, entry, token, orgID, tokenCache, logsWriter)
 	if err != nil {
 		return err
 	}
@@ -75,10 +84,25 @@ func cloneSessionRepoReadOnly(repoDir string, entry tasks.RepositoryEntry, orgID
 	return chownTreeToAgentbox(repoDir)
 }
 
+// sessionToken returns a token for the installation, minting + caching on a miss
+// so repos sharing one installation don't re-hit the refresh RPC.
+func sessionToken(cache map[string]string, installationID, orgID string) (string, error) {
+	if token, ok := cache[installationID]; ok {
+		return token, nil
+	}
+	token, err := commandUtils.RefreshGitTokenForInstallation(installationID, orgID)
+	if err != nil {
+		return "", err
+	}
+	cache[installationID] = token
+	return token, nil
+}
+
 // cloneSessionWithRetry runs the clone, refreshing the token + retrying once on
-// go-git's "authentication required" error. Returns the (possibly-refreshed)
-// token used for the successful clone.
-func cloneSessionWithRetry(repoDir string, entry tasks.RepositoryEntry, token, orgID string, logsWriter io.Writer) (*git.Repository, string, error) {
+// go-git's "authentication required" error. A refreshed token is written back to
+// the cache so later repos sharing the installation use it. Returns the
+// (possibly-refreshed) token used for the successful clone.
+func cloneSessionWithRetry(repoDir string, entry tasks.RepositoryEntry, token, orgID string, tokenCache map[string]string, logsWriter io.Writer) (*git.Repository, string, error) {
 	cloneURL, err := commandUtils.GetRepoUrlWithToken(entry.Provider, token, entry.CloneURL)
 	if err != nil {
 		return nil, token, err
@@ -94,6 +118,7 @@ func cloneSessionWithRetry(repoDir string, entry tasks.RepositoryEntry, token, o
 	if err != nil {
 		return nil, token, err
 	}
+	tokenCache[entry.InstallationID] = token
 	cloneURL, err = commandUtils.GetRepoUrlWithToken(entry.Provider, token, entry.CloneURL)
 	if err != nil {
 		return nil, token, err

--- a/jobs/commands/commands.go
+++ b/jobs/commands/commands.go
@@ -78,6 +78,8 @@ func Get(p commands_enums.Type) (jobs.Command, error) {
 		return &GetDeploymentLogsAws{}, nil
 	case commands_enums.RunAgentStep:
 		return &RunAgentStep{}, nil
+	case commands_enums.RunAssistantSession:
+		return &RunAssistantSession{}, nil
 	case commands_enums.CommitAndPush:
 		return &CommitAndPush{}, nil
 	case commands_enums.OpenPullRequest:

--- a/jobs/commands/run_assistant_session.go
+++ b/jobs/commands/run_assistant_session.go
@@ -201,11 +201,16 @@ func (rs *RunAssistantSession) runSession(orgID, jobID, imageRef, workDirHost st
 		dir:   filepath.Join(workDirHost, ".agentbox-input", "messages"),
 		orgID: orgID, jobID: jobID, logsWriter: logsWriter,
 	}
+	sf := &specForwarder{
+		path:  filepath.Join(workDirHost, ".agentbox-output", "task-spec.json"),
+		orgID: orgID, jobID: jobID, logsWriter: logsWriter,
+	}
 	stopBridge := make(chan struct{})
 	var bridgeWg sync.WaitGroup
-	bridgeWg.Add(2)
+	bridgeWg.Add(3)
 	go func() { defer bridgeWg.Done(); runSessionTicker(stopBridge, mf.tick) }()
 	go func() { defer bridgeWg.Done(); runSessionTicker(stopBridge, ip.tick) }()
+	go func() { defer bridgeWg.Done(); runSessionTicker(stopBridge, sf.tick) }()
 
 	waitCtx, cancelWait := context.WithTimeout(dockerCtx, defaultWallClockTimeout)
 	defer cancelWait()
@@ -213,6 +218,7 @@ func (rs *RunAssistantSession) runSession(orgID, jobID, imageRef, workDirHost st
 	close(stopBridge)
 	bridgeWg.Wait()
 	mf.tick() // final drain of any buffered output
+	sf.tick() // final spec snapshot
 	logSessionOutcome(workDirHost, logsWriter)
 	if waitErr != nil && !errors.Is(waitErr, types.ErrJobStoppedByUser) {
 		return waitErr
@@ -344,4 +350,56 @@ func logSessionOutcome(workDirHost string, logsWriter io.Writer) {
 	if b, err := os.ReadFile(specPath); err == nil && len(b) > 0 {
 		io.WriteString(logsWriter, "session produced a task spec\n")
 	}
+}
+
+// specForwarder reads agentbox's task-spec.json each tick and forwards it to
+// deployment-server (which persists it to Session.StructuredSpec) whenever the
+// content changes — the planning agent refines the spec across turns. The
+// convert flow reads the persisted spec. Best-effort: a failed forward leaves
+// lastContent unchanged so the next tick retries.
+type specForwarder struct {
+	path         string
+	orgID, jobID string
+	logsWriter   io.Writer
+	lastContent  string
+}
+
+func (sf *specForwarder) tick() {
+	b, err := os.ReadFile(sf.path)
+	if err != nil {
+		return // not written yet
+	}
+	if string(b) == sf.lastContent {
+		return // unchanged since the last successful forward
+	}
+	var rec struct {
+		Title       string   `json:"title"`
+		Goal        string   `json:"goal"`
+		Context     string   `json:"context"`
+		Acceptance  []string `json:"acceptance_criteria"`
+		Assumptions []string `json:"assumptions"`
+		OutOfScope  []string `json:"out_of_scope"`
+		Complexity  string   `json:"complexity"`
+		Readiness   string   `json:"readiness"`
+		Notes       string   `json:"readiness_notes"`
+	}
+	if json.Unmarshal(b, &rec) != nil {
+		return
+	}
+	if err := runnerclient.Get().UpdateSessionSpec(sessions.UpdateSpecDtoV1{
+		JobID:       sf.jobID,
+		Title:       rec.Title,
+		Goal:        rec.Goal,
+		Context:     rec.Context,
+		Acceptance:  rec.Acceptance,
+		Assumptions: rec.Assumptions,
+		OutOfScope:  rec.OutOfScope,
+		Complexity:  rec.Complexity,
+		Readiness:   rec.Readiness,
+		Notes:       rec.Notes,
+	}, sf.orgID); err != nil {
+		io.WriteString(sf.logsWriter, fmt.Sprintf("session: error forwarding spec: %s\n", err))
+		return // keep lastContent unchanged → retry next tick
+	}
+	sf.lastContent = string(b)
 }

--- a/jobs/commands/run_assistant_session.go
+++ b/jobs/commands/run_assistant_session.go
@@ -62,7 +62,7 @@ const (
 // in sync with agentbox/cmd/interactive-harness planModePrompt; production
 // injects it via APPEND_SYSTEM_PROMPT_FILE at spawn. Built with string
 // concatenation because the task-spec fence uses backticks.
-const planModePrompt = `You are in plan mode for a code repository. Investigate with read-only tools only — you cannot modify, build, run, or test the code (the sandbox is read-only at the OS level). Do not attempt builds or tests; verification happens later when the task is executed — note what should be verified in the spec's acceptance criteria instead.
+const planModePrompt = `You are in plan mode for one or more code repositories, each checked out as a subdirectory of your working directory. Investigate with read-only tools only — you cannot modify, build, run, or test the code (the sandbox is read-only at the OS level). Do not attempt builds or tests; verification happens later when the task is executed — note what should be verified in the spec's acceptance criteria instead.
 
 Each turn, judge what the user is doing:
 - Just asking a question, exploring, or discussing — answer normally and DO NOT emit a task-spec block.

--- a/jobs/commands/run_assistant_session.go
+++ b/jobs/commands/run_assistant_session.go
@@ -75,6 +75,14 @@ func (rs *RunAssistantSession) Run(parameters map[string]interface{}, logsWriter
 	if err != nil {
 		return parameters, fmt.Errorf("job id missing: %s", err)
 	}
+	// The work dir is keyed by OrganizationIDNamespace — the same param
+	// CheckoutRepo's runForSession used to clone the repo. That differs from
+	// OrganizationIdFromJob (the real org used for the message-stream bridge)
+	// under saas-runner mode, where the namespace is rewritten to the global org.
+	workDirOrg, err := jobs.GetParameterValue[string](parameters, parameters_enums.OrganizationIDNamespace)
+	if err != nil {
+		return parameters, fmt.Errorf("organization id namespace missing: %s", err)
+	}
 	imageRef, err := jobs.GetParameterValue[string](parameters, parameters_enums.AgentboxImage)
 	if err != nil {
 		return parameters, fmt.Errorf("agentbox image missing: %s", err)
@@ -82,7 +90,7 @@ func (rs *RunAssistantSession) Run(parameters map[string]interface{}, logsWriter
 	if err := pullAgentboxImage(imageRef); err != nil {
 		return parameters, fmt.Errorf("error pulling agentbox image: %s", err)
 	}
-	workDirHost := commandUtils.GetSessionRepositoriesBaseDir(orgID, jobID)
+	workDirHost := commandUtils.GetSessionRepositoriesBaseDir(workDirOrg, jobID)
 	if err := prepareSessionDirs(workDirHost); err != nil {
 		return parameters, fmt.Errorf("error preparing session dirs: %s", err)
 	}

--- a/jobs/commands/run_assistant_session.go
+++ b/jobs/commands/run_assistant_session.go
@@ -1,0 +1,339 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/deployment-io/deployment-runner-kit/enums/parameters_enums"
+	"github.com/deployment-io/deployment-runner-kit/jobs"
+	"github.com/deployment-io/deployment-runner-kit/sessions"
+	"github.com/deployment-io/deployment-runner-kit/types"
+	runnerclient "github.com/deployment-io/deployment-runner/client"
+	commandUtils "github.com/deployment-io/deployment-runner/jobs/commands/utils"
+	"github.com/docker/docker/api/types/container"
+	dockerclient "github.com/moby/moby/client"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+// RunAssistantSession is the runner command for an interactive Assistant
+// session. Unlike RunAgentStep (one-shot, batch result), it keeps an agentbox
+// container alive in interactive mode for the whole conversation and bridges it
+// to the browser: it forwards the agent's streamed output to deployment-server
+// (which appends to the thread's message_stream → SSE), and pulls the user's
+// turns back to feed the live agent. The container is read-only — sessions plan,
+// they don't modify code. Sits after CheckoutRepo, which populated /work.
+type RunAssistantSession struct {
+	// stopSignal closes when deployment-server reports the Job moved to
+	// Stopping (user ended the session, idle/wall-clock/budget cron). For a
+	// session, a stop is the normal end, not a failure.
+	stopSignal <-chan struct{}
+}
+
+// SetStopSignal satisfies jobs.StoppableCommand.
+func (rs *RunAssistantSession) SetStopSignal(stop <-chan struct{}) {
+	rs.stopSignal = stop
+}
+
+const (
+	sessionPromptInContainer = agentboxWorkDirInContainer + "/.agentbox-input/system-prompt.txt"
+	sessionPollInterval      = 750 * time.Millisecond
+)
+
+// planModePrompt instructs the agent for a read-only, plan-mode session. Kept
+// in sync with agentbox/cmd/interactive-harness planModePrompt; production
+// injects it via APPEND_SYSTEM_PROMPT_FILE at spawn. Built with string
+// concatenation because the task-spec fence uses backticks.
+const planModePrompt = `You are in plan mode for a code repository. Investigate with read-only tools only — you cannot modify, build, run, or test the code (the sandbox is read-only at the OS level). Do not attempt builds or tests; verification happens later when the task is executed — note what should be verified in the spec's acceptance criteria instead.
+
+Each turn, judge what the user is doing:
+- Just asking a question, exploring, or discussing — answer normally and DO NOT emit a task-spec block.
+- Working toward a concrete code change to dispatch — maintain a task-spec block at the END of your message, refining it as the task firms up.
+
+Only emit a task-spec once the user has expressed intent to change the code; never fabricate a task from a pure question. Block format:
+
+` + "```task-spec" + `
+{"title":"...","goal":"...","context":"...","acceptance_criteria":["..."],"assumptions":["..."],"out_of_scope":["..."],"complexity":"low|medium|high","readiness":"vague|partial|ready","readiness_notes":"..."}
+` + "```" + `
+
+Set readiness to "ready" only when the goal, acceptance criteria, and file scope are concrete. Set complexity to the model tier the EXECUTION task needs: "low" = trivial/one-file change, "medium" = a few files with some logic, "high" = multi-file work, refactors, tests, or tricky logic. It's a hint for choosing the execution model; the user can override.`
+
+func (rs *RunAssistantSession) Run(parameters map[string]interface{}, logsWriter io.Writer) (map[string]interface{}, error) {
+	orgID, err := jobs.GetParameterValue[string](parameters, parameters_enums.OrganizationIdFromJob)
+	if err != nil {
+		return parameters, fmt.Errorf("organization id missing: %s", err)
+	}
+	jobID, err := jobs.GetParameterValue[string](parameters, parameters_enums.JobID)
+	if err != nil {
+		return parameters, fmt.Errorf("job id missing: %s", err)
+	}
+	imageRef, err := jobs.GetParameterValue[string](parameters, parameters_enums.AgentboxImage)
+	if err != nil {
+		return parameters, fmt.Errorf("agentbox image missing: %s", err)
+	}
+	if err := pullAgentboxImage(imageRef); err != nil {
+		return parameters, fmt.Errorf("error pulling agentbox image: %s", err)
+	}
+	workDirHost := commandUtils.GetSessionRepositoriesBaseDir(orgID, jobID)
+	if err := prepareSessionDirs(workDirHost); err != nil {
+		return parameters, fmt.Errorf("error preparing session dirs: %s", err)
+	}
+	envVars, err := buildSessionSpawnEnvVars(parameters)
+	if err != nil {
+		return parameters, err
+	}
+	return parameters, rs.runSession(orgID, jobID, imageRef, workDirHost, envVars, logsWriter)
+}
+
+// prepareSessionDirs creates the bind-mounted input/output message dirs and the
+// plan-mode prompt file, then chowns them to the agentbox `agent` user so the
+// UID-1000 container can read input and write output through the bind mount.
+func prepareSessionDirs(workDirHost string) error {
+	outDir := filepath.Join(workDirHost, ".agentbox-output", "messages")
+	inDir := filepath.Join(workDirHost, ".agentbox-input", "messages")
+	for _, d := range []string{outDir, inDir} {
+		if err := os.MkdirAll(d, 0755); err != nil {
+			return err
+		}
+	}
+	promptPath := filepath.Join(workDirHost, ".agentbox-input", "system-prompt.txt")
+	if err := os.WriteFile(promptPath, []byte(planModePrompt), 0644); err != nil {
+		return err
+	}
+	for _, p := range []string{
+		filepath.Join(workDirHost, ".agentbox-output"),
+		filepath.Join(workDirHost, ".agentbox-input"),
+	} {
+		if err := chownTreeToAgentbox(p); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// buildSessionSpawnEnvVars assembles the interactive agentbox env: AGENT_MODE
+// and READ_ONLY pin the long-lived read-only session, SESSION_ID gives the
+// agent a stable conversation id, and the prompt file carries plan mode. The
+// rest mirrors buildAgentSpawnEnvVars (creds, agent type, model, versions,
+// allowlist) minus the one-shot STEP_PROMPT.
+func buildSessionSpawnEnvVars(parameters map[string]interface{}) ([]string, error) {
+	env := map[string]string{
+		"AGENT_MODE":                "interactive",
+		"READ_ONLY":                 "1",
+		"WORK_DIR":                  agentboxWorkDirInContainer,
+		"RESULT_PATH":               agentboxResultPathInCtr,
+		"APPEND_SYSTEM_PROMPT_FILE": sessionPromptInContainer,
+	}
+	if creds, err := jobs.GetParameterValue[map[string]string](parameters, parameters_enums.AgentEnvVars); err == nil {
+		for k, v := range creds {
+			env[k] = v
+		}
+	} else {
+		return nil, fmt.Errorf("agent env vars missing — deployment-server should have injected at pickup: %s", err)
+	}
+	for _, kv := range []struct {
+		envKey string
+		param  parameters_enums.Key
+	}{
+		{"SESSION_ID", parameters_enums.SessionUUID},
+		{"AGENT_TYPE", parameters_enums.AgentType},
+		{"MODEL", parameters_enums.Model},
+		{"CLAUDE_CODE_VERSION", parameters_enums.ClaudeCodeVersion},
+		{"CODEX_VERSION", parameters_enums.CodexVersion},
+	} {
+		if v, err := jobs.GetParameterValue[string](parameters, kv.param); err == nil && v != "" {
+			env[kv.envKey] = v
+		}
+	}
+	if allowed := mergeAdditionalAllowedHosts(parameters); allowed != "" {
+		env["ADDITIONAL_ALLOWED_HOSTS"] = allowed
+	}
+	return mapToEnvSlice(env), nil
+}
+
+// runSession spawns the interactive container, runs the output-forward and
+// input-pump bridge loops alongside it, and blocks until the container exits or
+// the session is stopped (the normal end). A stop is not a failure.
+func (rs *RunAssistantSession) runSession(orgID, jobID, imageRef, workDirHost string, envVars []string, logsWriter io.Writer) error {
+	dockerCtx := context.Background()
+	cli, err := dockerclient.NewClientWithOpts(dockerclient.FromEnv, dockerclient.WithAPIVersionNegotiation())
+	if err != nil {
+		return err
+	}
+	defer cli.Close()
+	containerID, err := createAgentboxContainer(dockerCtx, cli, agentboxSpawnSpec{imageRef: imageRef, workDirHost: workDirHost, env: envVars})
+	if err != nil {
+		return err
+	}
+	var logsWg sync.WaitGroup
+	defer logsWg.Wait()
+	defer func() { _ = removeContainer(dockerCtx, cli, containerID) }()
+	if err := cli.ContainerStart(dockerCtx, containerID, container.StartOptions{}); err != nil {
+		return fmt.Errorf("error starting container: %s", err)
+	}
+	logsWg.Add(1)
+	go func() {
+		defer logsWg.Done()
+		streamContainerLogs(dockerCtx, cli, containerID, logsWriter)
+	}()
+
+	mf := &messageForwarder{
+		dir:   filepath.Join(workDirHost, ".agentbox-output", "messages"),
+		orgID: orgID, jobID: jobID, logsWriter: logsWriter, seen: map[string]bool{},
+	}
+	ip := &inputPump{
+		dir:   filepath.Join(workDirHost, ".agentbox-input", "messages"),
+		orgID: orgID, jobID: jobID, logsWriter: logsWriter,
+	}
+	stopBridge := make(chan struct{})
+	var bridgeWg sync.WaitGroup
+	bridgeWg.Add(2)
+	go func() { defer bridgeWg.Done(); runSessionTicker(stopBridge, mf.tick) }()
+	go func() { defer bridgeWg.Done(); runSessionTicker(stopBridge, ip.tick) }()
+
+	waitCtx, cancelWait := context.WithTimeout(dockerCtx, defaultWallClockTimeout)
+	defer cancelWait()
+	_, waitErr := waitForContainerExit(waitCtx, cli, containerID, rs.stopSignal)
+	close(stopBridge)
+	bridgeWg.Wait()
+	mf.tick() // final drain of any buffered output
+	logSessionOutcome(workDirHost, logsWriter)
+	if waitErr != nil && !errors.Is(waitErr, types.ErrJobStoppedByUser) {
+		return waitErr
+	}
+	return nil
+}
+
+// runSessionTicker calls fn every sessionPollInterval until stop closes.
+func runSessionTicker(stop <-chan struct{}, fn func()) {
+	t := time.NewTicker(sessionPollInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-stop:
+			return
+		case <-t.C:
+			fn()
+		}
+	}
+}
+
+// messageForwarder reads agentbox's streamed output files in order and forwards
+// them to deployment-server as assistant-message deltas. agentbox emits a run
+// of "chunk" records (deltas) then a "final" per assistant message; a new
+// MessageID is minted at the first chunk after each final so the UI groups
+// deltas correctly.
+type messageForwarder struct {
+	dir          string
+	orgID, jobID string
+	logsWriter   io.Writer
+	seen         map[string]bool
+	currentMsgID string
+}
+
+func (mf *messageForwarder) tick() {
+	entries, _ := os.ReadDir(mf.dir)
+	var names []string
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".json") && !mf.seen[e.Name()] {
+			names = append(names, e.Name())
+		}
+	}
+	sort.Strings(names)
+	var batch []sessions.AppendMessageDtoV1
+	for _, n := range names {
+		mf.seen[n] = true
+		b, err := os.ReadFile(filepath.Join(mf.dir, n))
+		if err != nil {
+			continue
+		}
+		var rec struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		}
+		if json.Unmarshal(b, &rec) != nil {
+			continue
+		}
+		switch rec.Type {
+		case "chunk":
+			if mf.currentMsgID == "" {
+				mf.currentMsgID = primitive.NewObjectID().Hex()
+			}
+			batch = append(batch, sessions.AppendMessageDtoV1{JobID: mf.jobID, MessageID: mf.currentMsgID, Content: rec.Text})
+		case "final":
+			if mf.currentMsgID != "" {
+				batch = append(batch, sessions.AppendMessageDtoV1{JobID: mf.jobID, MessageID: mf.currentMsgID, IsDone: true})
+				mf.currentMsgID = ""
+			}
+		}
+	}
+	if len(batch) == 0 {
+		return
+	}
+	if err := runnerclient.Get().UpdateSessionMessages(batch, mf.orgID); err != nil {
+		io.WriteString(mf.logsWriter, fmt.Sprintf("session: error forwarding messages: %s\n", err))
+		// keep the names marked seen — a failed batch is dropped rather than
+		// replayed, matching the live-stream "prefer a gap over a dup" stance.
+	}
+}
+
+// inputPump pulls the user's new turns from deployment-server and writes them
+// into agentbox's input dir (atomic temp+rename) for the live agent to consume.
+type inputPump struct {
+	dir          string
+	orgID, jobID string
+	logsWriter   io.Writer
+	afterTs      int64
+	seq          int
+}
+
+func (ip *inputPump) tick() {
+	msgs, err := runnerclient.Get().GetSessionInput(ip.jobID, ip.afterTs, ip.orgID)
+	if err != nil {
+		io.WriteString(ip.logsWriter, fmt.Sprintf("session: error pulling input: %s\n", err))
+		return
+	}
+	sort.Slice(msgs, func(i, j int) bool { return msgs[i].Ts < msgs[j].Ts })
+	for _, m := range msgs {
+		ip.seq++
+		ip.write(m)
+		if m.Ts > ip.afterTs {
+			ip.afterTs = m.Ts
+		}
+	}
+}
+
+func (ip *inputPump) write(m sessions.UserMessageDtoV1) {
+	rec := map[string]any{"id": m.ID, "content": m.Content, "ts": m.Ts}
+	b, err := json.Marshal(rec)
+	if err != nil {
+		return
+	}
+	name := fmt.Sprintf("%010d.json", ip.seq)
+	tmp := filepath.Join(ip.dir, name+".tmp")
+	if err := os.WriteFile(tmp, b, 0644); err != nil {
+		return
+	}
+	_ = os.Rename(tmp, filepath.Join(ip.dir, name))
+}
+
+// logSessionOutcome best-effort surfaces the final agent result and whether a
+// task spec was produced. Spec persistence to the Session record is wired in a
+// later phase (app-server convert flow).
+func logSessionOutcome(workDirHost string, logsWriter io.Writer) {
+	if result, err := readAgentResult(workDirHost); err == nil {
+		io.WriteString(logsWriter, fmt.Sprintf("session ended: status=%s\n", result.Status))
+	}
+	specPath := filepath.Join(workDirHost, ".agentbox-output", "task-spec.json")
+	if b, err := os.ReadFile(specPath); err == nil && len(b) > 0 {
+		io.WriteString(logsWriter, "session produced a task spec\n")
+	}
+}

--- a/jobs/commands/run_assistant_session.go
+++ b/jobs/commands/run_assistant_session.go
@@ -139,6 +139,12 @@ func buildSessionSpawnEnvVars(parameters map[string]interface{}) ([]string, erro
 		"WORK_DIR":                  agentboxWorkDirInContainer,
 		"RESULT_PATH":               agentboxResultPathInCtr,
 		"APPEND_SYSTEM_PROMPT_FILE": sessionPromptInContainer,
+		// Disable agentbox's stdout no-activity watchdog for sessions: an
+		// interactive agent is idle by design between user turns, so the
+		// watchdog (built for batch — detect a hung subprocess) would kill a
+		// session whenever the user pauses longer than its timeout to think.
+		// The server-side idle cron (user-message-based) is the idle-killer.
+		"NO_ACTIVITY_TIMEOUT": "0",
 	}
 	if creds, err := jobs.GetParameterValue[map[string]string](parameters, parameters_enums.AgentEnvVars); err == nil {
 		for k, v := range creds {
@@ -214,16 +220,53 @@ func (rs *RunAssistantSession) runSession(orgID, jobID, imageRef, workDirHost st
 
 	waitCtx, cancelWait := context.WithTimeout(dockerCtx, defaultWallClockTimeout)
 	defer cancelWait()
-	_, waitErr := waitForContainerExit(waitCtx, cli, containerID, rs.stopSignal)
+	exitCode, waitErr := waitForContainerExit(waitCtx, cli, containerID, rs.stopSignal)
 	close(stopBridge)
 	bridgeWg.Wait()
 	mf.tick() // final drain of any buffered output
 	sf.tick() // final spec snapshot
 	logSessionOutcome(workDirHost, logsWriter)
-	if waitErr != nil && !errors.Is(waitErr, types.ErrJobStoppedByUser) {
-		return waitErr
+	if errors.Is(waitErr, types.ErrJobStoppedByUser) {
+		return nil // user / cron / convert stop — the normal session end
+	}
+	if waitErr != nil {
+		return waitErr // wall-clock cap or a wait error
+	}
+	// Natural container exit. A healthy interactive session agent doesn't exit
+	// on its own — a non-zero code means it failed (API credits/auth exhausted,
+	// a fatal rate-limit, or a crash). Surface the reason to the chat so the
+	// user sees why it stopped, and return an error so the Job is reported
+	// failed (deployment-server then marks the session Failed).
+	if exitCode != 0 {
+		failMsg := sessionAgentFailureMessage(workDirHost)
+		rs.forwardSessionFailure(orgID, jobID, failMsg, logsWriter)
+		return fmt.Errorf("session agent exited with code %d: %s", exitCode, failMsg)
 	}
 	return nil
+}
+
+// sessionAgentFailureMessage builds a user-facing reason for a failed session
+// agent, preferring agentbox's classified error from result.json (auth / credit
+// / rate-limit context) when present.
+func sessionAgentFailureMessage(workDirHost string) string {
+	if result, err := readAgentResult(workDirHost); err == nil && strings.TrimSpace(result.Error) != "" {
+		return result.Error
+	}
+	return "the agent stopped unexpectedly — it may have run out of API credits, hit an auth or rate-limit error, or crashed"
+}
+
+// forwardSessionFailure posts a final assistant message to the session thread so
+// the chat shows why the agent stopped instead of going silent.
+func (rs *RunAssistantSession) forwardSessionFailure(orgID, jobID, msg string, logsWriter io.Writer) {
+	err := runnerclient.Get().UpdateSessionMessages([]sessions.AppendMessageDtoV1{{
+		JobID:     jobID,
+		MessageID: primitive.NewObjectID().Hex(),
+		Content:   "⚠️ " + msg,
+		IsDone:    true,
+	}}, orgID)
+	if err != nil {
+		io.WriteString(logsWriter, fmt.Sprintf("session: error forwarding failure message: %s\n", err))
+	}
 }
 
 // runSessionTicker calls fn every sessionPollInterval until stop closes.

--- a/jobs/commands/run_assistant_session.go
+++ b/jobs/commands/run_assistant_session.go
@@ -318,43 +318,28 @@ func (mf *messageForwarder) tick() {
 	if len(names) == 0 {
 		return
 	}
-	// Build the batch over a COPY of the rotation cursor (msgID) and a local
-	// consumed list, committing neither mf.seen nor mf.currentMsgID until the
-	// forward succeeds — so a failed forward is retried verbatim next tick
-	// (at-least-once) rather than dropped. Dropping a batch that held the "final"
-	// would otherwise lose the whole assistant message (it would never persist).
-	// The server persists idempotently, so a redelivered final is a no-op.
-	msgID := mf.currentMsgID
-	var batch []sessions.AppendMessageDtoV1
+	// Read unseen files in order. A readable file is consumed even if its JSON
+	// is corrupt (agentbox writes atomically, so a parse failure is permanent —
+	// don't re-read it). Stop on a transient read error to preserve order.
+	var records []outputRec
 	var consumed []string
 	for _, n := range names {
 		b, err := os.ReadFile(filepath.Join(mf.dir, n))
 		if err != nil {
-			break // transient read error — stop here, preserve order, retry from n next tick
+			break // retry from n next tick
 		}
-		var rec struct {
-			Type string `json:"type"`
-			Text string `json:"text"`
-		}
+		var rec outputRec
 		if json.Unmarshal(b, &rec) == nil {
-			switch rec.Type {
-			case "chunk":
-				if msgID == "" {
-					msgID = primitive.NewObjectID().Hex()
-				}
-				batch = append(batch, sessions.AppendMessageDtoV1{JobID: mf.jobID, MessageID: msgID, Content: rec.Text})
-			case "final":
-				if msgID != "" {
-					batch = append(batch, sessions.AppendMessageDtoV1{JobID: mf.jobID, MessageID: msgID, IsDone: true})
-					msgID = ""
-				}
-			}
+			records = append(records, rec)
 		}
-		// A readable file is consumed whether it yielded a delta, an unknown
-		// type, or corrupt JSON (agentbox writes atomically, so a parse failure
-		// is permanent corruption — don't re-read it forever).
 		consumed = append(consumed, n)
 	}
+	// Rotate over a COPY of the cursor; commit neither mf.seen nor
+	// mf.currentMsgID until the forward succeeds, so a failed forward is retried
+	// verbatim next tick (at-least-once) rather than dropped. Dropping a batch
+	// that held the "final" would lose the whole assistant message. The server
+	// persists idempotently, so a redelivered final is a no-op.
+	batch, endMsgID := rotateOutputBatch(records, mf.jobID, mf.currentMsgID)
 	if len(batch) == 0 {
 		// Only unknown/corrupt files this pass; still advance seen so we don't
 		// re-scan them every tick.
@@ -370,7 +355,37 @@ func (mf *messageForwarder) tick() {
 	for _, n := range consumed {
 		mf.seen[n] = true
 	}
-	mf.currentMsgID = msgID
+	mf.currentMsgID = endMsgID
+}
+
+// outputRec is one parsed agentbox output record (.agentbox-output/messages).
+type outputRec struct {
+	Type string `json:"type"` // "chunk" | "final"
+	Text string `json:"text"`
+}
+
+// rotateOutputBatch turns a run of parsed output records into assistant-message
+// deltas: consecutive "chunk"s share one MessageID and "final" closes it.
+// startMsgID continues an in-flight message across ticks ("" mints a new id at
+// the first chunk); endMsgID is the cursor to carry to the next call. Pure (no
+// fs / client) so the chunk/final grouping is unit-testable.
+func rotateOutputBatch(records []outputRec, jobID, startMsgID string) (batch []sessions.AppendMessageDtoV1, endMsgID string) {
+	msgID := startMsgID
+	for _, rec := range records {
+		switch rec.Type {
+		case "chunk":
+			if msgID == "" {
+				msgID = primitive.NewObjectID().Hex()
+			}
+			batch = append(batch, sessions.AppendMessageDtoV1{JobID: jobID, MessageID: msgID, Content: rec.Text})
+		case "final":
+			if msgID != "" {
+				batch = append(batch, sessions.AppendMessageDtoV1{JobID: jobID, MessageID: msgID, IsDone: true})
+				msgID = ""
+			}
+		}
+	}
+	return batch, msgID
 }
 
 // inputPump pulls the user's new turns from deployment-server and writes them
@@ -391,10 +406,7 @@ func (ip *inputPump) tick() {
 		return
 	}
 	sort.Slice(msgs, func(i, j int) bool { return msgs[i].Ts < msgs[j].Ts })
-	for _, m := range msgs {
-		if ip.seen[m.ID] {
-			continue // already delivered (the server re-returns same-second turns via $gte)
-		}
+	for _, m := range filterUndelivered(msgs, ip.seen) {
 		ip.seq++
 		ip.write(m)
 		ip.seen[m.ID] = true
@@ -402,6 +414,19 @@ func (ip *inputPump) tick() {
 			ip.afterTs = m.Ts
 		}
 	}
+}
+
+// filterUndelivered drops messages already delivered (by id), so the server's
+// inclusive ($gte AfterTs) input query can re-return same-second turns without
+// the runner replaying them to the agent. Pure.
+func filterUndelivered(msgs []sessions.UserMessageDtoV1, seen map[string]bool) []sessions.UserMessageDtoV1 {
+	out := make([]sessions.UserMessageDtoV1, 0, len(msgs))
+	for _, m := range msgs {
+		if !seen[m.ID] {
+			out = append(out, m)
+		}
+	}
+	return out
 }
 
 func (ip *inputPump) write(m sessions.UserMessageDtoV1) {

--- a/jobs/commands/run_assistant_session.go
+++ b/jobs/commands/run_assistant_session.go
@@ -46,6 +46,16 @@ func (rs *RunAssistantSession) SetStopSignal(stop <-chan struct{}) {
 const (
 	sessionPromptInContainer = agentboxWorkDirInContainer + "/.agentbox-input/system-prompt.txt"
 	sessionPollInterval      = 750 * time.Millisecond
+	// sessionWallClockHardCap is the runner-side backstop on a session
+	// container's lifetime. The REAL wall-clock enforcement is the
+	// deployment-server idle/wall-clock cron (default 4h, honors the session's
+	// WallClockMaxHours), which MarkStopping's the Job → a clean, graceful end.
+	// This cap is deliberately well above that so the cron always wins; it only
+	// fires if the server never stops the session (server unreachable / broken
+	// heartbeat) — a genuinely orphaned container, where reporting failed is
+	// acceptable. Equal caps would race and mislabel a normal time-limit end as
+	// Failed, so keep this strictly larger than the server's max.
+	sessionWallClockHardCap = 8 * time.Hour
 )
 
 // planModePrompt instructs the agent for a read-only, plan-mode session. Kept
@@ -205,7 +215,7 @@ func (rs *RunAssistantSession) runSession(orgID, jobID, imageRef, workDirHost st
 	}
 	ip := &inputPump{
 		dir:   filepath.Join(workDirHost, ".agentbox-input", "messages"),
-		orgID: orgID, jobID: jobID, logsWriter: logsWriter,
+		orgID: orgID, jobID: jobID, logsWriter: logsWriter, seen: map[string]bool{},
 	}
 	sf := &specForwarder{
 		path:  filepath.Join(workDirHost, ".agentbox-output", "task-spec.json"),
@@ -218,7 +228,7 @@ func (rs *RunAssistantSession) runSession(orgID, jobID, imageRef, workDirHost st
 	go func() { defer bridgeWg.Done(); runSessionTicker(stopBridge, ip.tick) }()
 	go func() { defer bridgeWg.Done(); runSessionTicker(stopBridge, sf.tick) }()
 
-	waitCtx, cancelWait := context.WithTimeout(dockerCtx, defaultWallClockTimeout)
+	waitCtx, cancelWait := context.WithTimeout(dockerCtx, sessionWallClockHardCap)
 	defer cancelWait()
 	exitCode, waitErr := waitForContainerExit(waitCtx, cli, containerID, rs.stopSignal)
 	close(stopBridge)
@@ -305,41 +315,62 @@ func (mf *messageForwarder) tick() {
 		}
 	}
 	sort.Strings(names)
+	if len(names) == 0 {
+		return
+	}
+	// Build the batch over a COPY of the rotation cursor (msgID) and a local
+	// consumed list, committing neither mf.seen nor mf.currentMsgID until the
+	// forward succeeds — so a failed forward is retried verbatim next tick
+	// (at-least-once) rather than dropped. Dropping a batch that held the "final"
+	// would otherwise lose the whole assistant message (it would never persist).
+	// The server persists idempotently, so a redelivered final is a no-op.
+	msgID := mf.currentMsgID
 	var batch []sessions.AppendMessageDtoV1
+	var consumed []string
 	for _, n := range names {
-		mf.seen[n] = true
 		b, err := os.ReadFile(filepath.Join(mf.dir, n))
 		if err != nil {
-			continue
+			break // transient read error — stop here, preserve order, retry from n next tick
 		}
 		var rec struct {
 			Type string `json:"type"`
 			Text string `json:"text"`
 		}
-		if json.Unmarshal(b, &rec) != nil {
-			continue
-		}
-		switch rec.Type {
-		case "chunk":
-			if mf.currentMsgID == "" {
-				mf.currentMsgID = primitive.NewObjectID().Hex()
+		if json.Unmarshal(b, &rec) == nil {
+			switch rec.Type {
+			case "chunk":
+				if msgID == "" {
+					msgID = primitive.NewObjectID().Hex()
+				}
+				batch = append(batch, sessions.AppendMessageDtoV1{JobID: mf.jobID, MessageID: msgID, Content: rec.Text})
+			case "final":
+				if msgID != "" {
+					batch = append(batch, sessions.AppendMessageDtoV1{JobID: mf.jobID, MessageID: msgID, IsDone: true})
+					msgID = ""
+				}
 			}
-			batch = append(batch, sessions.AppendMessageDtoV1{JobID: mf.jobID, MessageID: mf.currentMsgID, Content: rec.Text})
-		case "final":
-			if mf.currentMsgID != "" {
-				batch = append(batch, sessions.AppendMessageDtoV1{JobID: mf.jobID, MessageID: mf.currentMsgID, IsDone: true})
-				mf.currentMsgID = ""
-			}
 		}
+		// A readable file is consumed whether it yielded a delta, an unknown
+		// type, or corrupt JSON (agentbox writes atomically, so a parse failure
+		// is permanent corruption — don't re-read it forever).
+		consumed = append(consumed, n)
 	}
 	if len(batch) == 0 {
+		// Only unknown/corrupt files this pass; still advance seen so we don't
+		// re-scan them every tick.
+		for _, n := range consumed {
+			mf.seen[n] = true
+		}
 		return
 	}
 	if err := runnerclient.Get().UpdateSessionMessages(batch, mf.orgID); err != nil {
 		io.WriteString(mf.logsWriter, fmt.Sprintf("session: error forwarding messages: %s\n", err))
-		// keep the names marked seen — a failed batch is dropped rather than
-		// replayed, matching the live-stream "prefer a gap over a dup" stance.
+		return // do NOT advance seen or currentMsgID — retry the whole batch next tick
 	}
+	for _, n := range consumed {
+		mf.seen[n] = true
+	}
+	mf.currentMsgID = msgID
 }
 
 // inputPump pulls the user's new turns from deployment-server and writes them
@@ -350,6 +381,7 @@ type inputPump struct {
 	logsWriter   io.Writer
 	afterTs      int64
 	seq          int
+	seen         map[string]bool // delivered message ids — dedup the inclusive ($gte) AfterTs boundary
 }
 
 func (ip *inputPump) tick() {
@@ -360,8 +392,12 @@ func (ip *inputPump) tick() {
 	}
 	sort.Slice(msgs, func(i, j int) bool { return msgs[i].Ts < msgs[j].Ts })
 	for _, m := range msgs {
+		if ip.seen[m.ID] {
+			continue // already delivered (the server re-returns same-second turns via $gte)
+		}
 		ip.seq++
 		ip.write(m)
+		ip.seen[m.ID] = true
 		if m.Ts > ip.afterTs {
 			ip.afterTs = m.Ts
 		}

--- a/jobs/commands/run_assistant_session_test.go
+++ b/jobs/commands/run_assistant_session_test.go
@@ -1,0 +1,102 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/deployment-io/deployment-runner-kit/sessions"
+)
+
+// TestRotateOutputBatch covers the chunk/final grouping that drives the
+// at-least-once message forwarder: consecutive chunks share one MessageID and
+// "final" closes it.
+func TestRotateOutputBatch(t *testing.T) {
+	const job = "job1"
+	batch, end := rotateOutputBatch([]outputRec{
+		{Type: "chunk", Text: "Hel"}, {Type: "chunk", Text: "lo"}, {Type: "final"},
+	}, job, "")
+
+	if len(batch) != 3 {
+		t.Fatalf("want 3 deltas, got %d", len(batch))
+	}
+	id := batch[0].MessageID
+	if id == "" {
+		t.Fatal("first chunk should mint a MessageID")
+	}
+	if batch[1].MessageID != id {
+		t.Error("chunks of one message must share the MessageID")
+	}
+	if batch[0].Content != "Hel" || batch[1].Content != "lo" {
+		t.Errorf("chunk content wrong: %q %q", batch[0].Content, batch[1].Content)
+	}
+	if !batch[2].IsDone || batch[2].MessageID != id || batch[2].Content != "" {
+		t.Error("final should close the same message with no content")
+	}
+	if end != "" {
+		t.Errorf("endMsgID should reset after a final, got %q", end)
+	}
+	if batch[0].JobID != job {
+		t.Errorf("jobID = %q, want %q", batch[0].JobID, job)
+	}
+}
+
+// TestRotateOutputBatch_CarryOver covers an in-flight message split across ticks
+// (no final yet): the id carries over and the next tick continues it.
+func TestRotateOutputBatch_CarryOver(t *testing.T) {
+	batch, end := rotateOutputBatch([]outputRec{{Type: "chunk", Text: "a"}, {Type: "chunk", Text: "b"}}, "j", "")
+	if end == "" {
+		t.Fatal("an in-flight message id should carry over when there's no final")
+	}
+	if batch[0].MessageID != end || batch[1].MessageID != end {
+		t.Error("trailing chunks should share the carried id")
+	}
+
+	batch2, end2 := rotateOutputBatch([]outputRec{{Type: "chunk", Text: "c"}, {Type: "final"}}, "j", end)
+	if batch2[0].MessageID != end {
+		t.Error("continuation should reuse the carried MessageID")
+	}
+	if !batch2[1].IsDone || batch2[1].MessageID != end {
+		t.Error("final should close the carried message")
+	}
+	if end2 != "" {
+		t.Errorf("id should reset after the final, got %q", end2)
+	}
+}
+
+func TestRotateOutputBatch_TwoMessages(t *testing.T) {
+	batch, _ := rotateOutputBatch([]outputRec{
+		{Type: "chunk", Text: "one"}, {Type: "final"},
+		{Type: "chunk", Text: "two"}, {Type: "final"},
+	}, "j", "")
+	if len(batch) != 4 {
+		t.Fatalf("want 4 deltas, got %d", len(batch))
+	}
+	if batch[0].MessageID == batch[2].MessageID {
+		t.Error("separate messages must have distinct MessageIDs")
+	}
+}
+
+func TestRotateOutputBatch_LoneFinalIgnored(t *testing.T) {
+	batch, end := rotateOutputBatch([]outputRec{{Type: "final"}}, "j", "")
+	if len(batch) != 0 {
+		t.Errorf("a final with no in-flight message should produce nothing, got %d", len(batch))
+	}
+	if end != "" {
+		t.Errorf("no in-flight id expected, got %q", end)
+	}
+}
+
+// TestFilterUndelivered covers the inputPump dedupe that makes the server's
+// inclusive ($gte) input query safe to re-return same-second turns.
+func TestFilterUndelivered(t *testing.T) {
+	seen := map[string]bool{"b": true}
+	out := filterUndelivered([]sessions.UserMessageDtoV1{{ID: "a"}, {ID: "b"}, {ID: "c"}}, seen)
+	if len(out) != 2 || out[0].ID != "a" || out[1].ID != "c" {
+		t.Errorf("want [a c], got %v", out)
+	}
+	if got := filterUndelivered([]sessions.UserMessageDtoV1{{ID: "b"}}, seen); len(got) != 0 {
+		t.Errorf("already-seen message should be filtered, got %v", got)
+	}
+	if got := filterUndelivered(nil, seen); len(got) != 0 {
+		t.Errorf("nil input should yield empty, got %v", got)
+	}
+}

--- a/jobs/commands/utils/sessions.go
+++ b/jobs/commands/utils/sessions.go
@@ -8,7 +8,7 @@ import (
 )
 
 // IsSessionMode reports whether the Job is an interactive Assistant session.
-// CheckoutRepo branches on this to take the read-only single-repo clone path
+// CheckoutRepo branches on this to take the read-only clone path
 // (runForSession). Keys on SessionUUID presence (stamped by
 // RunAssistantSessionBehavior); a session Job carries no TaskID, so it won't
 // match IsTasksMode either.
@@ -18,10 +18,18 @@ func IsSessionMode(parameters map[string]interface{}) bool {
 }
 
 // GetSessionRepositoriesBaseDir is the on-disk base under which an interactive
-// Assistant session's checked-out repo(s) live, bind-mounted into agentbox as
+// Assistant session's checked-out repos live, bind-mounted into agentbox as
 // /work. Keyed by (orgID, sessionJobID): a session has exactly one long-lived
 // Job, so the Job id is a stable per-session key that CheckoutRepo and
 // RunAssistantSession agree on without passing the path as a parameter.
 func GetSessionRepositoriesBaseDir(orgID, sessionJobID string) string {
 	return fmt.Sprintf("/tmp/%s/sessions/%s", orgID, sessionJobID)
+}
+
+// GetSessionRepositoryDir is one repo's clone path under the session base dir,
+// as <baseDir>/<idx>-<name> — mirrors GetTaskRepositoryDir so a session lays its
+// repos out identically to a Task (the agent's cwd is /work; each repo is an
+// <idx>-<name> subdirectory).
+func GetSessionRepositoryDir(orgID, sessionJobID string, idx int, name string) string {
+	return fmt.Sprintf("%s/%d-%s", GetSessionRepositoriesBaseDir(orgID, sessionJobID), idx, name)
 }

--- a/jobs/commands/utils/sessions.go
+++ b/jobs/commands/utils/sessions.go
@@ -1,0 +1,12 @@
+package utils
+
+import "fmt"
+
+// GetSessionRepositoriesBaseDir is the on-disk base under which an interactive
+// Assistant session's checked-out repo(s) live, bind-mounted into agentbox as
+// /work. Keyed by (orgID, sessionJobID): a session has exactly one long-lived
+// Job, so the Job id is a stable per-session key that CheckoutRepo and
+// RunAssistantSession agree on without passing the path as a parameter.
+func GetSessionRepositoriesBaseDir(orgID, sessionJobID string) string {
+	return fmt.Sprintf("/tmp/%s/sessions/%s", orgID, sessionJobID)
+}

--- a/jobs/commands/utils/sessions.go
+++ b/jobs/commands/utils/sessions.go
@@ -1,6 +1,21 @@
 package utils
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/deployment-io/deployment-runner-kit/enums/parameters_enums"
+	"github.com/deployment-io/deployment-runner-kit/jobs"
+)
+
+// IsSessionMode reports whether the Job is an interactive Assistant session.
+// CheckoutRepo branches on this to take the read-only single-repo clone path
+// (runForSession). Keys on SessionUUID presence (stamped by
+// RunAssistantSessionBehavior); a session Job carries no TaskID, so it won't
+// match IsTasksMode either.
+func IsSessionMode(parameters map[string]interface{}) bool {
+	v, err := jobs.GetParameterValue[string](parameters, parameters_enums.SessionUUID)
+	return err == nil && len(v) > 0
+}
 
 // GetSessionRepositoriesBaseDir is the on-disk base under which an interactive
 // Assistant session's checked-out repo(s) live, bind-mounted into agentbox as


### PR DESCRIPTION
## Summary
deployment-runner side of the interactive Assistant session bridge.

- `run_assistant_session.go` — spawns agentbox **interactive + read-only** (reusing the `run_agent_step` container helpers), keeps it alive for the conversation, and runs two bridge loops: forward `.agentbox-output/messages` deltas → `UpdateSessionMessages` (→ message_stream → SSE), and pump `GetSessionInput` → `.agentbox-input`. A stop signal is the normal session end. Carries the read-only plan-mode prompt.
- `client/sessions_operations.go` — `UpdateSessionMessages` + `GetSessionInput`.
- `utils/sessions.go` — `GetSessionRepositoriesBaseDir` work-dir helper.
- Registered `RunAssistantSession` in `commands.go`.

Depends on the **deployment-runner-kit** `feature/assistant-sessions` PR (sessions DTOs + commands_enums). **Not yet dispatchable** — needs the session checkout + Job creation (next).

## Test plan
Builds green through the Assistant workspace overlay (`go.work.assistant`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)