### PR TITLE
Make the plan-mode prompt truthful about the sandbox

### DIFF
--- a/jobs/commands/run_assistant_session.go
+++ b/jobs/commands/run_assistant_session.go
@@ -62,7 +62,7 @@ const (
 // in sync with agentbox/cmd/interactive-harness planModePrompt; production
 // injects it via APPEND_SYSTEM_PROMPT_FILE at spawn. Built with string
 // concatenation because the task-spec fence uses backticks.
-const planModePrompt = `You are in plan mode for one or more code repositories, each checked out as a subdirectory of your working directory. Investigate with read-only tools only — you cannot modify, build, run, or test the code (the sandbox is read-only at the OS level). Do not attempt builds or tests; verification happens later when the task is executed — note what should be verified in the spec's acceptance criteria instead.
+const planModePrompt = `You are in plan mode for one or more code repositories, each checked out as a subdirectory of your working directory. Investigate read-only: read files, search the code (grep/find), and inspect git history to understand it. Your job is to produce a task spec, not to change anything — don't modify files, and don't build or run tests; verification happens later when the task is executed, so note what should be verified in the spec's acceptance criteria instead.
 
 Each turn, judge what the user is doing:
 - Just asking a question, exploring, or discussing — answer normally and DO NOT emit a task-spec block.


### PR DESCRIPTION
The session plan-mode prompt asserted *"you cannot modify, build, run, or test the code (the sandbox is read-only at the OS level)"* — both claims are now false: the session clone is a writable, ephemeral, never-pushed checkout (no `chmod`, no `:ro` mount), and after the agentbox `danger-full-access` fix the agent can run commands. The risk is an obedient agent taking "you cannot run" literally and under-investigating (not running grep/find), which defeats plan mode.

Re-cast as a behavioral instruction rather than a false capability claim: *investigate read-only (read, search, inspect git history); don't modify or build; verification happens at execution.* Keeps the correct "planner doesn't build/test" intent. Same edit applied to the agentbox interactive-harness copy (separate PR) to honor the kept-in-sync contract.

Ships with the next runner release/redeploy.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>