### PR TITLE
Scrub the installation token from agent repo checkouts (sessions + tasks)

### DIFF
--- a/jobs/commands/checkout_repository_for_session.go
+++ b/jobs/commands/checkout_repository_for_session.go
@@ -81,7 +81,32 @@ func cloneSessionRepoReadOnly(repoDir string, entry tasks.RepositoryEntry, orgID
 	if err := worktree.Checkout(&git.CheckoutOptions{Branch: baseRef}); err != nil {
 		return fmt.Errorf("error checking out base branch %s: %s", entry.BaseBranch, err)
 	}
+	if err := scrubRemoteToken(repository, entry.CloneURL); err != nil {
+		return err
+	}
 	return chownTreeToAgentbox(repoDir)
+}
+
+// scrubRemoteToken resets origin's URL to the tokenless clone URL, removing the
+// installation token go-git persists into .git/config from a tokenized clone.
+// The in-container agent can read .git/config, but a session is read-only and
+// never fetches or pushes again (and the network proxy blocks GitHub anyway),
+// so the credential is pure liability — strip it. Best-effort by design: a
+// missing origin is not an error.
+func scrubRemoteToken(repository *git.Repository, tokenlessURL string) error {
+	cfg, err := repository.Config()
+	if err != nil {
+		return fmt.Errorf("error reading repo config to scrub token: %s", err)
+	}
+	remote, ok := cfg.Remotes["origin"]
+	if !ok {
+		return nil
+	}
+	remote.URLs = []string{tokenlessURL}
+	if err := repository.Storer.SetConfig(cfg); err != nil {
+		return fmt.Errorf("error setting scrubbed remote config: %s", err)
+	}
+	return nil
 }
 
 // sessionToken returns a token for the installation, minting + caching on a miss

--- a/jobs/commands/checkout_repository_for_session.go
+++ b/jobs/commands/checkout_repository_for_session.go
@@ -89,10 +89,11 @@ func cloneSessionRepoReadOnly(repoDir string, entry tasks.RepositoryEntry, orgID
 
 // scrubRemoteToken resets origin's URL to the tokenless clone URL, removing the
 // installation token go-git persists into .git/config from a tokenized clone.
-// The in-container agent can read .git/config, but a session is read-only and
-// never fetches or pushes again (and the network proxy blocks GitHub anyway),
-// so the credential is pure liability — strip it. Best-effort by design: a
-// missing origin is not an error.
+// Call it at the end of a checkout, after the runner's own clone/fetch, so the
+// in-container agent never sees a credential it doesn't need. Safe for both
+// flows: a session never pushes, and a Task pushes via commit_and_push, which
+// authenticates with its own freshly-minted token through PushOptions.Auth —
+// independent of the remote URL. Best-effort: a missing origin is not an error.
 func scrubRemoteToken(repository *git.Repository, tokenlessURL string) error {
 	cfg, err := repository.Config()
 	if err != nil {

--- a/jobs/commands/checkout_repository_for_session_test.go
+++ b/jobs/commands/checkout_repository_for_session_test.go
@@ -1,0 +1,55 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+
+	git "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
+)
+
+// TestScrubRemoteToken verifies the installation token is removed from origin's
+// URL after a session clone — the credential go-git persists into .git/config
+// must not be left readable by the in-container agent.
+func TestScrubRemoteToken(t *testing.T) {
+	repo, err := git.PlainInit(t.TempDir(), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Mirror what go-git persists into .git/config after a tokenized clone.
+	if _, err := repo.CreateRemote(&config.RemoteConfig{
+		Name: "origin",
+		URLs: []string{"https://x-access-token:ghs_supersecret@github.com/owner/repo.git"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	const tokenless = "https://github.com/owner/repo.git"
+	if err := scrubRemoteToken(repo, tokenless); err != nil {
+		t.Fatalf("scrubRemoteToken: %v", err)
+	}
+
+	cfg, err := repo.Config()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := cfg.Remotes["origin"].URLs[0]
+	if got != tokenless {
+		t.Errorf("origin URL = %q, want %q", got, tokenless)
+	}
+	if strings.Contains(got, "ghs_") || strings.Contains(got, "@") {
+		t.Errorf("origin URL still carries a credential: %q", got)
+	}
+}
+
+// TestScrubRemoteToken_NoOrigin is a no-op and returns no error when there is
+// no origin remote to scrub.
+func TestScrubRemoteToken_NoOrigin(t *testing.T) {
+	repo, err := git.PlainInit(t.TempDir(), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := scrubRemoteToken(repo, "https://github.com/owner/repo.git"); err != nil {
+		t.Errorf("expected no error with no origin, got %v", err)
+	}
+}

--- a/jobs/commands/checkout_repository_for_task.go
+++ b/jobs/commands/checkout_repository_for_task.go
@@ -163,6 +163,14 @@ func (tc *taskCheckout) checkoutOne(repoDir string, entry tasks.RepositoryEntry)
 			return err
 		}
 	}
+	// Strip the installation token from .git/config before the agent runs:
+	// the runner's own git ops (clone, and the Step>0 fetch above) are done,
+	// and commit_and_push later authenticates with its own freshly-minted
+	// token via PushOptions.Auth — so the embedded credential is not needed
+	// downstream, and the RunAgentStep container shouldn't be able to read it.
+	if err := scrubRemoteToken(repository, entry.CloneURL); err != nil {
+		return err
+	}
 	// go-git's PlainClone + Checkout ran as the runner process (root inside
 	// its container). Chown the entire repo tree to the agentbox `agent`
 	// user so the spawned RunAgentStep container can modify these files


### PR DESCRIPTION
A planning-session agent flagged it: *"both git remotes are configured with embedded credentials in the remote URL."* Accurate — both the session and Task checkouts clone via `GetRepoUrlWithToken(...)`, and go-git persists that tokenized URL into `.git/config`, which the in-container agent can read.

## Why it's safe to strip (both flows)

The agent never needs the remote credential:
- **Sessions** are read-only and never fetch/push again; the proxy blocks `github.com` anyway.
- **Tasks** push via `commit_and_push`, which authenticates with its **own** freshly-minted token through `git.PushOptions{Auth: BasicAuth{...}}` ([commit_and_push.go:257](https://github.com/deployment-io/runner/blob/master/jobs/commands/commit_and_push.go)) — independent of the remote URL. The scrub runs at the end of checkout, *after* the runner's own clone + Step>0 fetch, and `RunAgentStep` is a separate later command.

So a tokenless `origin` + explicit `Auth` push works; nothing downstream depends on the embedded credential.

## Fix

`scrubRemoteToken` resets `origin` to the tokenless `entry.CloneURL` after checkout, in both `cloneSessionRepoReadOnly` and `taskCheckout.checkoutOne`. Runs per-repo, so multi-repo checkouts are covered. Tested: token-bearing origin → tokenless (no `@`, no `ghs_`), plus a no-origin no-op.

## Severity

Low — installation tokens are short-lived (~1h), the checkout is ephemeral, and egress is proxy-restricted. But there's no reason to hand the agent a credential it can neither use nor should see. Defense in depth on the one component (the agent container) we don't fully trust.

`go build` / `go vet` / tests green. Ships with the next runner release.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>