### PR TITLE
Forward agentbox turn_end records to deployment-server

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.31.1
 	github.com/aws/aws-sdk-go-v2/service/sts v1.28.6
 	github.com/aws/smithy-go v1.22.2
-	github.com/deployment-io/deployment-runner-kit v0.0.0-20260610033908-2ecde01ee036
+	github.com/deployment-io/deployment-runner-kit v0.0.0-20260611151632-06e23ce46d59
 	github.com/deployment-io/team-ai v0.0.0-20250917084912-bdbad6a834e1
 	github.com/docker/docker v27.3.0+incompatible
 	github.com/go-git/go-git/v5 v5.12.0

--- a/go.sum
+++ b/go.sum
@@ -151,8 +151,8 @@ github.com/cyphar/filepath-securejoin v0.2.5/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxG
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deployment-io/deployment-runner-kit v0.0.0-20260610033908-2ecde01ee036 h1:2D8c5JTnomSltXVEMtxZtbcTbiTExsSilGHaBqzr4NY=
-github.com/deployment-io/deployment-runner-kit v0.0.0-20260610033908-2ecde01ee036/go.mod h1:OEoIfAAL2cUkK4Rf0rpW32YqHw7Mgx2aaC7o07IGAhQ=
+github.com/deployment-io/deployment-runner-kit v0.0.0-20260611151632-06e23ce46d59 h1:OF4sUwQrH0P30mcPGULsV6MDDmGX7MiKgIIaZnKApUY=
+github.com/deployment-io/deployment-runner-kit v0.0.0-20260611151632-06e23ce46d59/go.mod h1:OEoIfAAL2cUkK4Rf0rpW32YqHw7Mgx2aaC7o07IGAhQ=
 github.com/deployment-io/team-ai v0.0.0-20250917084912-bdbad6a834e1 h1:gfeNqym19IiO38sQ84WPMmZXrdDisu64qQP3Xs0N2RM=
 github.com/deployment-io/team-ai v0.0.0-20250917084912-bdbad6a834e1/go.mod h1:B0fxmLJICi0qP2R2m3I2tR1uRIKQxn4ekK67lyBRHjw=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=

--- a/jobs/commands/run_assistant_session.go
+++ b/jobs/commands/run_assistant_session.go
@@ -266,13 +266,21 @@ func sessionAgentFailureMessage(workDirHost string) string {
 }
 
 // forwardSessionFailure posts a final assistant message to the session thread so
-// the chat shows why the agent stopped instead of going silent.
+// the chat shows why the agent stopped instead of going silent. A turn-end
+// follows it: a dead agent never sends its own boundary, and without one the
+// UI's composer (gated on the turn boundary) would stay locked until the
+// session goes terminal.
 func (rs *RunAssistantSession) forwardSessionFailure(orgID, jobID, msg string, logsWriter io.Writer) {
 	err := runnerclient.Get().UpdateSessionMessages([]sessions.AppendMessageDtoV1{{
 		JobID:     jobID,
 		MessageID: primitive.NewObjectID().Hex(),
 		Content:   "⚠️ " + msg,
 		IsDone:    true,
+	}, {
+		JobID:     jobID,
+		MessageID: primitive.NewObjectID().Hex(),
+		IsDone:    true,
+		TurnEnd:   true,
 	}}, orgID)
 	if err != nil {
 		io.WriteString(logsWriter, fmt.Sprintf("session: error forwarding failure message: %s\n", err))
@@ -360,12 +368,13 @@ func (mf *messageForwarder) tick() {
 
 // outputRec is one parsed agentbox output record (.agentbox-output/messages).
 type outputRec struct {
-	Type string `json:"type"` // "chunk" | "final"
+	Type string `json:"type"` // "chunk" | "final" | "turn_end"
 	Text string `json:"text"`
 }
 
 // rotateOutputBatch turns a run of parsed output records into assistant-message
-// deltas: consecutive "chunk"s share one MessageID and "final" closes it.
+// deltas: consecutive "chunk"s share one MessageID, "final" closes it, and
+// "turn_end" forwards the agent's turn boundary as its own control update.
 // startMsgID continues an in-flight message across ticks ("" mints a new id at
 // the first chunk); endMsgID is the cursor to carry to the next call. Pure (no
 // fs / client) so the chunk/final grouping is unit-testable.
@@ -383,6 +392,14 @@ func rotateOutputBatch(records []outputRec, jobID, startMsgID string) (batch []s
 				batch = append(batch, sessions.AppendMessageDtoV1{JobID: jobID, MessageID: msgID, IsDone: true})
 				msgID = ""
 			}
+		case "turn_end":
+			if msgID != "" {
+				// Defensive: agentbox always finalizes a message before the
+				// boundary, but never let one ride past it half-open.
+				batch = append(batch, sessions.AppendMessageDtoV1{JobID: jobID, MessageID: msgID, IsDone: true})
+				msgID = ""
+			}
+			batch = append(batch, sessions.AppendMessageDtoV1{JobID: jobID, MessageID: primitive.NewObjectID().Hex(), IsDone: true, TurnEnd: true})
 		}
 	}
 	return batch, msgID

--- a/jobs/commands/run_assistant_session_test.go
+++ b/jobs/commands/run_assistant_session_test.go
@@ -85,6 +85,49 @@ func TestRotateOutputBatch_LoneFinalIgnored(t *testing.T) {
 	}
 }
 
+// TestRotateOutputBatch_TurnEnd covers the turn boundary: it forwards as its
+// own control update (fresh MessageID, IsDone, TurnEnd, no content) after the
+// turn's messages.
+func TestRotateOutputBatch_TurnEnd(t *testing.T) {
+	batch, end := rotateOutputBatch([]outputRec{
+		{Type: "chunk", Text: "answer"}, {Type: "final"}, {Type: "turn_end"},
+	}, "j", "")
+	if len(batch) != 3 {
+		t.Fatalf("want 3 deltas, got %d", len(batch))
+	}
+	te := batch[2]
+	if !te.TurnEnd || !te.IsDone || te.Content != "" {
+		t.Errorf("turn-end delta wrong: %+v", te)
+	}
+	if te.MessageID == "" || te.MessageID == batch[0].MessageID {
+		t.Error("turn-end must carry its own fresh MessageID")
+	}
+	if end != "" {
+		t.Errorf("no in-flight id expected after a turn end, got %q", end)
+	}
+}
+
+// TestRotateOutputBatch_TurnEndClosesHalfOpenMessage pins the defensive close:
+// a turn_end arriving while a message is mid-stream (no final yet) finalizes
+// it first so it isn't lost past the boundary.
+func TestRotateOutputBatch_TurnEndClosesHalfOpenMessage(t *testing.T) {
+	batch, end := rotateOutputBatch([]outputRec{
+		{Type: "chunk", Text: "orphan"}, {Type: "turn_end"},
+	}, "j", "")
+	if len(batch) != 3 {
+		t.Fatalf("want chunk + synthesized final + turn-end, got %d: %+v", len(batch), batch)
+	}
+	if !batch[1].IsDone || batch[1].MessageID != batch[0].MessageID || batch[1].TurnEnd {
+		t.Errorf("half-open message should be closed before the boundary: %+v", batch[1])
+	}
+	if !batch[2].TurnEnd {
+		t.Errorf("boundary should follow the synthesized final: %+v", batch[2])
+	}
+	if end != "" {
+		t.Errorf("no carry-over expected, got %q", end)
+	}
+}
+
 // TestFilterUndelivered covers the inputPump dedupe that makes the server's
 // inclusive ($gte) input query safe to re-return same-second turns.
 func TestFilterUndelivered(t *testing.T) {


### PR DESCRIPTION
## Summary
Bridges the session agent's turn boundary to the server: `rotateOutputBatch` maps agentbox's new `turn_end` output record to its own `AppendMessageDtoV1` control update (fresh `MessageID`, `IsDone`, `TurnEnd`, no content), defensively finalizing any half-open message first. `forwardSessionFailure` appends a turn-end after the failure message so a dead agent — which never sends its own boundary — doesn't leave the dashboard composer locked until the session goes terminal.

Old agentbox images simply never produce the record; an unknown record type was already ignored, so mixed versions are safe in both directions.

## Merge order
After deployment-io/deployment-runner-kit#39 (adds `message_enums.TurnEnd` + the DTO field); bump it in go.mod at merge.

## Verification
`go build ./... && go vet ./jobs/... && go test ./jobs/...` green via a workspace overlay against runner-kit#39. New tests: turn-end control update shape, half-open-message close at the boundary.

## Related
agentbox deployment-io/agentbox#30 (emits the record), deployment-server PR (records it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)