### PR TITLE
Check out session base branch as a local branch (fix false detached-HEAD finding)

### DIFF
--- a/jobs/commands/checkout_repository_for_session.go
+++ b/jobs/commands/checkout_repository_for_session.go
@@ -73,18 +73,42 @@ func cloneSessionRepoReadOnly(repoDir string, entry tasks.RepositoryEntry, orgID
 	if err != nil {
 		return err
 	}
-	worktree, err := repository.Worktree()
-	if err != nil {
-		return fmt.Errorf("error getting worktree: %s", err)
-	}
-	baseRef := plumbing.NewRemoteReferenceName("origin", entry.BaseBranch)
-	if err := worktree.Checkout(&git.CheckoutOptions{Branch: baseRef}); err != nil {
-		return fmt.Errorf("error checking out base branch %s: %s", entry.BaseBranch, err)
+	if err := checkoutSessionBaseBranch(repository, entry.BaseBranch); err != nil {
+		return err
 	}
 	if err := scrubRemoteToken(repository, entry.CloneURL); err != nil {
 		return err
 	}
 	return chownTreeToAgentbox(repoDir)
+}
+
+// checkoutSessionBaseBranch positions the worktree on baseBranch as a LOCAL
+// branch — creating refs/heads/<base> from origin/<base> when the clone didn't
+// already materialize it. Checking out the remote-tracking ref directly
+// (refs/remotes/origin/<base>) leaves HEAD detached, which a session agent
+// reads as a repo-hygiene problem and tells the user to "fix" (git checkout
+// main): a false finding about our own ephemeral clone, not their repo.
+func checkoutSessionBaseBranch(repository *git.Repository, baseBranch string) error {
+	worktree, err := repository.Worktree()
+	if err != nil {
+		return fmt.Errorf("error getting worktree: %s", err)
+	}
+	localRef := plumbing.NewBranchReferenceName(baseBranch)
+	opts := &git.CheckoutOptions{Branch: localRef}
+	if _, err := repository.Reference(localRef, false); err != nil {
+		// No local branch yet (base != the clone's default branch): create it
+		// at the remote ref and switch to it.
+		remoteRef, rerr := repository.Reference(plumbing.NewRemoteReferenceName("origin", baseBranch), true)
+		if rerr != nil {
+			return fmt.Errorf("error resolving base branch %s: %s", baseBranch, rerr)
+		}
+		opts.Hash = remoteRef.Hash()
+		opts.Create = true
+	}
+	if err := worktree.Checkout(opts); err != nil {
+		return fmt.Errorf("error checking out base branch %s: %s", baseBranch, err)
+	}
+	return nil
 }
 
 // scrubRemoteToken resets origin's URL to the tokenless clone URL, removing the

--- a/jobs/commands/checkout_repository_for_session_test.go
+++ b/jobs/commands/checkout_repository_for_session_test.go
@@ -1,11 +1,16 @@
 package commands
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	git "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
 )
 
 // TestScrubRemoteToken verifies the installation token is removed from origin's
@@ -51,5 +56,52 @@ func TestScrubRemoteToken_NoOrigin(t *testing.T) {
 	}
 	if err := scrubRemoteToken(repo, "https://github.com/owner/repo.git"); err != nil {
 		t.Errorf("expected no error with no origin, got %v", err)
+	}
+}
+
+// TestCheckoutSessionBaseBranch_NotDetached pins the fix for the false
+// "switch out of detached HEAD" finding sessions surfaced: checking out the
+// base must land HEAD on a local branch (refs/heads/<base>), not the
+// remote-tracking ref (which detaches HEAD). Exercises the create-from-remote
+// path — base branch name differs from the clone's default.
+func TestCheckoutSessionBaseBranch_NotDetached(t *testing.T) {
+	dir := t.TempDir()
+	repo, err := git.PlainInit(dir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wt, err := repo.Worktree()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "f.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := wt.Add("f.txt"); err != nil {
+		t.Fatal(err)
+	}
+	h, err := wt.Commit("init", &git.CommitOptions{
+		Author: &object.Signature{Name: "t", Email: "t@e", When: time.Unix(0, 0).UTC()},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Simulate the remote-tracking ref a clone leaves, for a base branch that
+	// is NOT the local default ("master" from PlainInit) — the detaching case.
+	if err := repo.Storer.SetReference(
+		plumbing.NewHashReference(plumbing.NewRemoteReferenceName("origin", "main"), h)); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := checkoutSessionBaseBranch(repo, "main"); err != nil {
+		t.Fatalf("checkoutSessionBaseBranch: %v", err)
+	}
+
+	head, err := repo.Head()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := plumbing.NewBranchReferenceName("main"); head.Name() != want {
+		t.Errorf("HEAD = %s, want %s (detached-HEAD regression)", head.Name(), want)
 	}
 }


### PR DESCRIPTION
## Symptom (from live codex session testing)

The agent reported the repo was in **detached HEAD** and recommended *"git checkout main"* as a top fix. That's a **false positive about our checkout**, not the user's repo.

## Cause

`cloneSessionRepoReadOnly` checked out the remote-tracking ref directly:

```go
baseRef := plumbing.NewRemoteReferenceName("origin", entry.BaseBranch) // refs/remotes/origin/main
worktree.Checkout(&git.CheckoutOptions{Branch: baseRef})
```

Checking out `origin/main` (a remote ref) rather than a local branch leaves `HEAD` detached. The agent dutifully flags it — and even bakes "switch out of detached HEAD" into its analysis/spec. The **Task** checkout already avoids this (its own code comments warn that checking out `refs/remotes/origin/<branch>` detaches HEAD); the session path didn't get the same treatment.

## Fix

New `checkoutSessionBaseBranch` helper materializes `refs/heads/<base>` from `origin/<base>` (when the clone didn't already, i.e. base ≠ default branch) and checks **that** out, so `HEAD` sits on a normal branch (`main`). Test asserts HEAD lands on `refs/heads/<base>`, not a detached ref.

Read-only investigation is unaffected functionally — this is purely so the agent sees a normal repo and stops giving bogus git advice. Ships with the next runner release.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
EOF
)