### PR TITLE
Explore: AWS ECS context source + whole-context materialize (#8)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.31.1
 	github.com/aws/aws-sdk-go-v2/service/sts v1.28.6
 	github.com/aws/smithy-go v1.22.2
-	github.com/deployment-io/deployment-runner-kit v0.0.0-20260624155432-6ebc4b042039
+	github.com/deployment-io/deployment-runner-kit v0.0.0-20260628142533-4bc6e5b4f6b7
 	github.com/deployment-io/team-ai v0.0.0-20250917084912-bdbad6a834e1
 	github.com/docker/docker v27.3.0+incompatible
 	github.com/go-git/go-git/v5 v5.12.0

--- a/go.sum
+++ b/go.sum
@@ -151,8 +151,8 @@ github.com/cyphar/filepath-securejoin v0.2.5/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxG
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deployment-io/deployment-runner-kit v0.0.0-20260624155432-6ebc4b042039 h1:0owA+9IfuabSmaR1x+BOrUva24l++EMg24XzH5ygXr8=
-github.com/deployment-io/deployment-runner-kit v0.0.0-20260624155432-6ebc4b042039/go.mod h1:OEoIfAAL2cUkK4Rf0rpW32YqHw7Mgx2aaC7o07IGAhQ=
+github.com/deployment-io/deployment-runner-kit v0.0.0-20260628142533-4bc6e5b4f6b7 h1:bdsMA/3QHjxMKZhbW+XkKONOKvNMRZyzKXqhPTgUqa0=
+github.com/deployment-io/deployment-runner-kit v0.0.0-20260628142533-4bc6e5b4f6b7/go.mod h1:OEoIfAAL2cUkK4Rf0rpW32YqHw7Mgx2aaC7o07IGAhQ=
 github.com/deployment-io/team-ai v0.0.0-20250917084912-bdbad6a834e1 h1:gfeNqym19IiO38sQ84WPMmZXrdDisu64qQP3Xs0N2RM=
 github.com/deployment-io/team-ai v0.0.0-20250917084912-bdbad6a834e1/go.mod h1:B0fxmLJICi0qP2R2m3I2tR1uRIKQxn4ekK67lyBRHjw=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=

--- a/jobs/commands/build_infra_context.go
+++ b/jobs/commands/build_infra_context.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -17,6 +18,11 @@ import (
 
 const contextPackVersion = 1
 
+// infraBuildTimeout is a generous wall-clock bound on the whole source-build pass, passed into every
+// source's Build. The heartbeat is a separate ticker that keeps beating even if a source blocks, so
+// it can't reclaim a hung command; this deadline is what bounds a pathological cloud-API hang.
+const infraBuildTimeout = 15 * time.Minute
+
 // BuildInfraContext is the deterministic context-pack builder. It iterates the registered
 // context sources, groups their output by scope (Org / Cluster), runs the
 // runner-side redaction backstop per scope, and writes the resulting []ScopedPack to
@@ -29,8 +35,10 @@ const contextPackVersion = 1
 // degraded snapshot — the cron/user retry refreshes it. (Manifest gaps are blind spots a
 // *successful* run determined, e.g. an `auth can-i` denial — not connector errors.)
 //
-// It's an ordinary command: running_jobs registration + heartbeat are handled by the runner's
-// outer execution loop, so the heartbeat-timeout cron covers it like any other job.
+// running_jobs registration + heartbeat are handled by the runner's outer execution loop, so a dead
+// runner is reclaimed by the heartbeat-timeout cron like any other job. The heartbeat is a separate
+// ticker, though, so it does NOT bound a hung command — the source builds run under a wall-clock
+// deadline (infraBuildTimeout) so a pathological cloud-API hang can't tie up a job slot.
 type BuildInfraContext struct{}
 
 func (b *BuildInfraContext) Run(parameters map[string]interface{}, logsWriter io.Writer) (map[string]interface{}, error) {
@@ -61,10 +69,12 @@ func (b *BuildInfraContext) Run(parameters map[string]interface{}, logsWriter io
 		return pack
 	}
 
+	ctx, cancel := context.WithTimeout(context.Background(), infraBuildTimeout)
+	defer cancel()
 	sources := context_sources.All()
 	io.WriteString(logsWriter, fmt.Sprintf("Running %d context source(s)...\n", len(sources)))
 	for _, src := range sources {
-		results, err := src.Build(parameters, logsWriter)
+		results, err := src.Build(ctx, parameters, logsWriter)
 		if err != nil {
 			// A connector error is transient plumbing failure, not knowledge about the infra:
 			// log it and skip. We deliberately do NOT fold it into the pack as a gap (gaps are

--- a/jobs/commands/build_infra_context.go
+++ b/jobs/commands/build_infra_context.go
@@ -11,8 +11,8 @@ import (
 	"github.com/deployment-io/deployment-runner-kit/enums/parameters_enums"
 	"github.com/deployment-io/deployment-runner-kit/jobs"
 	"github.com/deployment-io/deployment-runner/jobs/commands/context_sources"
-	// Register context sources here (blank imports run their init()), e.g.:
-	// _ "github.com/deployment-io/deployment-runner/jobs/commands/context_sources/repo_catalog"
+	// Register context sources here (blank imports run their init()).
+	_ "github.com/deployment-io/deployment-runner/jobs/commands/context_sources/aws_ecs"
 )
 
 const contextPackVersion = 1
@@ -64,7 +64,7 @@ func (b *BuildInfraContext) Run(parameters map[string]interface{}, logsWriter io
 	sources := context_sources.All()
 	io.WriteString(logsWriter, fmt.Sprintf("Running %d context source(s)...\n", len(sources)))
 	for _, src := range sources {
-		result, err := src.Build(parameters, logsWriter)
+		results, err := src.Build(parameters, logsWriter)
 		if err != nil {
 			// A connector error is transient plumbing failure, not knowledge about the infra:
 			// log it and skip. We deliberately do NOT fold it into the pack as a gap (gaps are
@@ -76,12 +76,16 @@ func (b *BuildInfraContext) Run(parameters map[string]interface{}, logsWriter io
 			io.WriteString(logsWriter, fmt.Sprintf("  source %s failed (skipping; last-good context retained): %v\n", src.Name(), err))
 			continue
 		}
-		// Success path: artifacts + any gaps the connector *determined* (real can-i-style blind
-		// spots, never errors) join the pack for its scope.
-		pack := ensure(normalize(result.Scope))
-		pack.Artifacts = append(pack.Artifacts, result.Artifacts...)
-		pack.Manifest.Files = append(pack.Manifest.Files, result.Entries...)
-		pack.Manifest.Gaps = append(pack.Manifest.Gaps, result.Gaps...)
+		// Success path: each Result is one scope's contribution — artifacts + any gaps the connector
+		// *determined* (real can-i-style blind spots, never errors) join that scope's pack. A
+		// connector spanning several scopes (e.g. one Result per ECS cluster) groups into one pack
+		// per scope here.
+		for _, result := range results {
+			pack := ensure(normalize(result.Scope))
+			pack.Artifacts = append(pack.Artifacts, result.Artifacts...)
+			pack.Manifest.Files = append(pack.Manifest.Files, result.Entries...)
+			pack.Manifest.Gaps = append(pack.Manifest.Gaps, result.Gaps...)
+		}
 	}
 
 	// Runner-side redaction invariant: every scope's pack passes through here before it's

--- a/jobs/commands/build_infra_context.go
+++ b/jobs/commands/build_infra_context.go
@@ -18,7 +18,7 @@ import (
 const contextPackVersion = 1
 
 // BuildInfraContext is the deterministic context-pack builder. It iterates the registered
-// context sources, groups their output by scope (Org / Environment / Cluster), runs the
+// context sources, groups their output by scope (Org / Cluster), runs the
 // runner-side redaction backstop per scope, and writes the resulting []ScopedPack to
 // JobOutput. deployment-server persists one context_packs record per (org, scope), so
 // org-wide content is stored once rather than duplicated per environment.

--- a/jobs/commands/context_sources/aws_ecs/aws_ecs.go
+++ b/jobs/commands/context_sources/aws_ecs/aws_ecs.go
@@ -55,7 +55,7 @@ type observedService struct {
 // the policy self-grant is what makes this work without a prior deployment; on an already-deployed
 // runner it is a no-op. Region comes from the job parameters (set by the trigger to the runner's
 // region); the cluster ARN carries account+region, so records stay unambiguous across runners.
-func (s *source) Build(parameters map[string]interface{}, logsWriter io.Writer) ([]context_sources.Result, error) {
+func (s *source) Build(ctx context.Context, parameters map[string]interface{}, logsWriter io.Writer) ([]context_sources.Result, error) {
 	runnerData := utils.RunnerData.Get()
 	if err := ensurePolicy(parameters, runnerData); err != nil {
 		return nil, err
@@ -77,7 +77,6 @@ func (s *source) Build(parameters map[string]interface{}, logsWriter io.Writer) 
 	}
 	io.WriteString(logsWriter, fmt.Sprintf("aws-ecs: scanning region %s (account %s)\n", runnerData.RunnerRegion, runnerData.AWSAccountID))
 
-	ctx := context.TODO()
 	clusterArns, err := listClusters(ctx, ecsClient)
 	if err != nil {
 		return nil, err

--- a/jobs/commands/context_sources/aws_ecs/aws_ecs.go
+++ b/jobs/commands/context_sources/aws_ecs/aws_ecs.go
@@ -159,6 +159,12 @@ func observeCluster(ctx context.Context, c *ecs.Client, clusterArn string, logsW
 			return nil, err
 		}
 		for _, svc := range out.Services {
+			// Only steady-state services: skip DRAINING/INACTIVE ones (being torn down) — they aren't
+			// what's running. (DescribeServices can also return Failures for services deleted between
+			// the list and describe; those simply don't appear in out.Services, so they're skipped.)
+			if aws.ToString(svc.Status) != "ACTIVE" {
+				continue
+			}
 			taskDef := aws.ToString(svc.TaskDefinition)
 			if taskDef == "" {
 				continue
@@ -190,12 +196,13 @@ func observeCluster(ctx context.Context, c *ecs.Client, clusterArn string, logsW
 	return observed, nil
 }
 
-// listServices returns every service ARN in a cluster, following pagination.
+// listServices returns every service ARN in a cluster, following pagination. MaxResults is set to
+// the max (100); ECS's ListServices default is only 10, which would 10x the page (call) count.
 func listServices(ctx context.Context, c *ecs.Client, clusterArn string) ([]string, error) {
 	var arns []string
 	var next *string
 	for {
-		out, err := c.ListServices(ctx, &ecs.ListServicesInput{Cluster: aws.String(clusterArn), NextToken: next})
+		out, err := c.ListServices(ctx, &ecs.ListServicesInput{Cluster: aws.String(clusterArn), MaxResults: aws.Int32(100), NextToken: next})
 		if err != nil {
 			return nil, err
 		}

--- a/jobs/commands/context_sources/aws_ecs/aws_ecs.go
+++ b/jobs/commands/context_sources/aws_ecs/aws_ecs.go
@@ -56,14 +56,26 @@ type observedService struct {
 // runner it is a no-op. Region comes from the job parameters (set by the trigger to the runner's
 // region); the cluster ARN carries account+region, so records stay unambiguous across runners.
 func (s *source) Build(parameters map[string]interface{}, logsWriter io.Writer) ([]context_sources.Result, error) {
-	if err := ensurePolicy(parameters); err != nil {
+	runnerData := utils.RunnerData.Get()
+	if err := ensurePolicy(parameters, runnerData); err != nil {
 		return nil, err
 	}
 
-	ecsClient, err := cloud_api_clients.GetEcsClient(parameters)
+	// Scan the runner's OWN install region. A runner is installed per region and its default
+	// credential chain is its own account, so the clusters it can see are exactly its region+account's
+	// — precisely the slice of infra this runner is responsible for. Self-sourced from RunnerData, NOT
+	// a job parameter: the trigger needn't pass a region and can't pass a wrong one. An org spanning
+	// regions/accounts installs a runner per region/account, and each builds its own slice; the packs
+	// compose by scope (cluster ARN carries account+region).
+	if runnerData.RunnerRegion == "" {
+		io.WriteString(logsWriter, "aws-ecs: runner has no region; skipping\n")
+		return nil, nil
+	}
+	ecsClient, err := cloud_api_clients.GetEcsClientFromRegion(runnerData.RunnerRegion)
 	if err != nil {
 		return nil, err
 	}
+	io.WriteString(logsWriter, fmt.Sprintf("aws-ecs: scanning region %s (account %s)\n", runnerData.RunnerRegion, runnerData.AWSAccountID))
 
 	ctx := context.TODO()
 	clusterArns, err := listClusters(ctx, ecsClient)
@@ -97,8 +109,7 @@ func (s *source) Build(parameters map[string]interface{}, logsWriter io.Writer) 
 // ensurePolicy self-grants the infra-context read bundle (ecs:*) on the runner's own task role,
 // mirroring every other command's policy self-grant. Idempotent; a no-op on a runner that already
 // has ecs:* from a prior deployment.
-func ensurePolicy(parameters map[string]interface{}) error {
-	runnerData := utils.RunnerData.Get()
+func ensurePolicy(parameters map[string]interface{}, runnerData utils.RunnerDataType) error {
 	organizationID, err := jobs.GetParameterValue[string](parameters, parameters_enums.OrganizationIDNamespace)
 	if err != nil {
 		return err

--- a/jobs/commands/context_sources/aws_ecs/aws_ecs.go
+++ b/jobs/commands/context_sources/aws_ecs/aws_ecs.go
@@ -1,0 +1,301 @@
+// Package aws_ecs is the AWS ECS context connector — the OBSERVED half of the service↔repo map.
+// It walks live ECS (clusters → services → task definitions → container images) and best-effort
+// recovers the repo that produced each image, emitting one Cluster-scoped Result per cluster
+// (scope ID = the cluster ARN). It is the live counterpart to the DECLARED service-repo-map that
+// app-server derives from each repo's deploy-config: same shape, different source of truth, so the
+// agent can reconcile "what's wired up" against "what's actually running".
+//
+// Source name "aws-ecs", SourceKind Discovered. Self-registers via init(); BuildInfraContext
+// blank-imports this package. Metadata/structure only — never secret values.
+package aws_ecs
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ecs"
+	"github.com/deployment-io/deployment-runner-kit/cloud_api_clients"
+	"github.com/deployment-io/deployment-runner-kit/context_pack"
+	"github.com/deployment-io/deployment-runner-kit/enums/context_pack_enums"
+	"github.com/deployment-io/deployment-runner-kit/enums/iam_policy_enums"
+	"github.com/deployment-io/deployment-runner-kit/enums/parameters_enums"
+	"github.com/deployment-io/deployment-runner-kit/iam_policies"
+	"github.com/deployment-io/deployment-runner-kit/jobs"
+	"github.com/deployment-io/deployment-runner/jobs/commands/context_sources"
+	"github.com/deployment-io/deployment-runner/utils"
+)
+
+func init() {
+	context_sources.Register(&source{})
+}
+
+type source struct{}
+
+func (s *source) Name() string { return context_pack.SourceAwsEcs }
+
+// observedService is one running ECS service mapped to the repo we recovered for it. The shape
+// mirrors the declared service-repo-map (service/repo/image) plus the observed coordinates and the
+// recovery method, so reconciliation can line the two up and weight the join. JSON tags are the
+// on-disk artifact schema; `cloud` keeps the record self-describing in a cross-cloud view.
+type observedService struct {
+	Service     string `json:"service"`
+	Cluster     string `json:"cluster"`               // human-facing cluster name (ARN is the scope ID)
+	Image       string `json:"image"`                 // full container image URI
+	Repo        string `json:"repo,omitempty"`        // recovered repo (best-effort; see recoverRepo)
+	RecoveredBy string `json:"recoveredBy,omitempty"` // how Repo was derived, e.g. "image-name"
+	Cloud       string `json:"cloud"`                 // "aws"
+}
+
+// Build self-provisions ECS read access, then emits one Cluster-scoped Result per ECS cluster in
+// the runner's region that has services. A never-deployed (context-only) runner has no ecs:* yet, so
+// the policy self-grant is what makes this work without a prior deployment; on an already-deployed
+// runner it is a no-op. Region comes from the job parameters (set by the trigger to the runner's
+// region); the cluster ARN carries account+region, so records stay unambiguous across runners.
+func (s *source) Build(parameters map[string]interface{}, logsWriter io.Writer) ([]context_sources.Result, error) {
+	if err := ensurePolicy(parameters); err != nil {
+		return nil, err
+	}
+
+	ecsClient, err := cloud_api_clients.GetEcsClient(parameters)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx := context.TODO()
+	clusterArns, err := listClusters(ctx, ecsClient)
+	if err != nil {
+		return nil, err
+	}
+	if len(clusterArns) == 0 {
+		io.WriteString(logsWriter, "aws-ecs: no ECS clusters in this region; nothing to observe\n")
+		return nil, nil
+	}
+
+	builtTs := time.Now().Unix()
+	var results []context_sources.Result
+	for _, clusterArn := range clusterArns {
+		observed, err := observeCluster(ctx, ecsClient, clusterArn, logsWriter)
+		if err != nil {
+			// One cluster failing shouldn't sink the others — log + skip. The scope's last-good
+			// record stands (per BuildInfraContext's failure posture: error != gap, no degraded write).
+			io.WriteString(logsWriter, fmt.Sprintf("aws-ecs: cluster %s failed (skipping): %v\n", nameFromArn(clusterArn), err))
+			continue
+		}
+		if len(observed) == 0 {
+			continue // empty cluster: nothing to record (no degraded/empty pack)
+		}
+		results = append(results, scopedResult(clusterArn, observed, builtTs))
+	}
+	io.WriteString(logsWriter, fmt.Sprintf("aws-ecs: observed %d cluster(s) with services\n", len(results)))
+	return results, nil
+}
+
+// ensurePolicy self-grants the infra-context read bundle (ecs:*) on the runner's own task role,
+// mirroring every other command's policy self-grant. Idempotent; a no-op on a runner that already
+// has ecs:* from a prior deployment.
+func ensurePolicy(parameters map[string]interface{}) error {
+	runnerData := utils.RunnerData.Get()
+	organizationID, err := jobs.GetParameterValue[string](parameters, parameters_enums.OrganizationIDNamespace)
+	if err != nil {
+		return err
+	}
+	return iam_policies.AddAwsPolicyForDeploymentRunner(iam_policy_enums.AwsInfraContext, runnerData.OsType.String(),
+		runnerData.CpuArchEnum.String(), organizationID, runnerData.RunnerRegion, runnerData.Mode, runnerData.TargetCloud)
+}
+
+// listClusters returns every ECS cluster ARN in the region, following pagination.
+func listClusters(ctx context.Context, c *ecs.Client) ([]string, error) {
+	var arns []string
+	var next *string
+	for {
+		out, err := c.ListClusters(ctx, &ecs.ListClustersInput{NextToken: next})
+		if err != nil {
+			return nil, err
+		}
+		arns = append(arns, out.ClusterArns...)
+		if out.NextToken == nil {
+			return arns, nil
+		}
+		next = out.NextToken
+	}
+}
+
+// observeCluster walks one cluster's services → task definitions → container images. A failure to
+// list the cluster's services is returned (caller skips the cluster); a single task definition that
+// can't be read is logged and skipped so one bad service doesn't blank the whole cluster.
+func observeCluster(ctx context.Context, c *ecs.Client, clusterArn string, logsWriter io.Writer) ([]observedService, error) {
+	serviceArns, err := listServices(ctx, c, clusterArn)
+	if err != nil {
+		return nil, err
+	}
+	if len(serviceArns) == 0 {
+		return nil, nil
+	}
+	clusterName := nameFromArn(clusterArn)
+	taskDefImages := map[string][]string{} // task-def ARN -> image URIs; services often share a task def
+	var observed []observedService
+	// DescribeServices accepts at most 10 services per call.
+	for _, batch := range chunk(serviceArns, 10) {
+		out, err := c.DescribeServices(ctx, &ecs.DescribeServicesInput{
+			Cluster:  aws.String(clusterArn),
+			Services: batch,
+		})
+		if err != nil {
+			return nil, err
+		}
+		for _, svc := range out.Services {
+			taskDef := aws.ToString(svc.TaskDefinition)
+			if taskDef == "" {
+				continue
+			}
+			images, cached := taskDefImages[taskDef]
+			if !cached {
+				images, err = imagesForTaskDef(ctx, c, taskDef)
+				if err != nil {
+					io.WriteString(logsWriter, fmt.Sprintf("aws-ecs: task def %s unreadable (skipping service %s): %v\n",
+						nameFromArn(taskDef), aws.ToString(svc.ServiceName), err))
+					taskDefImages[taskDef] = nil
+					continue
+				}
+				taskDefImages[taskDef] = images
+			}
+			for _, img := range images {
+				repo, by := recoverRepo(img)
+				observed = append(observed, observedService{
+					Service:     aws.ToString(svc.ServiceName),
+					Cluster:     clusterName,
+					Image:       img,
+					Repo:        repo,
+					RecoveredBy: by,
+					Cloud:       "aws",
+				})
+			}
+		}
+	}
+	return observed, nil
+}
+
+// listServices returns every service ARN in a cluster, following pagination.
+func listServices(ctx context.Context, c *ecs.Client, clusterArn string) ([]string, error) {
+	var arns []string
+	var next *string
+	for {
+		out, err := c.ListServices(ctx, &ecs.ListServicesInput{Cluster: aws.String(clusterArn), NextToken: next})
+		if err != nil {
+			return nil, err
+		}
+		arns = append(arns, out.ServiceArns...)
+		if out.NextToken == nil {
+			return arns, nil
+		}
+		next = out.NextToken
+	}
+}
+
+// imagesForTaskDef returns the container image URIs declared in a task definition.
+func imagesForTaskDef(ctx context.Context, c *ecs.Client, taskDefArn string) ([]string, error) {
+	out, err := c.DescribeTaskDefinition(ctx, &ecs.DescribeTaskDefinitionInput{TaskDefinition: aws.String(taskDefArn)})
+	if err != nil {
+		return nil, err
+	}
+	if out.TaskDefinition == nil {
+		return nil, nil
+	}
+	var images []string
+	for _, cd := range out.TaskDefinition.ContainerDefinitions {
+		if img := aws.ToString(cd.Image); img != "" {
+			images = append(images, img)
+		}
+	}
+	return images, nil
+}
+
+// scopedResult packs one cluster's observations into a Cluster-scoped Result. The scope ID is the
+// FULL cluster ARN (account + region embedded), so observations from different accounts/regions —
+// produced by different runners — never collide when merged. Artifact name + manifest entry path
+// both come from File(SourceAwsEcs); BuildInfraContext stamps the pack-level version/BuiltTs.
+func scopedResult(clusterArn string, observed []observedService, builtTs int64) context_sources.Result {
+	file := context_pack.File(context_pack.SourceAwsEcs)
+	withRepo := 0
+	for _, o := range observed {
+		if o.Repo != "" {
+			withRepo++
+		}
+	}
+	entry := context_pack.ManifestEntry{
+		Path:       file,
+		Source:     context_pack.SourceAwsEcs,
+		SourceKind: context_pack_enums.Discovered,
+		SyncedTs:   builtTs,
+		Confidence: context_pack_enums.ConfidenceHigh, // the services + images are directly observed; the repo join is qualified per-record by RecoveredBy
+		Summary: fmt.Sprintf("%d service(s) observed on cluster %s; %d repo-matched",
+			len(observed), nameFromArn(clusterArn), withRepo),
+	}
+	return context_sources.Result{
+		Scope:     context_pack.Scope{Level: context_pack_enums.Cluster, ID: clusterArn},
+		Artifacts: []context_pack.Artifact{{Name: file, Data: observed}},
+		Entries:   []context_pack.ManifestEntry{entry},
+	}
+}
+
+// recoverRepo best-effort maps a container image URI to the repo that produced it. First slice: the
+// image's repository name (last path segment, tag/digest/registry-host stripped), which by
+// convention usually matches the source repo — recorded with RecoveredBy "image-name" so
+// reconciliation treats it as a hint to confirm against the repo catalog rather than ground truth.
+// Higher-confidence recovery (the OCI org.opencontainers.image.source label, or tag-as-commit-SHA)
+// is a follow-up and will need ecr:* added to the AwsInfraContext bundle.
+func recoverRepo(image string) (repo string, recoveredBy string) {
+	name := imageRepoName(image)
+	if name == "" {
+		return "", ""
+	}
+	return name, "image-name"
+}
+
+// imageRepoName extracts the repository name from a container image URI — the last path segment with
+// any digest and tag removed:
+//
+//	123.dkr.ecr.us-east-1.amazonaws.com/team/billing-api:v3  -> billing-api
+//	ghcr.io/acme/web@sha256:abc...                           -> web
+//	billing-api:latest                                       -> billing-api
+func imageRepoName(image string) string {
+	ref := image
+	if i := strings.Index(ref, "@"); i >= 0 { // strip digest
+		ref = ref[:i]
+	}
+	path := ref
+	if slash := strings.LastIndex(ref, "/"); slash >= 0 { // last path segment (drops registry host)
+		path = ref[slash+1:]
+	}
+	if i := strings.LastIndex(path, ":"); i >= 0 { // a ":" in the last segment is a tag, not a port
+		path = path[:i]
+	}
+	return path
+}
+
+// nameFromArn returns the human-facing name from an ECS ARN — its last "/"-segment:
+//
+//	arn:aws:ecs:us-east-1:123456789:cluster/prod -> prod
+func nameFromArn(arn string) string {
+	if i := strings.LastIndex(arn, "/"); i >= 0 {
+		return arn[i+1:]
+	}
+	return arn
+}
+
+// chunk splits s into batches of at most n.
+func chunk(s []string, n int) [][]string {
+	var out [][]string
+	for i := 0; i < len(s); i += n {
+		end := i + n
+		if end > len(s) {
+			end = len(s)
+		}
+		out = append(out, s[i:end])
+	}
+	return out
+}

--- a/jobs/commands/context_sources/aws_ecs/aws_ecs_test.go
+++ b/jobs/commands/context_sources/aws_ecs/aws_ecs_test.go
@@ -1,0 +1,54 @@
+package aws_ecs
+
+import "testing"
+
+func TestImageRepoName(t *testing.T) {
+	cases := map[string]string{
+		"123.dkr.ecr.us-east-1.amazonaws.com/team/billing-api:v3": "billing-api",
+		"123.dkr.ecr.us-east-1.amazonaws.com/billing-api:latest":  "billing-api",
+		"ghcr.io/acme/web@sha256:abc123":                          "web",
+		"billing-api:latest":                                      "billing-api",
+		"billing-api":                                             "billing-api",
+		"nginx":                                                   "nginx",
+		"registry:5000/app:1.2.3":                                 "app", // port on host is not the last segment
+		"":                                                        "",
+	}
+	for in, want := range cases {
+		if got := imageRepoName(in); got != want {
+			t.Errorf("imageRepoName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestRecoverRepo(t *testing.T) {
+	repo, by := recoverRepo("123.dkr.ecr.us-east-1.amazonaws.com/billing-api:v3")
+	if repo != "billing-api" || by != "image-name" {
+		t.Errorf("recoverRepo = (%q, %q), want (billing-api, image-name)", repo, by)
+	}
+	if repo, by := recoverRepo(""); repo != "" || by != "" {
+		t.Errorf("recoverRepo(\"\") = (%q, %q), want empty", repo, by)
+	}
+}
+
+func TestNameFromArn(t *testing.T) {
+	cases := map[string]string{
+		"arn:aws:ecs:us-east-1:123456789:cluster/prod":         "prod",
+		"arn:aws:ecs:us-east-1:123456789:task-definition/web:7": "web:7", // last segment after the final slash
+		"prod": "prod",
+	}
+	for in, want := range cases {
+		if got := nameFromArn(in); got != want {
+			t.Errorf("nameFromArn(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestChunk(t *testing.T) {
+	got := chunk([]string{"a", "b", "c", "d", "e"}, 2)
+	if len(got) != 3 || len(got[0]) != 2 || len(got[2]) != 1 {
+		t.Fatalf("chunk into 2s = %v, want [[a b] [c d] [e]]", got)
+	}
+	if chunk(nil, 10) != nil {
+		t.Errorf("chunk(nil) should be nil")
+	}
+}

--- a/jobs/commands/context_sources/registry.go
+++ b/jobs/commands/context_sources/registry.go
@@ -29,8 +29,11 @@ type Result struct {
 type Source interface {
 	// Name is the connector identifier recorded in manifest entries (e.g. "repo-catalog").
 	Name() string
-	// Build runs the connector against the job parameters and returns its contribution.
-	Build(parameters map[string]interface{}, logsWriter io.Writer) (Result, error)
+	// Build runs the connector against the job parameters and returns its contributions — ONE Result
+	// per scope it observed. A connector commonly spans several scopes (the AWS source emits one
+	// Cluster-scoped Result per ECS cluster); a single-scope connector returns a one-element slice.
+	// Return a nil/empty slice for "ran cleanly, nothing to record". Metadata/structure only.
+	Build(parameters map[string]interface{}, logsWriter io.Writer) ([]Result, error)
 }
 
 var registry []Source

--- a/jobs/commands/context_sources/registry.go
+++ b/jobs/commands/context_sources/registry.go
@@ -7,6 +7,7 @@
 package context_sources
 
 import (
+	"context"
 	"io"
 
 	"github.com/deployment-io/deployment-runner-kit/context_pack"
@@ -33,7 +34,8 @@ type Source interface {
 	// per scope it observed. A connector commonly spans several scopes (the AWS source emits one
 	// Cluster-scoped Result per ECS cluster); a single-scope connector returns a one-element slice.
 	// Return a nil/empty slice for "ran cleanly, nothing to record". Metadata/structure only.
-	Build(parameters map[string]interface{}, logsWriter io.Writer) ([]Result, error)
+	// ctx carries the per-build wall-clock deadline — honor it on all I/O (BuildInfraContext bounds it).
+	Build(ctx context.Context, parameters map[string]interface{}, logsWriter io.Writer) ([]Result, error)
 }
 
 var registry []Source

--- a/jobs/commands/materialize_context.go
+++ b/jobs/commands/materialize_context.go
@@ -6,8 +6,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/deployment-io/deployment-runner-kit/context_pack"
-	"github.com/deployment-io/deployment-runner-kit/enums/context_pack_enums"
 	"github.com/deployment-io/deployment-runner-kit/enums/parameters_enums"
 	"github.com/deployment-io/deployment-runner-kit/jobs"
 	"github.com/deployment-io/deployment-runner/client"
@@ -33,10 +31,12 @@ func (m *MaterializeContext) Run(parameters map[string]interface{}, logsWriter i
 		return parameters, nil
 	}
 
-	// v1: org-wide context only (the repo catalog). The server owns the Org scope's id, so an
-	// empty/best-effort id here is fine. Environment/cluster scopes ride in with the infra source.
-	scopes := []context_pack.Scope{{Level: context_pack_enums.Org, ID: orgID}}
-	files, err := client.Get().MaterializeContext(orgID, scopes)
+	// Materialize the org's whole context. We send no explicit scopes: the server resolves them
+	// (the Org pack + every Cluster/Account pack the connectors built), because the runner can't
+	// enumerate the cluster scopes — the connectors discover them live, server-side. Each file
+	// arrives namespaced under its scope's path (context_pack.ScopePath), which the write loop below
+	// honors transparently via filepath.Join + MkdirAll.
+	files, err := client.Get().MaterializeContext(orgID, nil)
 	if err != nil {
 		io.WriteString(logsWriter, fmt.Sprintf("Context unavailable, continuing without it: %s\n", err))
 		return parameters, nil


### PR DESCRIPTION
The deployment-runner side of Explore/Context #8: the **observed** service↔repo connector, plus the runner-side materialize change to consume the per-cluster packs.

## AWS ECS context source (`context_sources/aws_ecs`)
Walks live ECS (`ListClusters → ListServices → DescribeServices → DescribeTaskDefinition → images`) and best-effort recovers the repo behind each image. Emits **one Cluster-scoped `Result` per cluster** (scope ID = the cluster **ARN**), source `aws-ecs`, Discovered — the live counterpart to the declared service-repo-map.
- **`Source.Build` now returns `[]Result`** (a connector spans many scopes — one per cluster). `build_infra_context` groups each into its scope's pack.
- **Self-provisions ECS read** (`AwsInfraContext` bundle) so a never-deployed, context-only runner works without a prior deployment; no-op once deployed.
- **Repo recovery = image-name hint** (`RecoveredBy: "image-name"`); OCI-label / tag-as-SHA recovery is a follow-up (adds `ecr:*`).
- **Graceful:** empty region/cluster records nothing; per-cluster + per-task-def failures logged and skipped. Entry confidence High (services + images directly observed); the join quality is per-record.
- Table tests for the recovery helpers.

## Whole-context materialize (`materialize_context.go`)
Stop hardcoding the Org scope — send no explicit scopes so the **server** resolves them (Org + every Cluster/Account pack), because the runner can't enumerate cluster scopes. Files arrive namespaced under their scope's path; the existing write-loop already handles subdirs (`filepath.Join` + `MkdirAll`), so no write-side change. Pairs with deployment-server#38.

## Dependencies
Depends on **drk#41** (`SourceAwsEcs`, `File()`, `AwsInfraContext`). Builds via `go.work`; bump the drk `go.mod` pin after #41 merges. Review-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)