### PR TITLE
aws_ecs: SourceKind.Observed (drk#43 rename)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.31.1
 	github.com/aws/aws-sdk-go-v2/service/sts v1.28.6
 	github.com/aws/smithy-go v1.22.2
-	github.com/deployment-io/deployment-runner-kit v0.0.0-20260628142533-4bc6e5b4f6b7
+	github.com/deployment-io/deployment-runner-kit v0.0.0-20260702034957-d8ffd52c0992
 	github.com/deployment-io/team-ai v0.0.0-20250917084912-bdbad6a834e1
 	github.com/docker/docker v27.3.0+incompatible
 	github.com/go-git/go-git/v5 v5.12.0

--- a/go.sum
+++ b/go.sum
@@ -151,8 +151,6 @@ github.com/cyphar/filepath-securejoin v0.2.5/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxG
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deployment-io/deployment-runner-kit v0.0.0-20260628142533-4bc6e5b4f6b7 h1:bdsMA/3QHjxMKZhbW+XkKONOKvNMRZyzKXqhPTgUqa0=
-github.com/deployment-io/deployment-runner-kit v0.0.0-20260628142533-4bc6e5b4f6b7/go.mod h1:OEoIfAAL2cUkK4Rf0rpW32YqHw7Mgx2aaC7o07IGAhQ=
 github.com/deployment-io/deployment-runner-kit v0.0.0-20260702034957-d8ffd52c0992 h1:h733ZCQF18bK85JZB6F3F755q/1OvdDvFCQFN9KBFZc=
 github.com/deployment-io/deployment-runner-kit v0.0.0-20260702034957-d8ffd52c0992/go.mod h1:OEoIfAAL2cUkK4Rf0rpW32YqHw7Mgx2aaC7o07IGAhQ=
 github.com/deployment-io/team-ai v0.0.0-20250917084912-bdbad6a834e1 h1:gfeNqym19IiO38sQ84WPMmZXrdDisu64qQP3Xs0N2RM=

--- a/go.sum
+++ b/go.sum
@@ -153,6 +153,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/deployment-io/deployment-runner-kit v0.0.0-20260628142533-4bc6e5b4f6b7 h1:bdsMA/3QHjxMKZhbW+XkKONOKvNMRZyzKXqhPTgUqa0=
 github.com/deployment-io/deployment-runner-kit v0.0.0-20260628142533-4bc6e5b4f6b7/go.mod h1:OEoIfAAL2cUkK4Rf0rpW32YqHw7Mgx2aaC7o07IGAhQ=
+github.com/deployment-io/deployment-runner-kit v0.0.0-20260702034957-d8ffd52c0992 h1:h733ZCQF18bK85JZB6F3F755q/1OvdDvFCQFN9KBFZc=
+github.com/deployment-io/deployment-runner-kit v0.0.0-20260702034957-d8ffd52c0992/go.mod h1:OEoIfAAL2cUkK4Rf0rpW32YqHw7Mgx2aaC7o07IGAhQ=
 github.com/deployment-io/team-ai v0.0.0-20250917084912-bdbad6a834e1 h1:gfeNqym19IiO38sQ84WPMmZXrdDisu64qQP3Xs0N2RM=
 github.com/deployment-io/team-ai v0.0.0-20250917084912-bdbad6a834e1/go.mod h1:B0fxmLJICi0qP2R2m3I2tR1uRIKQxn4ekK67lyBRHjw=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=

--- a/jobs/commands/context_sources/aws_ecs/aws_ecs.go
+++ b/jobs/commands/context_sources/aws_ecs/aws_ecs.go
@@ -5,7 +5,7 @@
 // app-server derives from each repo's deploy-config: same shape, different source of truth, so the
 // agent can reconcile "what's wired up" against "what's actually running".
 //
-// Source name "aws-ecs", SourceKind Discovered. Self-registers via init(); BuildInfraContext
+// Source name "aws-ecs", SourceKind Observed. Self-registers via init(); BuildInfraContext
 // blank-imports this package. Metadata/structure only — never secret values.
 package aws_ecs
 
@@ -246,7 +246,7 @@ func scopedResult(clusterArn string, observed []observedService, builtTs int64) 
 	entry := context_pack.ManifestEntry{
 		Path:       file,
 		Source:     context_pack.SourceAwsEcs,
-		SourceKind: context_pack_enums.Discovered,
+		SourceKind: context_pack_enums.Observed,
 		SyncedTs:   builtTs,
 		Confidence: context_pack_enums.ConfidenceHigh, // the services + images are directly observed; the repo join is qualified per-record by RecoveredBy
 		Summary: fmt.Sprintf("%d service(s) observed on cluster %s; %d repo-matched",


### PR DESCRIPTION
Follows drk#43 (`SourceKind.Discovered` → `Observed`). The `aws-ecs` source now stamps `Observed`. Same numeric value, so stored `context_packs` are unaffected — pure rename.

Depends on **drk#43**; builds via `go.work`, needs a drk bump to build standalone. Runner deploys last, as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)