### PR TITLE
aws-ecs: capture the ECS service ARN on observed services

### DIFF
--- a/jobs/commands/context_sources/aws_ecs/aws_ecs.go
+++ b/jobs/commands/context_sources/aws_ecs/aws_ecs.go
@@ -48,6 +48,11 @@ type observedService struct {
 	Repo        string `json:"repo,omitempty"`        // recovered repo (best-effort; see recoverRepo)
 	RecoveredBy string `json:"recoveredBy,omitempty"` // how Repo was derived, e.g. "image-name"
 	Cloud       string `json:"cloud"`                 // "aws"
+	// Arn is the ECS service ARN — the exact join key server-side reconciliation uses to RECOGNIZE a
+	// running service as one deployment.io already manages (match against Deployment.EcsServiceArn),
+	// so it enriches to the managed record instead of showing a rediscovered image-name row. Not a
+	// secret (a resource identifier), so it rides through the redaction backstop unchanged.
+	Arn string `json:"arn,omitempty"`
 }
 
 // Build self-provisions ECS read access, then emits one Cluster-scoped Result per ECS cluster in
@@ -188,6 +193,7 @@ func observeCluster(ctx context.Context, c *ecs.Client, clusterArn string, logsW
 					Repo:        repo,
 					RecoveredBy: by,
 					Cloud:       "aws",
+					Arn:         aws.ToString(svc.ServiceArn),
 				})
 			}
 		}


### PR DESCRIPTION
## What

Adds `Arn` (the ECS service ARN) to each `observedService` record emitted by the `aws-ecs` context source.

## Why

It's the exact join key server-side reconciliation will use to **recognize** a running service as one deployment.io already manages — matching the observed service against `Deployment.EcsServiceArn`. On a match, reconciliation enriches to the authoritative managed record (real name, repo, environment) instead of showing a rediscovered `es-<id>` image-name row, and **merges the Services table to one entry per service**.

This is **Phase A, step 1** of the build sequence in `PLAN_INFRA_ADOPTION.md` ("recognition, not adoption" — deployment.io-deployed services already have a `Deployment` record, so they're recognized, not adopted). The `managed-deployments` context source + the `managed` reconciliation layer that consume this ARN land in the app-server / kit follow-ups.

## Notes

- **Additive** — one optional field; existing consumers (reconciliation, dashboard) ignore it until the join ships.
- **Not a secret** — an ARN is a resource identifier, so it rides through the redaction backstop unchanged (`arn` matches none of the deny-list substrings). Correct by design.
- Branched from `origin/master`; `GOWORK=off` build + vet green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)