### PR TITLE
aws-ecs: drop scaled-to-zero services + skip our own runner infra clusters

### DIFF
--- a/jobs/commands/context_sources/aws_ecs/aws_ecs.go
+++ b/jobs/commands/context_sources/aws_ecs/aws_ecs.go
@@ -169,6 +169,13 @@ func observeCluster(ctx context.Context, c *ecs.Client, clusterArn string, logsW
 			if aws.ToString(svc.Status) != "ACTIVE" {
 				continue
 			}
+			// Scaled to zero — the service exists but serves nothing, so it isn't "running": drop it.
+			// BOTH must be zero: desired > 0 with running 0 is an OUTAGE (meant to run, isn't), which we
+			// deliberately keep visible. (A managed service scaled to zero still surfaces via the
+			// managed-deployments source, correctly reading "managed, not observed" rather than running.)
+			if svc.DesiredCount == 0 && svc.RunningCount == 0 {
+				continue
+			}
 			taskDef := aws.ToString(svc.TaskDefinition)
 			if taskDef == "" {
 				continue

--- a/jobs/commands/context_sources/aws_ecs/aws_ecs.go
+++ b/jobs/commands/context_sources/aws_ecs/aws_ecs.go
@@ -94,6 +94,16 @@ func (s *source) Build(ctx context.Context, parameters map[string]interface{}, l
 	builtTs := time.Now().Unix()
 	var results []context_sources.Result
 	for _, clusterArn := range clusterArns {
+		// Skip deployment.io's OWN runner infrastructure. The runner and its AWS controller run in a
+		// "dr-*" cluster (our deployment-runner naming convention — cf. dr-task-role / dr-policy in
+		// iam_policies), which is separate from user-deployment clusters ("ecs-<orgID>") and from
+		// foreign clusters. They're our platform, not a user service, so surfacing them as observed
+		// services is noise — and the runner appears in EVERY BYO account, not just dogfood. Skipping at
+		// the cluster level drops both the runner and the controller together.
+		if strings.HasPrefix(nameFromArn(clusterArn), "dr-") {
+			io.WriteString(logsWriter, fmt.Sprintf("aws-ecs: skipping deployment.io runner cluster %s\n", nameFromArn(clusterArn)))
+			continue
+		}
 		observed, err := observeCluster(ctx, ecsClient, clusterArn, logsWriter)
 		if err != nil {
 			// One cluster failing shouldn't sink the others — log + skip. The scope's last-good


### PR DESCRIPTION
Two observed-list cleanups in the ECS scan — both about making the observed layer mean "real, running services," not everything ECS returns.

## 1. Drop services scaled to zero

Skip a service with **both** `desiredCount == 0` **and** `runningCount == 0` — it exists but serves nothing.
- `desired = 0, running = 0` → parked → drop.
- `desired > 0, running = 0` → **outage** (meant to run, isn't) → **kept** (most important to surface).
- `running > 0` → kept.

A managed service scaled to zero still surfaces via the `managed-deployments` source, so it reads "managed, not observed" rather than falsely running.

## 2. Skip deployment.io's own runner infra clusters (`dr-*`)

The runner + its AWS controller run in a **`dr-*`** cluster (our deployment-runner naming convention — cf. `dr-task-role` / `dr-policy`), separate from user-deployment clusters (**`ecs-<orgID>`**) and foreign clusters. They're our platform, not user services — and the runner appears in **every BYO customer account**, not just the dogfood org. So `dr-…`, `dr-aws-controller-…` were showing up as "services." Cluster-level skip drops the runner + controller together.

**Approach note:** this is a heuristic on our own naming convention. `RunnerData` carries no cluster ARN and our infra isn't tagged in this repo (it's provisioned via install/CFN elsewhere), so the two cleaner signals — skip-self-cluster and tag-filter — weren't available without a change over there. Tagging our infra at provision time is the robust follow-up; `deployment-server` (dogfood-only control plane, `ecs-deployment-server` cluster) is intentionally *not* caught here since real customers don't run it.

`GOWORK=off` build + vet green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)