### PR TITLE
aws-ecs: write an empty layer for emptied clusters (clear stale observed data)

### DIFF
--- a/jobs/commands/context_sources/aws_ecs/aws_ecs.go
+++ b/jobs/commands/context_sources/aws_ecs/aws_ecs.go
@@ -111,12 +111,19 @@ func (s *source) Build(ctx context.Context, parameters map[string]interface{}, l
 			io.WriteString(logsWriter, fmt.Sprintf("aws-ecs: cluster %s failed (skipping): %v\n", nameFromArn(clusterArn), err))
 			continue
 		}
+		// Emit even when empty. aws-ecs is the SOLE writer of this cluster's observed layer, and
+		// merge-by-source only REPLACES a source that's present in the incoming pack — so a cluster that
+		// went from having services to none must still write an (empty) aws-ecs.json, or the previous
+		// scan's services linger forever (e.g. the last service scaled to zero + dropped, emptying the
+		// cluster). A scan *error* skips above (last-good stands); a confirmed-empty is authoritative and
+		// clears. Normalize an empty result (nil or empty) to a non-nil slice so the artifact serializes
+		// as [] (an empty layer), not null.
 		if len(observed) == 0 {
-			continue // empty cluster: nothing to record (no degraded/empty pack)
+			observed = []observedService{}
 		}
 		results = append(results, scopedResult(clusterArn, observed, builtTs))
 	}
-	io.WriteString(logsWriter, fmt.Sprintf("aws-ecs: observed %d cluster(s) with services\n", len(results)))
+	io.WriteString(logsWriter, fmt.Sprintf("aws-ecs: recorded %d cluster(s) (empty ones write an empty layer to clear stale data)\n", len(results)))
 	return results, nil
 }
 


### PR DESCRIPTION
## The bug

A cluster that went from having services to **none** kept its stale observed data forever. Two behaviors combined:

1. The scan **skipped empty clusters** (`if len(observed) == 0 { continue }` — "no degraded/empty pack").
2. Merge-by-source (`mergePack`) only **replaces a source that's present in the incoming pack**.

So when a cluster emptied, the scan emitted nothing for it → its scope was never in the `UpsertMany` → its old `aws-ecs.json` (still listing the gone services) was never overwritten.

**Repro (live):** a cluster's *last* service is set to `desired=0` → the scale-to-zero filter correctly drops it → the cluster is now empty → but the service **lingers in `services.json` across rebuilds**, because nothing clears that cluster's stale pack.

## The fix

Emit an **empty** `aws-ecs.json` for a cluster we scanned *successfully* but found empty, so merge-by-source replaces the stale layer with an empty one.

- A scan **error** still skips (last-good stands — `error != gap`); only a **confirmed-empty** clears.
- Force a non-nil slice so it serializes as `[]` (an empty layer), not `null`.

## Scope / remaining edge

This fixes an **emptied but still-existing** cluster (the reported case, and the common one). A **fully deleted** ECS cluster (gone from `ListClusters`, so never scanned) would still leave a stale scope — that needs a persist-side reconcile or a TTL on observed packs, noted as a separate, rarer follow-up.

Runner-only, no bumps. `GOWORK=off` build + vet green. Needs deploy + a context rebuild to clear existing stale data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)