### PR TITLE
agent tool channel (C0): runner MCP socket + per-task wiring

### DIFF
--- a/agent_mcp/ping.go
+++ b/agent_mcp/ping.go
@@ -1,0 +1,19 @@
+package agent_mcp
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// RegisterPing adds the C0 skeleton tool: a no-arg `ping` that returns "pong".
+// Its sole purpose is to validate the end-to-end transport — agent's MCP client
+// -> stdio bridge -> Unix socket -> runner -> back — before real tools land.
+func RegisterPing(s *Server) {
+	s.Register(Tool{
+		Name:        "ping",
+		Description: `Health check for the deployment.io runner tool channel. Returns "pong".`,
+		Handler: func(ctx context.Context, args json.RawMessage) (string, error) {
+			return "pong", nil
+		},
+	})
+}

--- a/agent_mcp/server.go
+++ b/agent_mcp/server.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"sync"
 )
 
 // defaultProtocolVersion is the MCP version advertised when the client doesn't
@@ -42,13 +41,16 @@ type Tool struct {
 	Handler     func(ctx context.Context, args json.RawMessage) (string, error)
 }
 
-// Server is a registry of tools served over a Unix socket. Construct with New,
-// register tools, then Serve. Safe for concurrent Register and serving.
+// Server is a registry of tools served over a Unix socket. Register all tools
+// BEFORE calling Serve/Listen: the serving goroutines read the registry without
+// synchronization, which is safe only because the go-statement that starts them
+// happens-after registration. Registration is NOT safe to interleave with
+// serving. If tools ever need to change at runtime, guard the maps with a mutex
+// and emit notifications/tools/list_changed.
 type Server struct {
 	name    string
 	version string
 
-	mu    sync.RWMutex
 	tools map[string]Tool
 	order []string // registration order, for a stable tools/list
 }
@@ -60,10 +62,8 @@ func New(name, version string) *Server {
 }
 
 // Register adds (or replaces, last-wins) a tool, preserving first-registration
-// order in tools/list.
+// order in tools/list. Call before Serve/Listen — see the Server doc.
 func (s *Server) Register(t Tool) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
 	if _, exists := s.tools[t.Name]; !exists {
 		s.order = append(s.order, t.Name)
 	}
@@ -213,8 +213,6 @@ func (s *Server) initializeResult(params json.RawMessage) map[string]interface{}
 }
 
 func (s *Server) toolsList() map[string]interface{} {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
 	tools := make([]map[string]interface{}, 0, len(s.order))
 	for _, name := range s.order {
 		t := s.tools[name]
@@ -239,9 +237,7 @@ func (s *Server) toolsCall(ctx context.Context, params json.RawMessage) (map[str
 	if err := json.Unmarshal(params, &p); err != nil {
 		return nil, &rpcError{Code: -32602, Message: "invalid params: " + err.Error()}
 	}
-	s.mu.RLock()
 	t, ok := s.tools[p.Name]
-	s.mu.RUnlock()
 	if !ok {
 		return nil, &rpcError{Code: -32602, Message: "unknown tool: " + p.Name}
 	}

--- a/agent_mcp/server.go
+++ b/agent_mcp/server.go
@@ -1,0 +1,260 @@
+// Package agent_mcp serves a minimal Model Context Protocol (MCP) endpoint over
+// a Unix socket so the coding agent running inside agentbox can invoke
+// runner-executed tools. The runner holds all credentials and performs the work;
+// the agent only speaks MCP over a bind-mounted socket (bridged to its stdio MCP
+// client). This is the C0 transport skeleton: a generic tool registry plus a
+// `ping` tool. Later capabilities (deploy_preview, verify_preview, and
+// eventually Fetched-context connectors) register as tools here.
+//
+// Framing matches MCP's stdio transport — newline-delimited JSON-RPC 2.0 — so a
+// trivial stdio<->socket byte bridge on the agentbox side is all that connects
+// the agent's (stdio-speaking) MCP client to this socket. The runner owns the
+// protocol; the bridge is a dumb pipe.
+package agent_mcp
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"sync"
+)
+
+// defaultProtocolVersion is the MCP version advertised when the client doesn't
+// request one. On initialize we echo the client's requested version (maximally
+// compatible) and fall back to this.
+const defaultProtocolVersion = "2024-11-05"
+
+// Tool is one capability the agent can invoke. Handler runs on the runner (with
+// the runner's credentials); args is the decoded `arguments` object from a
+// tools/call. The returned string is surfaced to the agent as text content; a
+// returned error becomes an MCP result with isError=true so the agent can read
+// the failure and react (rather than the call hard-failing).
+type Tool struct {
+	Name        string
+	Description string
+	// InputSchema is the JSON Schema for the tool's arguments (raw JSON). Nil is
+	// fine for a no-arg tool — an empty object schema is advertised.
+	InputSchema json.RawMessage
+	Handler     func(ctx context.Context, args json.RawMessage) (string, error)
+}
+
+// Server is a registry of tools served over a Unix socket. Construct with New,
+// register tools, then Serve. Safe for concurrent Register and serving.
+type Server struct {
+	name    string
+	version string
+
+	mu    sync.RWMutex
+	tools map[string]Tool
+	order []string // registration order, for a stable tools/list
+}
+
+// New returns a Server that identifies itself with name/version in the MCP
+// initialize handshake.
+func New(name, version string) *Server {
+	return &Server{name: name, version: version, tools: map[string]Tool{}}
+}
+
+// Register adds (or replaces, last-wins) a tool, preserving first-registration
+// order in tools/list.
+func (s *Server) Register(t Tool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, exists := s.tools[t.Name]; !exists {
+		s.order = append(s.order, t.Name)
+	}
+	s.tools[t.Name] = t
+}
+
+// Listen creates the Unix socket at socketPath (removing any stale file first)
+// and chmods it 0666 so the container's non-root agent user (UID 1000) can
+// connect through the bind mount — safe because the socket is task-scoped and
+// only reachable from inside that one task's container. Call Listen
+// synchronously before spawning the container (Docker turns a missing bind
+// source into a directory), then hand the listener to ServeListener.
+func (s *Server) Listen(socketPath string) (net.Listener, error) {
+	if err := os.RemoveAll(socketPath); err != nil {
+		return nil, fmt.Errorf("agent_mcp: clear stale socket %s: %w", socketPath, err)
+	}
+	ln, err := net.Listen("unix", socketPath)
+	if err != nil {
+		return nil, fmt.Errorf("agent_mcp: listen %s: %w", socketPath, err)
+	}
+	_ = os.Chmod(socketPath, 0o666)
+	return ln, nil
+}
+
+// ServeListener accepts and handles agent connections on ln until ctx is
+// cancelled (which closes ln). Blocks; run it in a goroutine.
+func (s *Server) ServeListener(ctx context.Context, ln net.Listener) error {
+	go func() {
+		<-ctx.Done()
+		_ = ln.Close()
+	}()
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			select {
+			case <-ctx.Done():
+				return nil // clean shutdown
+			default:
+				return fmt.Errorf("agent_mcp: accept: %w", err)
+			}
+		}
+		go s.handleConn(ctx, conn)
+	}
+}
+
+// Serve is Listen + ServeListener for callers that don't need the socket to
+// exist before a separate step (e.g. tests). Blocks; run it in a goroutine.
+func (s *Server) Serve(ctx context.Context, socketPath string) error {
+	ln, err := s.Listen(socketPath)
+	if err != nil {
+		return err
+	}
+	return s.ServeListener(ctx, ln)
+}
+
+// --- JSON-RPC 2.0 / MCP wire types ---
+
+type rpcRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"` // absent => notification
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+type rpcResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Result  interface{}     `json:"result,omitempty"`
+	Error   *rpcError       `json:"error,omitempty"`
+}
+
+func (s *Server) handleConn(ctx context.Context, conn net.Conn) {
+	defer conn.Close()
+	// MCP stdio framing is newline-delimited JSON. Raise the buffer so large
+	// args/results don't truncate a line.
+	sc := bufio.NewScanner(conn)
+	sc.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
+	enc := json.NewEncoder(conn) // Encode appends '\n' — keeps framing
+
+	for sc.Scan() {
+		if len(bytes.TrimSpace(sc.Bytes())) == 0 {
+			continue
+		}
+		var req rpcRequest
+		if err := json.Unmarshal(sc.Bytes(), &req); err != nil {
+			continue // can't recover an id from a malformed line; skip it
+		}
+		resp, isNotification := s.dispatch(ctx, req)
+		if isNotification {
+			continue
+		}
+		if err := enc.Encode(resp); err != nil {
+			return
+		}
+	}
+}
+
+func (s *Server) dispatch(ctx context.Context, req rpcRequest) (rpcResponse, bool) {
+	isNotification := len(req.ID) == 0
+	resp := rpcResponse{JSONRPC: "2.0", ID: req.ID}
+
+	switch req.Method {
+	case "initialize":
+		resp.Result = s.initializeResult(req.Params)
+	case "notifications/initialized", "notifications/cancelled":
+		return resp, true // fire-and-forget notifications
+	case "ping": // MCP protocol keepalive (distinct from the `ping` tool)
+		resp.Result = map[string]interface{}{}
+	case "tools/list":
+		resp.Result = s.toolsList()
+	case "tools/call":
+		result, rerr := s.toolsCall(ctx, req.Params)
+		if rerr != nil {
+			resp.Error = rerr
+		} else {
+			resp.Result = result
+		}
+	default:
+		if isNotification {
+			return resp, true // ignore unknown notifications
+		}
+		resp.Error = &rpcError{Code: -32601, Message: "method not found: " + req.Method}
+	}
+	return resp, isNotification
+}
+
+func (s *Server) initializeResult(params json.RawMessage) map[string]interface{} {
+	version := defaultProtocolVersion
+	if len(params) > 0 {
+		var p struct {
+			ProtocolVersion string `json:"protocolVersion"`
+		}
+		if json.Unmarshal(params, &p) == nil && p.ProtocolVersion != "" {
+			version = p.ProtocolVersion // echo the client's version
+		}
+	}
+	return map[string]interface{}{
+		"protocolVersion": version,
+		"capabilities":    map[string]interface{}{"tools": map[string]interface{}{}},
+		"serverInfo":      map[string]interface{}{"name": s.name, "version": s.version},
+	}
+}
+
+func (s *Server) toolsList() map[string]interface{} {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	tools := make([]map[string]interface{}, 0, len(s.order))
+	for _, name := range s.order {
+		t := s.tools[name]
+		schema := t.InputSchema
+		if len(schema) == 0 {
+			schema = json.RawMessage(`{"type":"object","properties":{}}`)
+		}
+		tools = append(tools, map[string]interface{}{
+			"name":        t.Name,
+			"description": t.Description,
+			"inputSchema": schema,
+		})
+	}
+	return map[string]interface{}{"tools": tools}
+}
+
+func (s *Server) toolsCall(ctx context.Context, params json.RawMessage) (map[string]interface{}, *rpcError) {
+	var p struct {
+		Name      string          `json:"name"`
+		Arguments json.RawMessage `json:"arguments"`
+	}
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, &rpcError{Code: -32602, Message: "invalid params: " + err.Error()}
+	}
+	s.mu.RLock()
+	t, ok := s.tools[p.Name]
+	s.mu.RUnlock()
+	if !ok {
+		return nil, &rpcError{Code: -32602, Message: "unknown tool: " + p.Name}
+	}
+	text, err := t.Handler(ctx, p.Arguments)
+	if err != nil {
+		// Surface tool failure as an MCP result (isError) so the agent reads the
+		// text and iterates, rather than the JSON-RPC call erroring out.
+		return map[string]interface{}{
+			"content": []map[string]interface{}{{"type": "text", "text": err.Error()}},
+			"isError": true,
+		}, nil
+	}
+	return map[string]interface{}{
+		"content": []map[string]interface{}{{"type": "text", "text": text}},
+	}, nil
+}

--- a/agent_mcp/server_test.go
+++ b/agent_mcp/server_test.go
@@ -1,0 +1,96 @@
+package agent_mcp
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"net"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestServerPingRoundTrip exercises the runner half of the C0 transport: it
+// serves on a real Unix socket and drives the MCP handshake + ping tool the way
+// the agentbox bridge (and Claude Code behind it) will — newline-delimited
+// JSON-RPC 2.0.
+func TestServerPingRoundTrip(t *testing.T) {
+	sock := filepath.Join(t.TempDir(), "mcp.sock")
+	s := New("deployment-io-runner", "test")
+	RegisterPing(s)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = s.Serve(ctx, sock) }()
+
+	var conn net.Conn
+	var err error
+	for i := 0; i < 100; i++ { // wait for the listener to bind
+		if conn, err = net.Dial("unix", sock); err == nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	r := bufio.NewReader(conn)
+
+	call := func(line string) map[string]any {
+		t.Helper()
+		if _, err := conn.Write([]byte(line + "\n")); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		respLine, err := r.ReadBytes('\n')
+		if err != nil {
+			t.Fatalf("read: %v", err)
+		}
+		var m map[string]any
+		if err := json.Unmarshal(respLine, &m); err != nil {
+			t.Fatalf("unmarshal %q: %v", respLine, err)
+		}
+		return m
+	}
+
+	// initialize echoes the client's protocol version.
+	init := call(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05"}}`)
+	res, _ := init["result"].(map[string]any)
+	if res == nil || res["protocolVersion"] != "2024-11-05" {
+		t.Fatalf("initialize result = %v", init)
+	}
+
+	// notifications/initialized is fire-and-forget (no response); send it and
+	// make sure the next request still gets answered on the same conn.
+	if _, err := conn.Write([]byte(`{"jsonrpc":"2.0","method":"notifications/initialized"}` + "\n")); err != nil {
+		t.Fatalf("write notification: %v", err)
+	}
+
+	// tools/list surfaces exactly the ping tool.
+	list := call(`{"jsonrpc":"2.0","id":2,"method":"tools/list"}`)
+	lr, _ := list["result"].(map[string]any)
+	tools, _ := lr["tools"].([]any)
+	if len(tools) != 1 {
+		t.Fatalf("tools/list = %v", list)
+	}
+	if first, _ := tools[0].(map[string]any); first["name"] != "ping" {
+		t.Fatalf("expected ping tool, got %v", first)
+	}
+
+	// tools/call ping -> pong.
+	callResp := call(`{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"ping","arguments":{}}}`)
+	cr, _ := callResp["result"].(map[string]any)
+	content, _ := cr["content"].([]any)
+	if len(content) != 1 {
+		t.Fatalf("tools/call result = %v", callResp)
+	}
+	if c0, _ := content[0].(map[string]any); c0["text"] != "pong" {
+		t.Fatalf("expected pong, got %v", callResp)
+	}
+
+	// unknown tool -> JSON-RPC error.
+	bad := call(`{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"nope","arguments":{}}}`)
+	if bad["error"] == nil {
+		t.Fatalf("expected error for unknown tool, got %v", bad)
+	}
+}

--- a/jobs/commands/run_agent_step.go
+++ b/jobs/commands/run_agent_step.go
@@ -17,6 +17,7 @@ import (
 	"github.com/deployment-io/deployment-runner-kit/enums/parameters_enums"
 	"github.com/deployment-io/deployment-runner-kit/jobs"
 	"github.com/deployment-io/deployment-runner-kit/types"
+	agentmcp "github.com/deployment-io/deployment-runner/agent_mcp"
 	commandUtils "github.com/deployment-io/deployment-runner/jobs/commands/utils"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/image"
@@ -93,6 +94,15 @@ const (
 	agentboxResultDirRel    = ".agentbox-output"
 	agentboxResultFile      = "result.json"
 	agentboxResultPathInCtr = agentboxWorkDirInContainer + "/" + agentboxResultDirRel + "/" + agentboxResultFile
+
+	// agentboxMCPSocketInContainer is where the per-task MCP tool socket is
+	// bind-mounted inside the agent container; agentbox reads its path from
+	// MCP_TOOL_RPC_SOCKET and bridges the agent's stdio MCP client to it. Tools
+	// execute on the runner side (agent_mcp), so credentials never enter the
+	// container. C0: a ping tool only.
+	agentboxMCPSocketInContainer = "/run/agentbox/tool-rpc.sock"
+	agentMCPSocketEnvVar         = "MCP_TOOL_RPC_SOCKET"
+	agentMCPServerVersion        = "0.1.0"
 
 	// agentboxCacheDirInContainer is the shared module-cache + toolchain
 	// shelf — a Docker volume mounted into both the vendor phase (which
@@ -227,11 +237,16 @@ func (rs *RunAgentStep) Run(parameters map[string]interface{}, logsWriter io.Wri
 	if err != nil {
 		return parameters, err
 	}
+	// Per-task MCP tool socket: the runner serves runner-executed tools on a
+	// host socket (sibling of the work dir, so it never lands in /work or a
+	// commit diff) bind-mounted into the agent container. C0 = ping only.
+	envVars = append(envVars, agentMCPSocketEnvVar+"="+agentboxMCPSocketInContainer)
 	result, err := rs.spawnAgentboxAndWait(agentboxSpawnSpec{
-		imageRef:    imageRef,
-		workDirHost: workDirHost,
-		cacheVolume: cacheVolume,
-		env:         envVars,
+		imageRef:      imageRef,
+		workDirHost:   workDirHost,
+		cacheVolume:   cacheVolume,
+		env:           envVars,
+		mcpSocketHost: agentMCPSocketHostPath(workDirHost),
 	}, logsWriter)
 	// User-stop path: agentbox SIGTERM-handled and wrote a partial
 	// /result.json (status="cancelled" with whatever progress it had).
@@ -443,6 +458,26 @@ func (rs *RunAgentStep) spawnAgentboxAndWait(spec agentboxSpawnSpec, logsWriter 
 		return agentResult{}, err
 	}
 	defer cli.Close()
+	// Bring the per-task MCP tool socket up BEFORE the container is created —
+	// Docker turns a missing bind source into a directory, so the socket file
+	// must already exist. Served on the runner side (agent_mcp) so credentials
+	// never enter the container; torn down on the way out (LIFO defer order runs
+	// this after the container is removed).
+	if spec.mcpSocketHost != "" {
+		mcpSrv := agentmcp.New("deployment-io-runner", agentMCPServerVersion)
+		agentmcp.RegisterPing(mcpSrv)
+		ln, lerr := mcpSrv.Listen(spec.mcpSocketHost)
+		if lerr != nil {
+			return agentResult{}, fmt.Errorf("error opening agent tool socket: %w", lerr)
+		}
+		mcpCtx, cancelMCP := context.WithCancel(dockerCtx)
+		defer func() {
+			cancelMCP()
+			_ = ln.Close()
+			_ = os.Remove(spec.mcpSocketHost)
+		}()
+		go func() { _ = mcpSrv.ServeListener(mcpCtx, ln) }()
+	}
 	containerID, err := createAgentboxContainer(dockerCtx, cli, spec)
 	if err != nil {
 		return agentResult{}, err
@@ -539,6 +574,13 @@ func createAgentboxContainer(ctx context.Context, cli *client.Client, spec agent
 			Type:   mount.TypeVolume,
 			Source: spec.cacheVolume,
 			Target: agentboxCacheDirInContainer,
+		})
+	}
+	if spec.mcpSocketHost != "" {
+		mounts = append(mounts, mount.Mount{
+			Type:   mount.TypeBind,
+			Source: spec.mcpSocketHost,
+			Target: agentboxMCPSocketInContainer,
 		})
 	}
 	hostCfg := &container.HostConfig{
@@ -872,6 +914,18 @@ type agentboxSpawnSpec struct {
 	cacheVolume string
 	cmd         []string
 	env         []string
+	// mcpSocketHost, set for the agent phase only, is the host path of the
+	// per-task MCP tool socket. The runner serves tools on it and bind-mounts
+	// it into the container at agentboxMCPSocketInContainer. Empty for the
+	// vendor phase (no agent, no tools).
+	mcpSocketHost string
+}
+
+// agentMCPSocketHostPath returns the host path for a task's MCP tool socket: a
+// sibling of the work dir (NOT inside it) so the socket never appears in /work
+// — keeping it out of the agent's file view and CommitAndPush's diff.
+func agentMCPSocketHostPath(workDirHost string) string {
+	return strings.TrimRight(workDirHost, "/") + "-agent-mcp.sock"
 }
 
 // spawnVendorAndWait runs the vendor container to completion, streaming its


### PR DESCRIPTION
**Phase C, step 0 (of C0–C5)** — the runner half of the agent tool channel: the socket the coding agent inside agentbox uses to invoke **runner-executed** tools. Later carries `deploy_preview`/`verify_preview` and, generically, any authenticated tool + runner-side Fetched-context connector. Pairs with agentbox PR (the stdio bridge).

### What's here
- **`agent_mcp/`** — a minimal MCP server (newline-delimited JSON-RPC 2.0) over a Unix socket, with a **generic tool registry** + a `ping` tool. Framing matches MCP's stdio transport, so the agentbox side is a dumb byte bridge.
- **`run_agent_step.go`** — per-task socket: created **before** container-create (Docker turns a missing bind source into a directory), served runner-side, bind-mounted into the agent container at `/run/agentbox/tool-rpc.sock`, `MCP_TOOL_RPC_SOCKET` exported, torn down after the container exits (LIFO-safe).

### Security
Credentials never enter the container — the agent only speaks MCP over the socket; the runner executes. Socket is task-scoped (a sibling of the work dir, not inside `/work`, so it never appears in the agent's view or a commit diff), chmod 0666, reachable only from that task's container.

### Verification
- `GOWORK=off go build ./...` + `go vet` green.
- `agent_mcp` socket round-trip test: `initialize` → `tools/list` → `tools/call ping` → `pong` + unknown-tool error path.
- **Remaining (deploy-time):** the real-Claude-Code E2E spike — build the agentbox image + run a task and confirm the agent discovers + calls `ping` over the bridge. That's the C0 spike's final validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)