### PR TITLE
preview: verify_preview MCP tool (C3) + fabrication guardrail

### DIFF
--- a/agenttools/deploy_preview.go
+++ b/agenttools/deploy_preview.go
@@ -103,8 +103,10 @@ func RegisterDeployPreview(s *agentmcp.Server, deps DeployPreviewDeps) {
 	s.Register(agentmcp.Tool{
 		Name: "deploy_preview",
 		Description: "Deploy the built static site to a live preview URL on the project's cloud and return the URL. " +
-			"Call this AFTER the site is built — publish_dir (relative to /work) must contain index.html. " +
-			"Set is_spa=true for single-page apps with client-side routing. Re-call to redeploy after changes; the same preview URL is reused.",
+			"Call this AFTER a successful build — publish_dir (relative to /work) must be the output of your REAL build " +
+			"command and contain index.html. NEVER hand-create files to deploy; if the build fails, report that instead " +
+			"of deploying a placeholder. Set is_spa=true for single-page apps with client-side routing. Re-call to " +
+			"redeploy after changes (the same preview URL is reused), then use verify_preview to confirm it's live.",
 		InputSchema: json.RawMessage(deployPreviewInputSchema),
 		Handler: func(ctx context.Context, args json.RawMessage) (string, error) {
 			return handleDeployPreview(ctx, deps, &mu, cache, args)

--- a/agenttools/verify_preview.go
+++ b/agenttools/verify_preview.go
@@ -137,6 +137,12 @@ func isAllowedPreviewURL(raw string) bool {
 // holds it) or maxWait elapses. Host-agnostic — the handler applies the SSRF
 // allowlist before calling this.
 func pollURL(ctx context.Context, target, contains string, maxWait, interval time.Duration, logsWriter io.Writer) verifyPreviewResult {
+	// Floor the interval. The guaranteed sleep between attempts is what caps the
+	// attempt count (together with the maxWait deadline); a non-positive interval
+	// would turn the loop into a tight spin, so never allow that regardless of caller.
+	if interval <= 0 {
+		interval = verifyPreviewPollInterval
+	}
 	ctx, cancel := context.WithTimeout(ctx, maxWait)
 	defer cancel()
 	client := &http.Client{Timeout: verifyPreviewPerRequestTO}

--- a/agenttools/verify_preview.go
+++ b/agenttools/verify_preview.go
@@ -1,0 +1,225 @@
+package agenttools
+
+// verify_preview.go implements the agent-invoked `verify_preview` MCP tool: after
+// deploying a preview, the agent calls this to confirm the URL is actually live and
+// serving. It runs on the RUNNER, not the agent — the agentbox proxy allowlist
+// blocks arbitrary outbound hosts, so the agent can't reach the CloudFront URL
+// itself; the runner (open network) polls it and returns the result.
+//
+// SECURITY: the runner fetches an agent-supplied URL, which is an SSRF vector — a
+// prompt-injected agent could ask it to fetch cloud-metadata (169.254.169.254) or
+// an internal host and exfiltrate the response through the tool result. So
+// verify_preview ONLY fetches hosts under *.cloudfront.net (every preview is a
+// CloudFront distribution). That allowlist is the whole SSRF defense; widen it
+// deliberately when custom preview domains land (Cw).
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	agentmcp "github.com/deployment-io/deployment-runner/agent_mcp"
+)
+
+const (
+	verifyPreviewDefaultMaxWait = 120 * time.Second
+	verifyPreviewMaxWaitCap     = 240 * time.Second
+	verifyPreviewPollInterval   = 5 * time.Second
+	verifyPreviewPerRequestTO   = 10 * time.Second
+	verifyPreviewSnippetRunes   = 500
+	verifyPreviewReadLimitBytes = 64 * 1024
+)
+
+const verifyPreviewInputSchema = `{
+  "type": "object",
+  "properties": {
+    "url": {
+      "type": "string",
+      "description": "The preview URL returned by deploy_preview (an https://*.cloudfront.net URL). Only CloudFront preview hosts are accepted."
+    },
+    "contains": {
+      "type": "string",
+      "description": "Optional substring to require in the served response body. NOTE: an SPA's body is the HTML shell, so client-rendered text will NOT be present — use this for shell/asset markers (e.g. the <title>), not rendered UI."
+    },
+    "max_wait_seconds": {
+      "type": "integer",
+      "description": "How long to poll for the URL to go live before giving up (default 120, max 240). A first-time distribution may still be propagating."
+    }
+  },
+  "required": ["url"]
+}`
+
+// verifyPreviewResult is the JSON the agent receives.
+type verifyPreviewResult struct {
+	Live           bool   `json:"live"`
+	StatusCode     int    `json:"status_code"`
+	Attempts       int    `json:"attempts"`
+	ElapsedSeconds int    `json:"elapsed_seconds"`
+	Matched        *bool  `json:"matched,omitempty"` // set only when `contains` was requested
+	BodySnippet    string `json:"body_snippet,omitempty"`
+	Message        string `json:"message,omitempty"`
+}
+
+// RegisterVerifyPreview registers the verify_preview tool. logsWriter is the Step
+// Job's log writer; poll progress streams there.
+func RegisterVerifyPreview(s *agentmcp.Server, logsWriter io.Writer) {
+	s.Register(agentmcp.Tool{
+		Name: "verify_preview",
+		Description: "Confirm a deployed preview URL is live and serving. Polls it until it returns HTTP 200 " +
+			"(a first-time distribution may take a few minutes to propagate — call again if it times out). Runs on the " +
+			"runner, so it works even though your sandbox can't reach the URL directly. Only *.cloudfront.net preview " +
+			"URLs are accepted. For an SPA the response is the HTML shell, so client-rendered text won't appear in the " +
+			"body — check the built bundle for that.",
+		InputSchema: json.RawMessage(verifyPreviewInputSchema),
+		Handler: func(ctx context.Context, args json.RawMessage) (string, error) {
+			return handleVerifyPreview(ctx, logsWriter, args)
+		},
+	})
+}
+
+func handleVerifyPreview(ctx context.Context, logsWriter io.Writer, rawArgs json.RawMessage) (string, error) {
+	var args struct {
+		URL            string `json:"url"`
+		Contains       string `json:"contains"`
+		MaxWaitSeconds int    `json:"max_wait_seconds"`
+	}
+	if len(rawArgs) > 0 {
+		if err := json.Unmarshal(rawArgs, &args); err != nil {
+			return "", fmt.Errorf("invalid arguments: %w", err)
+		}
+	}
+	target := strings.TrimSpace(args.URL)
+	if target == "" {
+		return "", fmt.Errorf("url is required")
+	}
+	if !isAllowedPreviewURL(target) {
+		return "", fmt.Errorf("url must be an https://*.cloudfront.net preview URL (got %q) — verify_preview only fetches CloudFront preview hosts", target)
+	}
+
+	maxWait := verifyPreviewDefaultMaxWait
+	if args.MaxWaitSeconds > 0 {
+		maxWait = time.Duration(args.MaxWaitSeconds) * time.Second
+		if maxWait > verifyPreviewMaxWaitCap {
+			maxWait = verifyPreviewMaxWaitCap
+		}
+	}
+
+	res := pollURL(ctx, target, args.Contains, maxWait, verifyPreviewPollInterval, logsWriter)
+	b, err := json.Marshal(res)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// isAllowedPreviewURL is the SSRF guard: only https URLs whose host is under
+// *.cloudfront.net. Blocks cloud-metadata IPs, localhost, internal hosts, and
+// lookalike domains (evil.cloudfront.net.attacker.com ends in .attacker.com, and
+// bare cloudfront.net has no leading dot).
+func isAllowedPreviewURL(raw string) bool {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return false
+	}
+	if u.Scheme != "https" {
+		return false
+	}
+	host := strings.ToLower(u.Hostname())
+	return strings.HasSuffix(host, ".cloudfront.net")
+}
+
+// pollURL GETs target until it returns 200 (and, when contains != "", the body
+// holds it) or maxWait elapses. Host-agnostic — the handler applies the SSRF
+// allowlist before calling this.
+func pollURL(ctx context.Context, target, contains string, maxWait, interval time.Duration, logsWriter io.Writer) verifyPreviewResult {
+	ctx, cancel := context.WithTimeout(ctx, maxWait)
+	defer cancel()
+	client := &http.Client{Timeout: verifyPreviewPerRequestTO}
+	start := time.Now()
+	wantContains := contains != ""
+
+	attempts := 0
+	var lastStatus int
+	var lastSnippet string
+	for {
+		attempts++
+		status, body, _ := fetchOnce(ctx, client, target)
+		matched := !wantContains || strings.Contains(body, contains)
+		// Record only a real HTTP response — a network error (status 0), e.g. the
+		// final fetch racing the deadline, must not clobber the last observed status.
+		if status != 0 {
+			lastStatus = status
+			lastSnippet = snippet(body, verifyPreviewSnippetRunes)
+		}
+		if status == http.StatusOK && matched {
+			res := verifyPreviewResult{
+				Live:           true,
+				StatusCode:     status,
+				Attempts:       attempts,
+				ElapsedSeconds: int(time.Since(start).Seconds()),
+				BodySnippet:    lastSnippet,
+				Message:        "preview is live",
+			}
+			if wantContains {
+				t := true
+				res.Matched = &t
+			}
+			return res
+		}
+		if logsWriter != nil {
+			io.WriteString(logsWriter, fmt.Sprintf("verify_preview: attempt %d — status=%d, not live yet, retrying...\n", attempts, status))
+		}
+		select {
+		case <-ctx.Done():
+			msg := "timed out waiting for the preview to go live"
+			if wantContains && lastStatus == http.StatusOK {
+				msg = "preview responded 200 but the body did not contain the expected string (an SPA's body is the shell — client-rendered text won't be here)"
+			}
+			res := verifyPreviewResult{
+				Live:           false,
+				StatusCode:     lastStatus,
+				Attempts:       attempts,
+				ElapsedSeconds: int(time.Since(start).Seconds()),
+				BodySnippet:    lastSnippet,
+				Message:        msg,
+			}
+			if wantContains {
+				f := false
+				res.Matched = &f
+			}
+			return res
+		case <-time.After(interval):
+		}
+	}
+}
+
+func fetchOnce(ctx context.Context, client *http.Client, target string) (int, string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
+	if err != nil {
+		return 0, "", err
+	}
+	req.Header.Set("User-Agent", "deployment-io-verify/1.0")
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, "", err
+	}
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(io.LimitReader(resp.Body, verifyPreviewReadLimitBytes))
+	return resp.StatusCode, string(b), nil
+}
+
+// snippet returns the first maxRunes runes of s (trimmed), rune-safe, with an
+// ellipsis when truncated.
+func snippet(s string, maxRunes int) string {
+	s = strings.TrimSpace(s)
+	r := []rune(s)
+	if len(r) <= maxRunes {
+		return s
+	}
+	return string(r[:maxRunes]) + "…"
+}

--- a/agenttools/verify_preview_test.go
+++ b/agenttools/verify_preview_test.go
@@ -100,3 +100,20 @@ func TestPollURL_Contains(t *testing.T) {
 		t.Fatalf("expected matched=false, got %+v", res2)
 	}
 }
+
+func TestPollURL_ZeroIntervalDoesNotSpin(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	// interval 0 must be floored, not turned into a tight spin. With the floor the
+	// loop makes only a handful of attempts before maxWait expires.
+	res := pollURL(context.Background(), srv.URL, "", 100*time.Millisecond, 0, nil)
+	if res.Live {
+		t.Fatalf("expected not live, got %+v", res)
+	}
+	if res.Attempts > 20 {
+		t.Fatalf("interval=0 spun: %d attempts (expected it to be floored)", res.Attempts)
+	}
+}

--- a/agenttools/verify_preview_test.go
+++ b/agenttools/verify_preview_test.go
@@ -1,0 +1,102 @@
+package agenttools
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestIsAllowedPreviewURL locks down the SSRF guard: only https *.cloudfront.net.
+func TestIsAllowedPreviewURL(t *testing.T) {
+	allowed := []string{
+		"https://d1cocjwyiwd0na.cloudfront.net/",
+		"https://d1cocjwyiwd0na.cloudfront.net/signin",
+		"https://ABC123.cloudfront.net", // hostname is lowercased before the check
+	}
+	blocked := []string{
+		"http://d1.cloudfront.net/",                 // not https
+		"https://169.254.169.254/latest/meta-data/", // cloud metadata
+		"https://localhost:8080/",                   // localhost
+		"https://10.0.0.5/",                         // internal IP
+		"https://evil.cloudfront.net.attacker.com/", // lookalike suffix
+		"https://cloudfront.net/",                   // no subdomain (no leading dot)
+		"https://example.com/",                      // arbitrary host
+		"ftp://x.cloudfront.net/",                   // wrong scheme
+		"not a url",
+	}
+	for _, u := range allowed {
+		if !isAllowedPreviewURL(u) {
+			t.Errorf("expected allowed: %s", u)
+		}
+	}
+	for _, u := range blocked {
+		if isAllowedPreviewURL(u) {
+			t.Errorf("expected BLOCKED: %s", u)
+		}
+	}
+}
+
+func TestPollURL_BecomesLive(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if atomic.AddInt32(&calls, 1) < 3 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		io.WriteString(w, "<html><title>ok</title></html>")
+	}))
+	defer srv.Close()
+
+	res := pollURL(context.Background(), srv.URL, "", 10*time.Second, 5*time.Millisecond, nil)
+	if !res.Live {
+		t.Fatalf("expected live, got %+v", res)
+	}
+	if res.Attempts < 3 {
+		t.Fatalf("expected >=3 attempts, got %d", res.Attempts)
+	}
+	if res.StatusCode != 200 {
+		t.Fatalf("expected status 200, got %d", res.StatusCode)
+	}
+}
+
+func TestPollURL_Timeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	res := pollURL(context.Background(), srv.URL, "", 60*time.Millisecond, 5*time.Millisecond, nil)
+	if res.Live {
+		t.Fatalf("expected not live, got %+v", res)
+	}
+	if res.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("expected last status 503, got %d", res.StatusCode)
+	}
+}
+
+func TestPollURL_Contains(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		io.WriteString(w, "<title>Deployment.io - Dashboard</title>")
+	}))
+	defer srv.Close()
+
+	// present → live + matched
+	res := pollURL(context.Background(), srv.URL, "Deployment.io", 2*time.Second, 5*time.Millisecond, nil)
+	if !res.Live || res.Matched == nil || !*res.Matched {
+		t.Fatalf("expected live+matched, got %+v", res)
+	}
+	// absent → 200 but no match → not live, matched=false
+	res2 := pollURL(context.Background(), srv.URL, "NOPE", 60*time.Millisecond, 5*time.Millisecond, nil)
+	if res2.Live {
+		t.Fatalf("expected not live for missing substring, got %+v", res2)
+	}
+	if res2.Matched == nil || *res2.Matched {
+		t.Fatalf("expected matched=false, got %+v", res2)
+	}
+}

--- a/jobs/commands/run_agent_step.go
+++ b/jobs/commands/run_agent_step.go
@@ -480,6 +480,7 @@ func (rs *RunAgentStep) spawnAgentboxAndWait(spec agentboxSpawnSpec, logsWriter 
 		agentmcp.RegisterPing(mcpSrv)
 		if spec.previewDeps != nil {
 			agenttools.RegisterDeployPreview(mcpSrv, *spec.previewDeps)
+			agenttools.RegisterVerifyPreview(mcpSrv, spec.previewDeps.LogsWriter)
 		}
 		ln, lerr := mcpSrv.Listen(spec.mcpSocketHost)
 		if lerr != nil {


### PR DESCRIPTION
## C3 — verify_preview + fabrication guardrail
Completes the *verify* half of the deploy → verify → iterate loop.

### verify_preview (runner-side)
The agent calls it after deploying to confirm the preview is live. Polls the URL until HTTP 200 (a first-time distribution may still be propagating — call again on timeout), optionally asserts a body substring, returns `{live, status_code, attempts, elapsed_seconds, body_snippet, matched?}`.

**Why runner-side:** the agentbox proxy allowlist blocks the agent from reaching the CloudFront URL itself, so the runner (open network) polls it — same pattern as `deploy_preview`.

**SSRF guard:** the runner fetching an agent-supplied URL is an SSRF vector (a prompt-injected agent could point it at `169.254.169.254`). So verify_preview only fetches `https://*.cloudfront.net` — every preview is a CloudFront distribution. Blocks metadata IPs, localhost, internal hosts, and lookalike domains (`evil.cloudfront.net.attacker.com`). Widen deliberately when custom preview domains land (Cw).

### Iterate loop
Agent-driven — with verify_preview + `deploy_preview`'s in-memory distribution reuse (C2), the agent can deploy → verify → fix → redeploy in one run. No extra runner code.

### Fabrication guardrail
`deploy_preview`'s description now forbids hand-rolling a preview and points at verify_preview. The C2 E2E showed a codex agent, blocked by an OOM build, deploying a fabricated `index.html`. This is the *behavioral* half; a structural "deploy only a verified build" gate is a follow-up.

### SPA caveat
An SPA's body is the HTML shell, so `contains` matches shell/asset markers (e.g. the `<title>`), not client-rendered UI. Rendered-UI verification needs a headless browser — deferred to a later tier.

Unit tests cover the SSRF allowlist + the poll (becomes-live / timeout / contains). Requires a runner redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)