### PR TITLE
preview: web-service preview deploy core — ECS half (Cw1a)

### DIFF
--- a/agenttools/deploy_web_service_preview.go
+++ b/agenttools/deploy_web_service_preview.go
@@ -1,0 +1,420 @@
+package agenttools
+
+// deploy_web_service_preview.go is the arg-based, self-contained web-service preview
+// deploy core — the twin of deploy_static.go's DeployStaticSitePreview. Where the
+// static preview stands up S3 + CloudFront, a web-service preview builds/pushes a
+// container image, runs it as a Fargate service behind a target group, and (Cw1b)
+// fronts it with a shared ALB + a per-preview CloudFront distribution.
+//
+// Like the static core it is invoked in-process by the (future, Cw2)
+// deploy_web_service_preview MCP tool handler and is deliberately NOT the
+// production DeployAwsWebService command (a 1348-line monolith welded to the job
+// `parameters` map with a per-service ALB). It references that monolith's SDK
+// calls but is written fresh so the preview can use a shared, cost-optimized
+// ingress. The AWS primitives live in the leaf utils/aws_utils package.
+//
+// Cw1a (this slice) covers the ECS half: image build+push, cluster, execution
+// role, VPC/subnets, task security group, task definition, target group, and the
+// Fargate service. Cw1b appends the ingress half (shared ALB + header-routed
+// listener rule + CloudFront) and populates the URL.
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/cloudfront"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ecr"
+	"github.com/aws/aws-sdk-go-v2/service/ecs"
+	ecsTypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
+	elb "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/deployment-io/deployment-runner/utils/aws_utils"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/image"
+	"github.com/moby/moby/client"
+	"github.com/moby/moby/pkg/archive"
+)
+
+// Fargate defaults for a preview: the smallest valid CPU/memory combo (0.25 vCPU
+// / 0.5 GB) — cheapest for a short-lived, low-traffic preview.
+const (
+	defaultPreviewCPU    = "256"
+	defaultPreviewMemory = "512"
+)
+
+// WebServicePreviewDeployInput is the request for DeployWebServicePreview.
+type WebServicePreviewDeployInput struct {
+	OrgID     string // organization id (resource naming)
+	PreviewID string // the ephemeral preview Deployment's id (per-preview resource naming)
+	Region    string // AWS region string, e.g. "us-east-1" (log config)
+
+	// --- Image build (runner-side; the agent built the source into /work) ---
+	BuildContextDir string            // host path to the build context (the repo dir with the Dockerfile)
+	DockerfilePath  string            // Dockerfile path relative to the context; default "Dockerfile"
+	ImageTag        string            // image tag; default a unix-timestamp tag (unique per redeploy)
+	BuildArgs       map[string]string // docker build args
+
+	// --- Runtime ---
+	Port            int32             // container port the service listens on
+	HealthCheckPath string            // target-group health check path; default "/"
+	Cpu             string            // Fargate CPU units; default "256"
+	Memory          string            // Fargate memory MiB; default "512"
+	EnvVars         map[string]string // runtime env, already resolved by the runner (agent-blind)
+	CpuArchitecture ecsTypes.CPUArchitecture
+	OSFamily        ecsTypes.OSFamily
+
+	// --- Networking (optional; discover the default VPC when VpcID is empty) ---
+	VpcID     string
+	SubnetIDs []string
+
+	// --- Reuse across iterations (empty on the first deploy of a task) ---
+	ExistingClusterArn       string
+	ExistingExecutionRoleArn string
+	ExistingTargetGroupArn   string
+	ExistingEcsServiceArn    string
+
+	// --- Clients (built by the caller from the runner's IAM role + region) ---
+	EcrClient        *ecr.Client
+	EcsClient        *ecs.Client
+	Ec2Client        *ec2.Client
+	ElbClient        *elb.Client
+	IamClient        *iam.Client
+	CloudfrontClient *cloudfront.Client // used by the Cw1b ingress half
+
+	// SkipServiceStableWait leaves the ECS service create/update without blocking
+	// on the stable waiter. Cw1a sets this (the target group can't go healthy
+	// before an ALB health-checks it); Cw1b clears it once the listener rule
+	// attaches the target group to the shared ALB.
+	SkipServiceStableWait bool
+}
+
+// WebServicePreviewDeployResult carries every resource the deploy created or
+// reused, so the (Cw2) tool can persist it via SavePreview for the next
+// iteration. Field names mirror the union deployments.UpdateDeploymentDtoV1 so
+// the mapping in the commands layer is one-to-one.
+type WebServicePreviewDeployResult struct {
+	EcrRepositoryUri  string
+	ImageUri          string // ECR URI including the pushed tag
+	ClusterArn        string
+	ExecutionRoleArn  string
+	TaskDefinitionArn string
+	TargetGroupArn    string
+	EcsServiceArn     string
+	Port              int32
+	VpcID             string
+	TaskRunning       bool // Cw1a signal: at least one task reached RUNNING
+
+	// --- Ingress half (populated by Cw1b) ---
+	LoadBalancerArn           string
+	LoadBalancerDns           string
+	ListenerArn               string
+	ListenerRuleArn           string
+	CloudFrontDistributionID  string
+	CloudFrontDistributionArn string
+	CloudFrontDomainName      string
+	URL                       string
+}
+
+// DeployWebServicePreview builds + pushes the agent's container image and runs it
+// as an ephemeral Fargate service wired to a target group, on the shared
+// per-org ECS cluster. It is idempotent across a task's iterations: reused
+// resource ids are passed back via the Existing* fields and a redeploy registers
+// a fresh task-definition revision + updates the service.
+//
+// Cw1a scope: this returns after the ECS service is created/updated and (best
+// effort) a task reaches RUNNING. The shared ALB + listener rule + CloudFront
+// that make the service publicly reachable — and populate the URL — arrive in
+// Cw1b.
+func DeployWebServicePreview(in WebServicePreviewDeployInput, logsWriter io.Writer) (WebServicePreviewDeployResult, error) {
+	// Defaults.
+	dockerfile := in.DockerfilePath
+	if dockerfile == "" {
+		dockerfile = "Dockerfile"
+	}
+	imageTag := in.ImageTag
+	if imageTag == "" {
+		imageTag = fmt.Sprintf("%d", time.Now().Unix())
+	}
+	cpu := in.Cpu
+	if cpu == "" {
+		cpu = defaultPreviewCPU
+	}
+	memory := in.Memory
+	if memory == "" {
+		memory = defaultPreviewMemory
+	}
+
+	if in.Port <= 0 {
+		return WebServicePreviewDeployResult{}, fmt.Errorf("port is required for a web-service preview")
+	}
+	if _, err := os.Stat(filepath.Join(in.BuildContextDir, dockerfile)); err != nil {
+		return WebServicePreviewDeployResult{}, fmt.Errorf("no %s in build context %s: %w", dockerfile, in.BuildContextDir, err)
+	}
+
+	res := WebServicePreviewDeployResult{Port: in.Port}
+
+	// 1. Build + push the image to a per-preview ECR repo.
+	repoURI, err := aws_utils.EnsureEcrRepository(in.EcrClient, ecrRepositoryName(in.OrgID, in.PreviewID), logsWriter)
+	if err != nil {
+		return res, fmt.Errorf("ensure ECR repository: %w", err)
+	}
+	res.EcrRepositoryUri = repoURI
+	imageURI := repoURI + ":" + imageTag
+	localTag := localImageName(in.OrgID, in.PreviewID, imageTag)
+	if err := buildAndPushImage(in.EcrClient, in.BuildContextDir, dockerfile, localTag, imageURI, in.BuildArgs, logsWriter); err != nil {
+		return res, fmt.Errorf("build and push image: %w", err)
+	}
+	res.ImageUri = imageURI
+
+	// 2. Shared per-org Fargate cluster.
+	clusterArn := in.ExistingClusterArn
+	if clusterArn == "" {
+		clusterArn, err = aws_utils.EnsureEcsCluster(in.EcsClient, clusterName(in.OrgID))
+		if err != nil {
+			return res, fmt.Errorf("ensure ECS cluster: %w", err)
+		}
+	}
+	res.ClusterArn = clusterArn
+
+	// 3. Task execution role (ECR pull + CloudWatch logs).
+	executionRoleArn := in.ExistingExecutionRoleArn
+	if executionRoleArn == "" {
+		executionRoleArn, err = aws_utils.EnsureEcsTaskExecutionRole(in.IamClient, executionRoleName(in.OrgID))
+		if err != nil {
+			return res, fmt.Errorf("ensure task execution role: %w", err)
+		}
+	}
+	res.ExecutionRoleArn = executionRoleArn
+
+	// 4. Resolve the VPC + public subnets the task and (Cw1b) ALB live in.
+	var network aws_utils.VpcNetwork
+	if in.VpcID != "" {
+		network, err = aws_utils.DescribeVpcNetwork(in.Ec2Client, in.VpcID)
+	} else {
+		network, err = aws_utils.DiscoverDefaultVpcNetwork(in.Ec2Client)
+	}
+	if err != nil {
+		return res, fmt.Errorf("resolve VPC network: %w", err)
+	}
+	if len(in.SubnetIDs) > 0 {
+		network.SubnetIDs = in.SubnetIDs
+	}
+	res.VpcID = network.VpcID
+
+	// 5. Shared per-org task security group: reachable from within the VPC (the
+	// ALB fronts it) on all TCP; default egress-all lets it pull ECR / reach out.
+	taskSgID, err := aws_utils.EnsureSecurityGroup(in.Ec2Client, taskSecurityGroupName(in.OrgID),
+		"deployment.io preview task security group", network.VpcID)
+	if err != nil {
+		return res, fmt.Errorf("ensure task security group: %w", err)
+	}
+	if err := aws_utils.AuthorizeTCPIngressFromCIDR(in.Ec2Client, taskSgID, network.VpcCidr, 0, 65535); err != nil {
+		return res, fmt.Errorf("authorize task security group ingress: %w", err)
+	}
+
+	// 6. Task definition (new revision each deploy so a redeploy re-pulls).
+	taskDefArn, err := aws_utils.RegisterWebServiceTaskDefinition(in.EcsClient, aws_utils.TaskDefinitionInput{
+		Family:           taskDefinitionFamily(in.PreviewID),
+		ContainerName:    containerName(in.PreviewID),
+		ImageURI:         imageURI,
+		Port:             in.Port,
+		Cpu:              cpu,
+		Memory:           memory,
+		ExecutionRoleArn: executionRoleArn,
+		EnvVars:          in.EnvVars,
+		LogGroup:         logGroupName(in.OrgID, in.PreviewID),
+		LogRegion:        in.Region,
+		LogStreamPrefix:  "application",
+		CpuArchitecture:  in.CpuArchitecture,
+		OSFamily:         in.OSFamily,
+	})
+	if err != nil {
+		return res, fmt.Errorf("register task definition: %w", err)
+	}
+	res.TaskDefinitionArn = taskDefArn
+
+	// 7. Target group (ECS registers the task ENI IP into it).
+	targetGroupArn := in.ExistingTargetGroupArn
+	if targetGroupArn == "" {
+		targetGroupArn, err = aws_utils.EnsureTargetGroup(in.ElbClient, aws_utils.TargetGroupInput{
+			Name:            targetGroupName(in.PreviewID),
+			Port:            in.Port,
+			VpcID:           network.VpcID,
+			HealthCheckPath: in.HealthCheckPath,
+		})
+		if err != nil {
+			return res, fmt.Errorf("ensure target group: %w", err)
+		}
+	}
+	res.TargetGroupArn = targetGroupArn
+
+	// 8. Create/update the Fargate service, wired to the target group.
+	serviceArn, err := aws_utils.CreateOrUpdateEcsService(in.EcsClient, aws_utils.EcsServiceInput{
+		ClusterArn:        clusterArn,
+		ServiceName:       ecsServiceName(in.PreviewID),
+		TaskDefinitionArn: taskDefArn,
+		ContainerName:     containerName(in.PreviewID),
+		Port:              in.Port,
+		TargetGroupArn:    targetGroupArn,
+		SubnetIDs:         network.SubnetIDs,
+		SecurityGroupIDs:  []string{taskSgID},
+		AssignPublicIP:    true, // public subnets, no NAT
+		WaitForStable:     !in.SkipServiceStableWait,
+	}, logsWriter)
+	if err != nil {
+		return res, fmt.Errorf("create/update ECS service: %w", err)
+	}
+	res.EcsServiceArn = serviceArn
+
+	// Cw1a confirmation: without an ALB the stable waiter can't run, so poll for a
+	// RUNNING task (best effort — a slow first image pull just returns false).
+	if in.SkipServiceStableWait {
+		running, werr := aws_utils.WaitForRunningTask(in.EcsClient, clusterArn, ecsServiceName(in.PreviewID), 5*time.Minute)
+		if werr != nil {
+			return res, fmt.Errorf("await running task: %w", werr)
+		}
+		res.TaskRunning = running
+		if running {
+			io.WriteString(logsWriter, "Preview task is running and registered with the target group\n")
+		} else {
+			io.WriteString(logsWriter, "Preview service created; task not yet running (still pulling/starting)\n")
+		}
+	}
+
+	return res, nil
+}
+
+// buildAndPushImage builds the image from the agent's build context and pushes it
+// to ECR — the runner (which holds the Docker daemon + cloud creds), not
+// agentbox, performs both, mirroring the production build_docker_image /
+// upload_docker_image_to_ecr commands.
+func buildAndPushImage(ecrClient *ecr.Client, buildContextDir, dockerfile, localTag, imageURI string, buildArgs map[string]string, logsWriter io.Writer) error {
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	if err != nil {
+		return err
+	}
+	defer cli.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	defer cancel()
+
+	tar, err := archive.TarWithOptions(buildContextDir, &archive.TarOptions{})
+	if err != nil {
+		return fmt.Errorf("tar build context: %w", err)
+	}
+	io.WriteString(logsWriter, "Building preview image\n")
+	buildRes, err := cli.ImageBuild(ctx, tar, types.ImageBuildOptions{
+		Dockerfile: dockerfile,
+		Tags:       []string{localTag},
+		Remove:     true,
+		BuildArgs:  toBuildArgPointers(buildArgs),
+	})
+	if err != nil {
+		return err
+	}
+	defer buildRes.Body.Close()
+	if err := streamDockerJSONLogs(buildRes.Body, logsWriter); err != nil {
+		return fmt.Errorf("image build: %w", err)
+	}
+
+	if err := cli.ImageTag(ctx, localTag, imageURI); err != nil {
+		return fmt.Errorf("tag image: %w", err)
+	}
+
+	auth, err := aws_utils.EcrDockerAuth(ecrClient)
+	if err != nil {
+		return fmt.Errorf("ecr auth: %w", err)
+	}
+	io.WriteString(logsWriter, fmt.Sprintf("Pushing preview image to ECR: %s\n", imageURI))
+	pushRes, err := cli.ImagePush(ctx, imageURI, image.PushOptions{RegistryAuth: auth})
+	if err != nil {
+		return err
+	}
+	defer pushRes.Close()
+	if err := streamDockerJSONLogs(pushRes, logsWriter); err != nil {
+		return fmt.Errorf("image push: %w", err)
+	}
+	return nil
+}
+
+// toBuildArgPointers adapts a plain build-arg map to docker's map[string]*string.
+func toBuildArgPointers(args map[string]string) map[string]*string {
+	if len(args) == 0 {
+		return nil
+	}
+	out := make(map[string]*string, len(args))
+	for k, v := range args {
+		v := v
+		out[k] = &v
+	}
+	return out
+}
+
+// streamDockerJSONLogs copies a docker build/push JSON-lines stream to the log
+// writer and returns an error if any line reports one. Both the build and push
+// streams surface failures as a trailing {"error":...} / {"errorDetail":...}
+// line rather than a non-nil call error.
+func streamDockerJSONLogs(r io.Reader, logsWriter io.Writer) error {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	var streamErr string
+	for scanner.Scan() {
+		line := scanner.Text()
+		var msg struct {
+			Stream      string `json:"stream"`
+			Status      string `json:"status"`
+			Error       string `json:"error"`
+			ErrorDetail struct {
+				Message string `json:"message"`
+			} `json:"errorDetail"`
+		}
+		if json.Unmarshal([]byte(line), &msg) == nil {
+			switch {
+			case msg.Stream != "":
+				io.WriteString(logsWriter, msg.Stream)
+			case msg.Status != "":
+				io.WriteString(logsWriter, msg.Status+"\n")
+			}
+			if msg.Error != "" {
+				streamErr = msg.Error
+			} else if msg.ErrorDetail.Message != "" {
+				streamErr = msg.ErrorDetail.Message
+			}
+		} else {
+			io.WriteString(logsWriter, line+"\n")
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+	if streamErr != "" {
+		return fmt.Errorf("%s", streamErr)
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Resource naming. Per-preview names key on the previewID (a 24-char deployment
+// id) with short prefixes so they stay under AWS's 32-char ALB/target-group
+// limit; shared names key on the org.
+// ---------------------------------------------------------------------------
+
+func ecrRepositoryName(orgID, previewID string) string { return "ecr-" + orgID + "-" + previewID }
+func localImageName(orgID, previewID, tag string) string {
+	return orgID + "-" + previewID + ":" + tag
+}
+func clusterName(orgID string) string              { return "ecs-" + orgID }
+func executionRoleName(orgID string) string        { return "pv-ecs-exec-" + orgID }
+func taskSecurityGroupName(orgID string) string    { return "pv-tasksg-" + orgID }
+func taskDefinitionFamily(previewID string) string { return "pv-td-" + previewID }
+func containerName(previewID string) string        { return "pv-c-" + previewID }
+func targetGroupName(previewID string) string      { return "pv-tg-" + previewID } // <=32 chars
+func ecsServiceName(previewID string) string       { return "pv-es-" + previewID }
+func logGroupName(orgID, previewID string) string  { return "pv/" + orgID + "/" + previewID }

--- a/agenttools/deploy_web_service_preview_test.go
+++ b/agenttools/deploy_web_service_preview_test.go
@@ -1,0 +1,90 @@
+package agenttools
+
+import (
+	"io"
+	"strings"
+	"testing"
+)
+
+// TestWebServiceResourceNames pins the naming scheme and, critically, guards the
+// AWS 32-char limit on target-group names for a standard 24-hex-char preview id.
+func TestWebServiceResourceNames(t *testing.T) {
+	const org = "org123"
+	const previewID = "64f0c2a1b3d4e5f6a7b8c9d0" // 24-char Mongo object id
+
+	if got := ecrRepositoryName(org, previewID); got != "ecr-org123-64f0c2a1b3d4e5f6a7b8c9d0" {
+		t.Errorf("ecrRepositoryName = %q", got)
+	}
+	if got := clusterName(org); got != "ecs-org123" {
+		t.Errorf("clusterName = %q", got)
+	}
+	if got := ecsServiceName(previewID); got != "pv-es-"+previewID {
+		t.Errorf("ecsServiceName = %q", got)
+	}
+	if got := localImageName(org, previewID, "1700000000"); got != "org123-64f0c2a1b3d4e5f6a7b8c9d0:1700000000" {
+		t.Errorf("localImageName = %q", got)
+	}
+
+	// Target-group names must stay <= 32 chars (AWS limit) for a 24-char id.
+	if got := targetGroupName(previewID); len(got) > 32 {
+		t.Errorf("targetGroupName %q is %d chars, exceeds AWS 32-char limit", got, len(got))
+	}
+}
+
+// TestToBuildArgPointers covers the map[string]string -> map[string]*string
+// adaptation docker expects (nil for empty, distinct pointers per value).
+func TestToBuildArgPointers(t *testing.T) {
+	if got := toBuildArgPointers(nil); got != nil {
+		t.Fatalf("toBuildArgPointers(nil) = %v, want nil", got)
+	}
+	args := map[string]string{"FOO": "1", "BAR": "2"}
+	got := toBuildArgPointers(args)
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2", len(got))
+	}
+	if got["FOO"] == nil || *got["FOO"] != "1" || got["BAR"] == nil || *got["BAR"] != "2" {
+		t.Fatalf("values not adapted correctly: %v", got)
+	}
+	// Each entry must point at its own value, not a shared loop variable.
+	if got["FOO"] == got["BAR"] {
+		t.Fatalf("build-arg pointers alias the same address")
+	}
+}
+
+// TestDeployWebServicePreviewValidation covers the two guards that fire before
+// any AWS client is touched, so they are safe to exercise with a zero-value input.
+func TestDeployWebServicePreviewValidation(t *testing.T) {
+	if _, err := DeployWebServicePreview(WebServicePreviewDeployInput{}, io.Discard); err == nil ||
+		!strings.Contains(err.Error(), "port") {
+		t.Fatalf("missing port: got err %v, want a port error", err)
+	}
+
+	_, err := DeployWebServicePreview(WebServicePreviewDeployInput{
+		Port:            8080,
+		BuildContextDir: "/nonexistent-preview-context-xyz",
+	}, io.Discard)
+	if err == nil || !strings.Contains(err.Error(), "Dockerfile") {
+		t.Fatalf("missing Dockerfile: got err %v, want a Dockerfile error", err)
+	}
+}
+
+// TestStreamDockerJSONLogs covers surfacing a build/push error line and copying
+// stream/status text through.
+func TestStreamDockerJSONLogs(t *testing.T) {
+	var buf strings.Builder
+	ok := `{"stream":"Step 1/2\n"}
+{"status":"Pushing"}`
+	if err := streamDockerJSONLogs(strings.NewReader(ok), &buf); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "Step 1/2") || !strings.Contains(buf.String(), "Pushing") {
+		t.Fatalf("stream/status not copied: %q", buf.String())
+	}
+
+	fail := `{"stream":"Step 1/2\n"}
+{"errorDetail":{"message":"boom"},"error":"boom"}`
+	if err := streamDockerJSONLogs(strings.NewReader(fail), io.Discard); err == nil ||
+		!strings.Contains(err.Error(), "boom") {
+		t.Fatalf("error line not surfaced: got %v", err)
+	}
+}

--- a/utils/aws_utils/web_service.go
+++ b/utils/aws_utils/web_service.go
@@ -1,0 +1,663 @@
+package aws_utils
+
+// web_service.go holds the arg-based AWS primitives that back the in-process
+// web-service preview deploy (agenttools.DeployWebServicePreview). It is the
+// web-service twin of static_site.go: every helper takes explicit arguments +
+// an already-built AWS client, with NO coupling to the job `parameters` map, so
+// the preview deploy core can reuse them the way the static preview reuses the
+// S3/CloudFront helpers.
+//
+// These are written FRESH against the AWS SDK (referencing, not refactoring, the
+// production monolith jobs/commands/deploy_aws_web_service.go). The production
+// path is per-service (one ALB per deployment, private subnets + NAT + Service
+// Connect); the preview is deliberately leaner and self-contained:
+//
+//   - Fargate tasks run in the account's DEFAULT VPC public subnets with a public
+//     IP (AssignPublicIp=ENABLED) so they pull the ECR image + reach the internet
+//     with NO NAT gateway (a NAT's idle charge is exactly what a cost-optimized
+//     preview avoids).
+//   - One shared per-org task security group (ingress from the VPC CIDR) rather
+//     than a per-service SG + default-SG mutation.
+//   - No Cloud Map / Service Connect (the preview is reached through the shared
+//     ALB + CloudFront, not service-to-service internal DNS).
+//
+// Cw1a covers the ECS half (ECR, cluster, execution role, VPC/subnets, task SG,
+// task definition, target group, service). Cw1b appends the ingress half (shared
+// ALB + header-routed listener rule).
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2Types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/aws/aws-sdk-go-v2/service/ecr"
+	ecrTypes "github.com/aws/aws-sdk-go-v2/service/ecr/types"
+	"github.com/aws/aws-sdk-go-v2/service/ecs"
+	ecsTypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
+	elb "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
+	elbTypes "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamTypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/aws/smithy-go"
+)
+
+// awsCreatedByTag is the marker every production resource carries; previews reuse
+// it so an operator (and the GC sweep) can recognize deployment.io-owned infra.
+const awsCreatedByTag = "deployment.io"
+
+// apiErrCodeIs reports whether err is (or wraps) an AWS API error with one of the
+// given codes — used to make create/authorize calls idempotent (a concurrent or
+// retried first-deploy hits "already exists" instead of a real failure).
+func apiErrCodeIs(err error, codes ...string) bool {
+	var ae smithy.APIError
+	if !errors.As(err, &ae) {
+		return false
+	}
+	for _, c := range codes {
+		if ae.ErrorCode() == c {
+			return true
+		}
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// ECR
+// ---------------------------------------------------------------------------
+
+// EnsureEcrRepository find-or-creates an ECR repository by name and returns its
+// URI. Mirrors the monolith's createEcrRepositoryIfNeeded but arg-based and
+// without the control-plane persistence side effects.
+func EnsureEcrRepository(ecrClient *ecr.Client, repositoryName string, logsWriter io.Writer) (string, error) {
+	describeOut, _ := ecrClient.DescribeRepositories(context.TODO(), &ecr.DescribeRepositoriesInput{
+		RepositoryNames: []string{repositoryName},
+	})
+	if describeOut != nil {
+		for _, repo := range describeOut.Repositories {
+			if aws.ToString(repo.RepositoryName) == repositoryName {
+				return aws.ToString(repo.RepositoryUri), nil
+			}
+		}
+	}
+
+	createOut, err := ecrClient.CreateRepository(context.TODO(), &ecr.CreateRepositoryInput{
+		RepositoryName:     aws.String(repositoryName),
+		ImageTagMutability: ecrTypes.ImageTagMutabilityMutable,
+		Tags: []ecrTypes.Tag{
+			{Key: aws.String("Name"), Value: aws.String(repositoryName)},
+			{Key: aws.String("created by"), Value: aws.String(awsCreatedByTag)},
+		},
+	})
+	if err != nil {
+		// A concurrent first-deploy may have won the race — re-describe.
+		if apiErrCodeIs(err, "RepositoryAlreadyExistsException") {
+			describeOut, derr := ecrClient.DescribeRepositories(context.TODO(), &ecr.DescribeRepositoriesInput{
+				RepositoryNames: []string{repositoryName},
+			})
+			if derr == nil && describeOut != nil && len(describeOut.Repositories) > 0 {
+				return aws.ToString(describeOut.Repositories[0].RepositoryUri), nil
+			}
+		}
+		return "", err
+	}
+	io.WriteString(logsWriter, fmt.Sprintf("Created ECR repository: %s\n", aws.ToString(createOut.Repository.RepositoryUri)))
+	return aws.ToString(createOut.Repository.RepositoryUri), nil
+}
+
+// EcrDockerAuth returns a base64-encoded docker registry auth string for the
+// account's ECR registry (the form docker's ImagePush RegistryAuth expects).
+// Mirrors the monolith's GetAuthorizationToken -> "AWS:<token>" decoding.
+func EcrDockerAuth(ecrClient *ecr.Client) (string, error) {
+	out, err := ecrClient.GetAuthorizationToken(context.TODO(), &ecr.GetAuthorizationTokenInput{})
+	if err != nil {
+		return "", err
+	}
+	if len(out.AuthorizationData) < 1 {
+		return "", fmt.Errorf("no auth token from ECR")
+	}
+	decoded, err := base64.StdEncoding.DecodeString(aws.ToString(out.AuthorizationData[0].AuthorizationToken))
+	if err != nil {
+		return "", err
+	}
+	// The decoded token is "AWS:<password>".
+	full := string(decoded)
+	pw := full
+	for i := 0; i < len(full); i++ {
+		if full[i] == ':' {
+			pw = full[i+1:]
+			break
+		}
+	}
+	authJSON, err := json.Marshal(map[string]string{"username": "AWS", "password": pw})
+	if err != nil {
+		return "", err
+	}
+	return base64.URLEncoding.EncodeToString(authJSON), nil
+}
+
+// ---------------------------------------------------------------------------
+// ECS cluster + task execution role
+// ---------------------------------------------------------------------------
+
+// EnsureEcsCluster find-or-creates a FARGATE ECS cluster by name and returns its
+// ARN. Mirrors create_ecs_cluster.go's createEcsClusterIfNeeded (an INACTIVE
+// cluster of the same name is treated as absent and recreated).
+func EnsureEcsCluster(ecsClient *ecs.Client, clusterName string) (string, error) {
+	describeOut, err := ecsClient.DescribeClusters(context.TODO(), &ecs.DescribeClustersInput{
+		Clusters: []string{clusterName},
+	})
+	if err == nil && describeOut != nil {
+		for _, c := range describeOut.Clusters {
+			if aws.ToString(c.ClusterName) == clusterName && aws.ToString(c.Status) != "INACTIVE" {
+				return aws.ToString(c.ClusterArn), nil
+			}
+		}
+	}
+
+	createOut, err := ecsClient.CreateCluster(context.TODO(), &ecs.CreateClusterInput{
+		ClusterName:       aws.String(clusterName),
+		CapacityProviders: []string{"FARGATE"},
+		Tags:              []ecsTypes.Tag{{Key: aws.String("created by"), Value: aws.String(awsCreatedByTag)}},
+	})
+	if err != nil {
+		return "", err
+	}
+	return aws.ToString(createOut.Cluster.ClusterArn), nil
+}
+
+// ecsTaskExecutionAssumeRolePolicy lets ECS tasks assume the execution role.
+const ecsTaskExecutionAssumeRolePolicy = `{
+  "Version": "2012-10-17",
+  "Statement": [{"Effect": "Allow", "Principal": {"Service": "ecs-tasks.amazonaws.com"}, "Action": "sts:AssumeRole"}]
+}`
+
+// EnsureEcsTaskExecutionRole find-or-creates an ECS task execution role and
+// returns its ARN. The role lets the task pull from ECR and ship logs to
+// CloudWatch; CloudWatchFullAccess is attached in addition to the managed ECS
+// execution policy because the awslogs driver is configured with
+// awslogs-create-group=true (which needs logs:CreateLogGroup). IAM is global, so
+// a per-org role is reused across regions/previews.
+func EnsureEcsTaskExecutionRole(iamClient *iam.Client, roleName string) (string, error) {
+	getOut, err := iamClient.GetRole(context.TODO(), &iam.GetRoleInput{RoleName: aws.String(roleName)})
+	if err == nil && getOut.Role != nil {
+		return aws.ToString(getOut.Role.Arn), nil
+	}
+	if err != nil && !apiErrCodeIs(err, "NoSuchEntity", "NoSuchEntityException") {
+		return "", err
+	}
+
+	createOut, err := iamClient.CreateRole(context.TODO(), &iam.CreateRoleInput{
+		RoleName:                 aws.String(roleName),
+		AssumeRolePolicyDocument: aws.String(ecsTaskExecutionAssumeRolePolicy),
+		Description:              aws.String("ECS task execution role for deployment.io previews"),
+		Tags:                     []iamTypes.Tag{{Key: aws.String("created by"), Value: aws.String(awsCreatedByTag)}},
+	})
+	if err != nil {
+		// Lost the create race — fetch the existing role.
+		if apiErrCodeIs(err, "EntityAlreadyExists", "EntityAlreadyExistsException") {
+			getOut, gerr := iamClient.GetRole(context.TODO(), &iam.GetRoleInput{RoleName: aws.String(roleName)})
+			if gerr == nil && getOut.Role != nil {
+				return aws.ToString(getOut.Role.Arn), nil
+			}
+		}
+		return "", err
+	}
+
+	for _, policyArn := range []string{
+		"arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy",
+		"arn:aws:iam::aws:policy/CloudWatchFullAccess",
+	} {
+		if _, err := iamClient.AttachRolePolicy(context.TODO(), &iam.AttachRolePolicyInput{
+			RoleName:  aws.String(roleName),
+			PolicyArn: aws.String(policyArn),
+		}); err != nil {
+			return "", fmt.Errorf("attach %s: %w", policyArn, err)
+		}
+	}
+	return aws.ToString(createOut.Role.Arn), nil
+}
+
+// ---------------------------------------------------------------------------
+// VPC / subnets
+// ---------------------------------------------------------------------------
+
+// VpcNetwork is the resolved VPC a preview deploys into: the VPC id, its CIDR
+// (for intra-VPC security-group rules), and public subnets across distinct AZs
+// (Fargate tasks + the shared ALB both live here).
+type VpcNetwork struct {
+	VpcID     string
+	VpcCidr   string
+	SubnetIDs []string
+}
+
+// DiscoverDefaultVpcNetwork resolves the account's default VPC in the client's
+// region and its public subnets. The default VPC's subnets have an
+// internet-gateway route, so tasks with a public IP reach ECR/the internet
+// without a NAT. Callers that have deleted their default VPC should pass an
+// explicit VpcID (see DescribeVpcNetwork).
+func DiscoverDefaultVpcNetwork(ec2Client *ec2.Client) (VpcNetwork, error) {
+	out, err := ec2Client.DescribeVpcs(context.TODO(), &ec2.DescribeVpcsInput{
+		Filters: []ec2Types.Filter{{Name: aws.String("isDefault"), Values: []string{"true"}}},
+	})
+	if err != nil {
+		return VpcNetwork{}, err
+	}
+	if len(out.Vpcs) == 0 {
+		return VpcNetwork{}, fmt.Errorf("no default VPC in this region — supply an explicit VpcID for the preview")
+	}
+	return DescribeVpcNetwork(ec2Client, aws.ToString(out.Vpcs[0].VpcId))
+}
+
+// DescribeVpcNetwork resolves an explicit VPC's CIDR + public subnets (one per
+// AZ, preferring auto-assign-public-IP subnets). Used when the caller supplies a
+// VpcID instead of relying on the default VPC.
+func DescribeVpcNetwork(ec2Client *ec2.Client, vpcID string) (VpcNetwork, error) {
+	vpcsOut, err := ec2Client.DescribeVpcs(context.TODO(), &ec2.DescribeVpcsInput{VpcIds: []string{vpcID}})
+	if err != nil {
+		return VpcNetwork{}, err
+	}
+	if len(vpcsOut.Vpcs) == 0 {
+		return VpcNetwork{}, fmt.Errorf("VPC %s not found", vpcID)
+	}
+	cidr := aws.ToString(vpcsOut.Vpcs[0].CidrBlock)
+
+	subnetsOut, err := ec2Client.DescribeSubnets(context.TODO(), &ec2.DescribeSubnetsInput{
+		Filters: []ec2Types.Filter{{Name: aws.String("vpc-id"), Values: []string{vpcID}}},
+	})
+	if err != nil {
+		return VpcNetwork{}, err
+	}
+
+	// One subnet per AZ (an ALB needs >=2 AZs), preferring public (auto-assign
+	// public IP) subnets so a NAT-less task can still egress.
+	perAZ := map[string]string{}     // az -> subnet id (a public one if seen)
+	perAZPublic := map[string]bool{} // az -> whether the chosen subnet is public
+	for _, sn := range subnetsOut.Subnets {
+		az := aws.ToString(sn.AvailabilityZone)
+		id := aws.ToString(sn.SubnetId)
+		isPublic := aws.ToBool(sn.MapPublicIpOnLaunch)
+		if _, ok := perAZ[az]; !ok || (isPublic && !perAZPublic[az]) {
+			perAZ[az] = id
+			perAZPublic[az] = isPublic
+		}
+	}
+	if len(perAZ) == 0 {
+		return VpcNetwork{}, fmt.Errorf("no subnets found in VPC %s", vpcID)
+	}
+	azs := make([]string, 0, len(perAZ))
+	for az := range perAZ {
+		azs = append(azs, az)
+	}
+	sort.Strings(azs) // deterministic subnet ordering
+	subnetIDs := make([]string, 0, len(azs))
+	for _, az := range azs {
+		subnetIDs = append(subnetIDs, perAZ[az])
+	}
+	return VpcNetwork{VpcID: vpcID, VpcCidr: cidr, SubnetIDs: subnetIDs}, nil
+}
+
+// ---------------------------------------------------------------------------
+// Security groups
+// ---------------------------------------------------------------------------
+
+// EnsureSecurityGroup find-or-creates a security group by name within a VPC and
+// returns its id. New groups carry the default allow-all egress rule, which is
+// all a preview needs (tasks egress to ECR/internet; the ALB egresses to tasks).
+func EnsureSecurityGroup(ec2Client *ec2.Client, name, description, vpcID string) (string, error) {
+	describeOut, err := ec2Client.DescribeSecurityGroups(context.TODO(), &ec2.DescribeSecurityGroupsInput{
+		Filters: []ec2Types.Filter{
+			{Name: aws.String("group-name"), Values: []string{name}},
+			{Name: aws.String("vpc-id"), Values: []string{vpcID}},
+		},
+	})
+	if err == nil && describeOut != nil && len(describeOut.SecurityGroups) > 0 {
+		return aws.ToString(describeOut.SecurityGroups[0].GroupId), nil
+	}
+
+	createOut, err := ec2Client.CreateSecurityGroup(context.TODO(), &ec2.CreateSecurityGroupInput{
+		GroupName:   aws.String(name),
+		Description: aws.String(description),
+		VpcId:       aws.String(vpcID),
+		TagSpecifications: []ec2Types.TagSpecification{{
+			ResourceType: ec2Types.ResourceTypeSecurityGroup,
+			Tags: []ec2Types.Tag{
+				{Key: aws.String("Name"), Value: aws.String(name)},
+				{Key: aws.String("created by"), Value: aws.String(awsCreatedByTag)},
+			},
+		}},
+	})
+	if err != nil {
+		// Lost the create race — re-describe.
+		if apiErrCodeIs(err, "InvalidGroup.Duplicate") {
+			describeOut, derr := ec2Client.DescribeSecurityGroups(context.TODO(), &ec2.DescribeSecurityGroupsInput{
+				Filters: []ec2Types.Filter{
+					{Name: aws.String("group-name"), Values: []string{name}},
+					{Name: aws.String("vpc-id"), Values: []string{vpcID}},
+				},
+			})
+			if derr == nil && describeOut != nil && len(describeOut.SecurityGroups) > 0 {
+				return aws.ToString(describeOut.SecurityGroups[0].GroupId), nil
+			}
+		}
+		return "", err
+	}
+	return aws.ToString(createOut.GroupId), nil
+}
+
+// AuthorizeTCPIngressFromCIDR adds a TCP ingress rule (idempotent) allowing the
+// given CIDR to reach [fromPort,toPort] on the security group. A duplicate rule
+// (redeploy / concurrent) is treated as success.
+func AuthorizeTCPIngressFromCIDR(ec2Client *ec2.Client, sgID, cidr string, fromPort, toPort int32) error {
+	_, err := ec2Client.AuthorizeSecurityGroupIngress(context.TODO(), &ec2.AuthorizeSecurityGroupIngressInput{
+		GroupId: aws.String(sgID),
+		IpPermissions: []ec2Types.IpPermission{{
+			IpProtocol: aws.String("tcp"),
+			FromPort:   aws.Int32(fromPort),
+			ToPort:     aws.Int32(toPort),
+			IpRanges:   []ec2Types.IpRange{{CidrIp: aws.String(cidr), Description: aws.String("deployment.io preview")}},
+		}},
+	})
+	if err != nil && !apiErrCodeIs(err, "InvalidPermission.Duplicate") {
+		return err
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Task definition
+// ---------------------------------------------------------------------------
+
+// TaskDefinitionInput describes the Fargate task definition for a preview.
+type TaskDefinitionInput struct {
+	Family           string
+	ContainerName    string
+	ImageURI         string // ECR URI including the tag
+	Port             int32
+	Cpu              string // Fargate CPU units, e.g. "256"
+	Memory           string // Fargate memory (MiB), e.g. "512"
+	ExecutionRoleArn string
+	EnvVars          map[string]string
+	LogGroup         string
+	LogRegion        string
+	LogStreamPrefix  string
+	CpuArchitecture  ecsTypes.CPUArchitecture // default X86_64
+	OSFamily         ecsTypes.OSFamily        // default LINUX
+}
+
+// envMapToKeyValuePairs converts an env map to ECS KeyValuePairs, sorted by key
+// so a redeploy of the same env produces a byte-identical container definition
+// (and the output is deterministic for tests).
+func envMapToKeyValuePairs(env map[string]string) []ecsTypes.KeyValuePair {
+	if len(env) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(env))
+	for k := range env {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	pairs := make([]ecsTypes.KeyValuePair, 0, len(keys))
+	for _, k := range keys {
+		pairs = append(pairs, ecsTypes.KeyValuePair{Name: aws.String(k), Value: aws.String(env[k])})
+	}
+	return pairs
+}
+
+// RegisterWebServiceTaskDefinition registers a new Fargate task-definition
+// revision and returns its ARN. Env vars are injected as plaintext KeyValuePairs
+// exactly as the production monolith does (they arrive already resolved from the
+// runner, which is why the agent never sees them — the runner, not agentbox,
+// performs the injection).
+func RegisterWebServiceTaskDefinition(ecsClient *ecs.Client, in TaskDefinitionInput) (string, error) {
+	cpuArch := in.CpuArchitecture
+	if cpuArch == "" {
+		cpuArch = ecsTypes.CPUArchitectureX8664
+	}
+	osFamily := in.OSFamily
+	if osFamily == "" {
+		osFamily = ecsTypes.OSFamilyLinux
+	}
+
+	container := ecsTypes.ContainerDefinition{
+		Name:         aws.String(in.ContainerName),
+		Image:        aws.String(in.ImageURI),
+		Essential:    aws.Bool(true),
+		Environment:  envMapToKeyValuePairs(in.EnvVars),
+		PortMappings: []ecsTypes.PortMapping{{ContainerPort: aws.Int32(in.Port), Protocol: ecsTypes.TransportProtocolTcp}},
+		LogConfiguration: &ecsTypes.LogConfiguration{
+			LogDriver: ecsTypes.LogDriverAwslogs,
+			Options: map[string]string{
+				"awslogs-create-group":  "true",
+				"awslogs-group":         in.LogGroup,
+				"awslogs-region":        in.LogRegion,
+				"awslogs-stream-prefix": in.LogStreamPrefix,
+			},
+		},
+	}
+
+	out, err := ecsClient.RegisterTaskDefinition(context.TODO(), &ecs.RegisterTaskDefinitionInput{
+		Family:                  aws.String(in.Family),
+		ContainerDefinitions:    []ecsTypes.ContainerDefinition{container},
+		Cpu:                     aws.String(in.Cpu),
+		Memory:                  aws.String(in.Memory),
+		ExecutionRoleArn:        aws.String(in.ExecutionRoleArn),
+		NetworkMode:             ecsTypes.NetworkModeAwsvpc,
+		RequiresCompatibilities: []ecsTypes.Compatibility{ecsTypes.CompatibilityFargate},
+		RuntimePlatform: &ecsTypes.RuntimePlatform{
+			CpuArchitecture:       cpuArch,
+			OperatingSystemFamily: osFamily,
+		},
+		Tags: []ecsTypes.Tag{{Key: aws.String("created by"), Value: aws.String(awsCreatedByTag)}},
+	})
+	if err != nil {
+		return "", err
+	}
+	return aws.ToString(out.TaskDefinition.TaskDefinitionArn), nil
+}
+
+// ---------------------------------------------------------------------------
+// Target group
+// ---------------------------------------------------------------------------
+
+// TargetGroupInput describes an ip-target-type target group for a preview
+// service.
+type TargetGroupInput struct {
+	Name            string
+	Port            int32
+	VpcID           string
+	HealthCheckPath string // default "/"
+}
+
+// EnsureTargetGroup find-or-creates an ip target group and returns its ARN.
+// Target type is ip (required for Fargate/awsvpc); ECS registers the task's ENI
+// IP into it via the service's LoadBalancers block.
+func EnsureTargetGroup(elbClient *elb.Client, in TargetGroupInput) (string, error) {
+	describeOut, err := elbClient.DescribeTargetGroups(context.TODO(), &elb.DescribeTargetGroupsInput{
+		Names: []string{in.Name},
+	})
+	if err == nil && describeOut != nil && len(describeOut.TargetGroups) > 0 {
+		return aws.ToString(describeOut.TargetGroups[0].TargetGroupArn), nil
+	}
+	if err != nil && !apiErrCodeIs(err, "TargetGroupNotFound") {
+		return "", err
+	}
+
+	healthPath := in.HealthCheckPath
+	if healthPath == "" {
+		healthPath = "/"
+	}
+	createOut, err := elbClient.CreateTargetGroup(context.TODO(), &elb.CreateTargetGroupInput{
+		Name:                       aws.String(in.Name),
+		Port:                       aws.Int32(in.Port),
+		Protocol:                   elbTypes.ProtocolEnumHttp,
+		TargetType:                 elbTypes.TargetTypeEnumIp,
+		VpcId:                      aws.String(in.VpcID),
+		HealthCheckEnabled:         aws.Bool(true),
+		HealthCheckProtocol:        elbTypes.ProtocolEnumHttp,
+		HealthCheckPath:            aws.String(healthPath),
+		HealthCheckIntervalSeconds: aws.Int32(30),
+		HealthCheckTimeoutSeconds:  aws.Int32(10),
+		HealthyThresholdCount:      aws.Int32(2),
+		UnhealthyThresholdCount:    aws.Int32(5),
+		Matcher:                    &elbTypes.Matcher{HttpCode: aws.String("200-399")},
+		Tags: []elbTypes.Tag{
+			{Key: aws.String("Name"), Value: aws.String(in.Name)},
+			{Key: aws.String("created by"), Value: aws.String(awsCreatedByTag)},
+		},
+	})
+	if err != nil {
+		return "", err
+	}
+	return aws.ToString(createOut.TargetGroups[0].TargetGroupArn), nil
+}
+
+// ---------------------------------------------------------------------------
+// ECS service
+// ---------------------------------------------------------------------------
+
+// EcsServiceInput describes the Fargate service for a preview.
+type EcsServiceInput struct {
+	ClusterArn        string
+	ServiceName       string
+	TaskDefinitionArn string
+	ContainerName     string
+	Port              int32
+	TargetGroupArn    string // wires container:port -> target group
+	SubnetIDs         []string
+	SecurityGroupIDs  []string
+	AssignPublicIP    bool
+	// WaitForStable blocks on the service reaching a stable state. It only
+	// succeeds once the target group is health-checked by a load balancer, so
+	// Cw1a (no ALB yet) leaves it false; Cw1b sets it once the listener rule
+	// attaches the target group to the shared ALB.
+	WaitForStable bool
+}
+
+// CreateOrUpdateEcsService creates the service if absent, else updates it to the
+// new task definition (forcing a fresh deployment). Returns the service ARN.
+func CreateOrUpdateEcsService(ecsClient *ecs.Client, in EcsServiceInput, logsWriter io.Writer) (string, error) {
+	describeOut, err := ecsClient.DescribeServices(context.TODO(), &ecs.DescribeServicesInput{
+		Cluster:  aws.String(in.ClusterArn),
+		Services: []string{in.ServiceName},
+	})
+	if err != nil {
+		return "", err
+	}
+	var existingArn string
+	for _, svc := range describeOut.Services {
+		if aws.ToString(svc.ServiceName) == in.ServiceName {
+			status := aws.ToString(svc.Status)
+			if status == "ACTIVE" || status == "DRAINING" {
+				existingArn = aws.ToString(svc.ServiceArn)
+			}
+		}
+	}
+
+	if existingArn != "" {
+		io.WriteString(logsWriter, fmt.Sprintf("Updating preview service: %s\n", in.ServiceName))
+		if _, err := ecsClient.UpdateService(context.TODO(), &ecs.UpdateServiceInput{
+			Cluster:            aws.String(in.ClusterArn),
+			Service:            aws.String(in.ServiceName),
+			TaskDefinition:     aws.String(in.TaskDefinitionArn),
+			DesiredCount:       aws.Int32(1),
+			ForceNewDeployment: true,
+			PropagateTags:      ecsTypes.PropagateTagsTaskDefinition,
+		}); err != nil {
+			return "", err
+		}
+		if err := waitEcsServiceStable(ecsClient, in, logsWriter); err != nil {
+			return "", err
+		}
+		return existingArn, nil
+	}
+
+	var loadBalancers []ecsTypes.LoadBalancer
+	var gracePeriod *int32
+	if in.TargetGroupArn != "" {
+		loadBalancers = []ecsTypes.LoadBalancer{{
+			ContainerName:  aws.String(in.ContainerName),
+			ContainerPort:  aws.Int32(in.Port),
+			TargetGroupArn: aws.String(in.TargetGroupArn),
+		}}
+		gracePeriod = aws.Int32(60)
+	}
+	assignPublicIP := ecsTypes.AssignPublicIpDisabled
+	if in.AssignPublicIP {
+		assignPublicIP = ecsTypes.AssignPublicIpEnabled
+	}
+
+	io.WriteString(logsWriter, fmt.Sprintf("Creating preview service: %s\n", in.ServiceName))
+	createOut, err := ecsClient.CreateService(context.TODO(), &ecs.CreateServiceInput{
+		ServiceName:                   aws.String(in.ServiceName),
+		Cluster:                       aws.String(in.ClusterArn),
+		TaskDefinition:                aws.String(in.TaskDefinitionArn),
+		DesiredCount:                  aws.Int32(1),
+		LaunchType:                    ecsTypes.LaunchTypeFargate,
+		SchedulingStrategy:            ecsTypes.SchedulingStrategyReplica,
+		LoadBalancers:                 loadBalancers,
+		HealthCheckGracePeriodSeconds: gracePeriod,
+		PropagateTags:                 ecsTypes.PropagateTagsTaskDefinition,
+		NetworkConfiguration: &ecsTypes.NetworkConfiguration{
+			AwsvpcConfiguration: &ecsTypes.AwsVpcConfiguration{
+				Subnets:        in.SubnetIDs,
+				SecurityGroups: in.SecurityGroupIDs,
+				AssignPublicIp: assignPublicIP,
+			},
+		},
+		Tags: []ecsTypes.Tag{{Key: aws.String("created by"), Value: aws.String(awsCreatedByTag)}},
+	})
+	if err != nil {
+		return "", err
+	}
+	if err := waitEcsServiceStable(ecsClient, in, logsWriter); err != nil {
+		return "", err
+	}
+	return aws.ToString(createOut.Service.ServiceArn), nil
+}
+
+// waitEcsServiceStable optionally blocks until the service is stable.
+func waitEcsServiceStable(ecsClient *ecs.Client, in EcsServiceInput, logsWriter io.Writer) error {
+	if !in.WaitForStable {
+		return nil
+	}
+	io.WriteString(logsWriter, fmt.Sprintf("Waiting for preview service to stabilize: %s\n", in.ServiceName))
+	waiter := ecs.NewServicesStableWaiter(ecsClient)
+	return waiter.Wait(context.TODO(), &ecs.DescribeServicesInput{
+		Cluster:  aws.String(in.ClusterArn),
+		Services: []string{in.ServiceName},
+	}, 15*time.Minute)
+}
+
+// WaitForRunningTask polls the service until it reports at least one RUNNING
+// task or the deadline elapses. Cw1a uses this in place of the stable waiter
+// (which can't succeed before an ALB health-checks the target group) so the
+// deploy core can confirm the task actually launched.
+func WaitForRunningTask(ecsClient *ecs.Client, clusterArn, serviceName string, timeout time.Duration) (bool, error) {
+	deadline := time.Now().Add(timeout)
+	for {
+		out, err := ecsClient.DescribeServices(context.TODO(), &ecs.DescribeServicesInput{
+			Cluster:  aws.String(clusterArn),
+			Services: []string{serviceName},
+		})
+		if err != nil {
+			return false, err
+		}
+		for _, svc := range out.Services {
+			if aws.ToString(svc.ServiceName) == serviceName && svc.RunningCount >= 1 {
+				return true, nil
+			}
+		}
+		if time.Now().After(deadline) {
+			return false, nil
+		}
+		time.Sleep(10 * time.Second)
+	}
+}

--- a/utils/aws_utils/web_service_test.go
+++ b/utils/aws_utils/web_service_test.go
@@ -1,0 +1,49 @@
+package aws_utils
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/smithy-go"
+)
+
+// TestEnvMapToKeyValuePairs covers deterministic (key-sorted) conversion and the
+// empty -> nil case (so a no-env container definition stays byte-stable).
+func TestEnvMapToKeyValuePairs(t *testing.T) {
+	if got := envMapToKeyValuePairs(nil); got != nil {
+		t.Fatalf("empty map -> %v, want nil", got)
+	}
+	pairs := envMapToKeyValuePairs(map[string]string{"ZED": "z", "ALPHA": "a", "MID": "m"})
+	if len(pairs) != 3 {
+		t.Fatalf("len = %d, want 3", len(pairs))
+	}
+	wantKeys := []string{"ALPHA", "MID", "ZED"} // sorted
+	wantVals := []string{"a", "m", "z"}
+	for i, p := range pairs {
+		if aws.ToString(p.Name) != wantKeys[i] || aws.ToString(p.Value) != wantVals[i] {
+			t.Errorf("pair[%d] = (%q,%q), want (%q,%q)", i,
+				aws.ToString(p.Name), aws.ToString(p.Value), wantKeys[i], wantVals[i])
+		}
+	}
+}
+
+// TestApiErrCodeIs covers the idempotency helper matching an AWS error code.
+func TestApiErrCodeIs(t *testing.T) {
+	dup := &smithy.GenericAPIError{Code: "InvalidPermission.Duplicate", Message: "exists"}
+	if !apiErrCodeIs(dup, "InvalidPermission.Duplicate") {
+		t.Errorf("expected match on exact code")
+	}
+	if !apiErrCodeIs(dup, "Other", "InvalidPermission.Duplicate") {
+		t.Errorf("expected match when code is among the list")
+	}
+	if apiErrCodeIs(dup, "InvalidGroup.Duplicate") {
+		t.Errorf("unexpected match on a different code")
+	}
+	if apiErrCodeIs(nil, "InvalidPermission.Duplicate") {
+		t.Errorf("nil error should not match")
+	}
+	if apiErrCodeIs(errors.New("plain error"), "InvalidPermission.Duplicate") {
+		t.Errorf("non-API error should not match")
+	}
+}


### PR DESCRIPTION
## What

`Cw1a` of the agent-driven **web-service** preview path — the first half of the arg-based `DeployWebServicePreview` deploy core. It's the web-service twin of the static preview core (`agenttools.DeployStaticSitePreview`).

Two new files, **runner-only**, no behavior change to any existing path:

- `agenttools/deploy_web_service_preview.go` — `WebServicePreviewDeployInput`/`Result` + `DeployWebServicePreview` (ECS half) + the runner-side image build/push orchestration.
- `utils/aws_utils/web_service.go` — the arg-based AWS SDK helpers (sibling of `static_site.go`).

This slice covers the **ECS compute half**:

- **Image build + push** (runner-side): moby client against the runner's Docker daemon → per-preview ECR repo (`ecr-<org>-<previewID>`), `GetAuthorizationToken` → `ImagePush`. Mirrors the production `build_docker_image` / `upload_docker_image_to_ecr` commands. **agentbox never builds images** — the runner holds the daemon + cloud creds (decision: creds never enter agentbox).
- **Shared per-org Fargate cluster** (`ecs-<org>`, find-or-create) + **task execution role** (ECR pull + CloudWatch logs).
- **Networking**: default-VPC **public subnets** with `AssignPublicIp=ENABLED` so tasks pull the image + egress with **no NAT gateway** (the idle charge a cost-optimized preview avoids). One **shared per-org task SG** (VPC-CIDR ingress).
- **Task definition** (env injected as plaintext `KeyValuePair`s — resolved by the runner, so **agent-blind**) + **ip target group** + the **Fargate service**.

## Why written fresh (not extracted)

`deploy_aws_web_service.go` is a 1348-line monolith welded to the job `parameters` map with **no arg-based reuse surface**, and its ALB is **per-service** (`getAlbName ← deploymentID`) whereas the preview wants a **shared ALB + header-routed rules**. So this is written fresh against the SDK, **referencing** the monolith's calls, and leaner than prod: public subnets + public IP (no NAT), one shared task SG, no Cloud Map / Service Connect. The production deploy path is **untouched**.

## Scope / relationship to #84

- **[#84](https://github.com/deployment-io/deployment-runner/pull/84) (Cw1b)** adds the ingress half: shared ALB find-or-create + `X-Preview-Target` header listener rule + per-preview CloudFront (`CustomOriginConfig`) → returns the `https://<x>.cloudfront.net` URL. **Live target-health + reachability validate there** (a target group only goes healthy once an ALB health-checks it), so this PR's service create leaves the stable-waiter off and instead polls for a RUNNING task.
- #84's branch is built on this one, so it targets `master` carrying **both** commits — it's the complete Cw1 if you'd rather review/merge it all at once. Merging this PR first is fine: #84's diff then reduces to the Cw1b commit only.
- **Cw2** (the MCP tool), **Cw3** (verify — free, cloudfront.net), **Cw4** (GC) are separate.

No drk change: the union `deployments.UpdateDeploymentDtoV1` already carries every ECS/ALB/CloudFront field, and the result struct's field names mirror it 1:1 for Cw2's `SavePreview` mapping. `PreviewStore`/`PreviewState`/`EnsureV1` are reused unchanged.

## Verification

- `GOWORK=off go build ./...` ✓ · `GOWORK=off go vet ./utils/aws_utils/ ./agenttools/` ✓ · `gofmt` clean ✓
- `GOWORK=off go test ./utils/aws_utils/ ./agenttools/` ✓ — unit tests cover the pure logic: resource naming (+ the AWS 32-char target-group-name guard), env-map → sorted `KeyValuePair`s, build-arg pointer adaptation, docker JSON-log error surfacing, the API-error-code idempotency helper, and the pre-client input guards.
- A full **live** AWS run (task RUNNING + healthy in the TG + reachable) needs the runner's cloud + #84's ingress; that E2E is the reviewer's to run.

Review-only — I won't merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)