### PR TITLE
preview: web-service preview ingress — shared ALB + CloudFront (Cw1b)

### DIFF
--- a/agenttools/deploy_web_service_preview.go
+++ b/agenttools/deploy_web_service_preview.go
@@ -3,8 +3,8 @@ package agenttools
 // deploy_web_service_preview.go is the arg-based, self-contained web-service preview
 // deploy core — the twin of deploy_static.go's DeployStaticSitePreview. Where the
 // static preview stands up S3 + CloudFront, a web-service preview builds/pushes a
-// container image, runs it as a Fargate service behind a target group, and (Cw1b)
-// fronts it with a shared ALB + a per-preview CloudFront distribution.
+// container image, runs it as a Fargate service behind a target group, and fronts
+// it with a shared ALB + a per-preview CloudFront distribution.
 //
 // Like the static core it is invoked in-process by the (future, Cw2)
 // deploy_web_service_preview MCP tool handler and is deliberately NOT the
@@ -13,14 +13,17 @@ package agenttools
 // calls but is written fresh so the preview can use a shared, cost-optimized
 // ingress. The AWS primitives live in the leaf utils/aws_utils package.
 //
-// Cw1a (this slice) covers the ECS half: image build+push, cluster, execution
-// role, VPC/subnets, task security group, task definition, target group, and the
-// Fargate service. Cw1b appends the ingress half (shared ALB + header-routed
-// listener rule + CloudFront) and populates the URL.
+// The core was built in two slices: Cw1a (the ECS half — image build+push,
+// cluster, execution role, VPC/subnets, task security group, task definition,
+// target group, and the Fargate service) and Cw1b (the ingress half — the shared
+// ALB + header-routed listener rule + per-preview CloudFront, which populate the
+// public URL).
 
 import (
 	"bufio"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -28,7 +31,9 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudfront"
+	cloudfrontTypes "github.com/aws/aws-sdk-go-v2/service/cloudfront/types"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ecr"
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
@@ -41,6 +46,18 @@ import (
 	"github.com/moby/moby/client"
 	"github.com/moby/moby/pkg/archive"
 )
+
+// previewTargetHeader is the origin custom header the preview's CloudFront
+// distribution injects and the shared ALB's listener rule matches — the routing
+// key that fans one shared ALB out to many previews' target groups.
+const previewTargetHeader = "X-Preview-Target"
+
+// allViewerOriginRequestPolicyID is CloudFront's AWS-managed "AllViewer" origin
+// request policy: it forwards all viewer headers, cookies, and query strings to
+// the origin. A web service (unlike a static site) needs the full request, and
+// like cachingDisabledPolicyID this is a global AWS-managed id, safe to hardcode
+// in the BYO multi-account model.
+const allViewerOriginRequestPolicyID = "216adef6-5c7f-47e4-b989-5492eafa07d3"
 
 // Fargate defaults for a preview: the smallest valid CPU/memory combo (0.25 vCPU
 // / 0.5 GB) — cheapest for a short-lived, low-traffic preview.
@@ -79,6 +96,11 @@ type WebServicePreviewDeployInput struct {
 	ExistingExecutionRoleArn string
 	ExistingTargetGroupArn   string
 	ExistingEcsServiceArn    string
+	// ExistingDistID is the per-preview CloudFront distribution from a prior
+	// iteration. The distribution fronts the (stable) shared ALB, so on reuse
+	// there's nothing to recreate — the same URL keeps serving. The shared ALB +
+	// header rule are found-or-created by identity, so they need no reuse handle.
+	ExistingDistID string
 
 	// --- Clients (built by the caller from the runner's IAM role + region) ---
 	EcrClient        *ecr.Client
@@ -128,10 +150,12 @@ type WebServicePreviewDeployResult struct {
 // resource ids are passed back via the Existing* fields and a redeploy registers
 // a fresh task-definition revision + updates the service.
 //
-// Cw1a scope: this returns after the ECS service is created/updated and (best
-// effort) a task reaches RUNNING. The shared ALB + listener rule + CloudFront
-// that make the service publicly reachable — and populate the URL — arrive in
-// Cw1b.
+// Full flow: build+push image -> shared cluster -> execution role -> VPC/subnets
+// -> task security group -> task definition -> target group -> shared ALB +
+// header-routed listener rule -> Fargate service -> per-preview CloudFront
+// distribution. Returns the public https://<x>.cloudfront.net URL. Like the
+// static preview it does not block on CloudFront propagation (SkipServiceStableWait
+// also skips the ECS stable wait) — the agent's verify step polls the URL.
 func DeployWebServicePreview(in WebServicePreviewDeployInput, logsWriter io.Writer) (WebServicePreviewDeployResult, error) {
 	// Defaults.
 	dockerfile := in.DockerfilePath
@@ -255,7 +279,31 @@ func DeployWebServicePreview(in WebServicePreviewDeployInput, logsWriter io.Writ
 	}
 	res.TargetGroupArn = targetGroupArn
 
-	// 8. Create/update the Fargate service, wired to the target group.
+	// 8. Shared ingress: the one-per-org ALB + a header-routed listener rule that
+	// forwards this preview's X-Preview-Target header to its target group.
+	// Creating the rule associates the target group with the ALB, so the
+	// service's targets start getting health-checked (and the service can reach a
+	// stable state below).
+	alb, err := aws_utils.EnsureSharedAlb(in.ElbClient, in.Ec2Client, aws_utils.SharedAlbInput{
+		AlbName:   albName(in.OrgID),
+		AlbSgName: albSecurityGroupName(in.OrgID),
+		VpcID:     network.VpcID,
+		SubnetIDs: network.SubnetIDs,
+	})
+	if err != nil {
+		return res, fmt.Errorf("ensure shared ALB: %w", err)
+	}
+	res.LoadBalancerArn = alb.LoadBalancerArn
+	res.LoadBalancerDns = alb.LoadBalancerDns
+	res.ListenerArn = alb.ListenerArn
+
+	ruleArn, err := aws_utils.EnsurePreviewListenerRule(in.ElbClient, alb.ListenerArn, previewTargetHeader, in.PreviewID, targetGroupArn)
+	if err != nil {
+		return res, fmt.Errorf("ensure listener rule: %w", err)
+	}
+	res.ListenerRuleArn = ruleArn
+
+	// 9. Create/update the Fargate service, wired to the target group.
 	serviceArn, err := aws_utils.CreateOrUpdateEcsService(in.EcsClient, aws_utils.EcsServiceInput{
 		ClusterArn:        clusterArn,
 		ServiceName:       ecsServiceName(in.PreviewID),
@@ -273,22 +321,123 @@ func DeployWebServicePreview(in WebServicePreviewDeployInput, logsWriter io.Writ
 	}
 	res.EcsServiceArn = serviceArn
 
-	// Cw1a confirmation: without an ALB the stable waiter can't run, so poll for a
-	// RUNNING task (best effort — a slow first image pull just returns false).
 	if in.SkipServiceStableWait {
+		// Returned promptly (the agent's verify step polls the URL until live); a
+		// best-effort check still reports whether a task already launched.
 		running, werr := aws_utils.WaitForRunningTask(in.EcsClient, clusterArn, ecsServiceName(in.PreviewID), 5*time.Minute)
 		if werr != nil {
 			return res, fmt.Errorf("await running task: %w", werr)
 		}
 		res.TaskRunning = running
-		if running {
-			io.WriteString(logsWriter, "Preview task is running and registered with the target group\n")
-		} else {
-			io.WriteString(logsWriter, "Preview service created; task not yet running (still pulling/starting)\n")
-		}
+	} else {
+		res.TaskRunning = true // the stable waiter already confirmed healthy targets
+	}
+
+	// 10. Per-preview CloudFront distribution fronting the shared ALB — the public
+	// https://<x>.cloudfront.net surface (free managed cert to the viewer; reaches
+	// the ALB over HTTP with the X-Preview-Target origin header). Reused across
+	// iterations via ExistingDistID.
+	distID, distArn, domain, err := ensurePreviewDistribution(in.CloudfrontClient, alb.LoadBalancerDns, in.PreviewID, in.ExistingDistID, logsWriter)
+	if err != nil {
+		return res, fmt.Errorf("ensure preview distribution: %w", err)
+	}
+	res.CloudFrontDistributionID = distID
+	res.CloudFrontDistributionArn = distArn
+	res.CloudFrontDomainName = domain
+	if domain != "" {
+		res.URL = "https://" + domain
 	}
 
 	return res, nil
+}
+
+// ensurePreviewDistribution creates (or, on reuse, re-reads) the per-preview
+// CloudFront distribution that fronts the shared ALB, returning its id, ARN, and
+// domain. Like the static preview it does NOT block on CloudFront propagation
+// (the agent's verify step polls the URL until it serves).
+func ensurePreviewDistribution(cf *cloudfront.Client, albDns, previewID, existingDistID string, logsWriter io.Writer) (id, arn, domain string, err error) {
+	if existingDistID != "" {
+		// Reuse: the distribution already fronts the (stable) shared ALB. Re-read it
+		// so the result still carries a usable URL.
+		out, gerr := cf.GetDistribution(context.TODO(), &cloudfront.GetDistributionInput{Id: aws.String(existingDistID)})
+		if gerr != nil {
+			return "", "", "", gerr
+		}
+		io.WriteString(logsWriter, fmt.Sprintf("Reusing preview distribution: %s\n", existingDistID))
+		return aws.ToString(out.Distribution.Id), aws.ToString(out.Distribution.ARN), aws.ToString(out.Distribution.DomainName), nil
+	}
+	io.WriteString(logsWriter, "Creating preview CloudFront distribution (ALB origin)\n")
+	out, cerr := cf.CreateDistribution(context.TODO(), &cloudfront.CreateDistributionInput{
+		DistributionConfig: buildPreviewWebServiceDistributionConfig(albDns, previewID),
+	})
+	if cerr != nil {
+		return "", "", "", cerr
+	}
+	d := out.Distribution
+	return aws.ToString(d.Id), aws.ToString(d.ARN), aws.ToString(d.DomainName), nil
+}
+
+// buildPreviewWebServiceDistributionConfig is the CloudFront config for a
+// web-service preview: a CustomOrigin pointing at the shared ALB's DNS name over
+// HTTP-only, with the X-Preview-Target origin custom header that routes this
+// preview through the ALB's listener rule. Caching is disabled (a preview
+// iterates constantly) and the AllViewer origin-request policy forwards the full
+// request so the app sees real headers/cookies/query. cf. the static twin
+// buildPreviewDistributionConfig (S3-OAC origin, GET/HEAD only).
+func buildPreviewWebServiceDistributionConfig(albDns, previewID string) *cloudfrontTypes.DistributionConfig {
+	const originID = "alb-origin"
+	origins := &cloudfrontTypes.Origins{
+		Quantity: aws.Int32(1),
+		Items: []cloudfrontTypes.Origin{{
+			Id:         aws.String(originID),
+			DomainName: aws.String(albDns),
+			CustomOriginConfig: &cloudfrontTypes.CustomOriginConfig{
+				HTTPPort:             aws.Int32(80),
+				HTTPSPort:            aws.Int32(443),
+				OriginProtocolPolicy: cloudfrontTypes.OriginProtocolPolicyHttpOnly,
+				OriginSslProtocols: &cloudfrontTypes.OriginSslProtocols{
+					Quantity: aws.Int32(1),
+					Items:    []cloudfrontTypes.SslProtocol{cloudfrontTypes.SslProtocolTLSv12},
+				},
+			},
+			CustomHeaders: &cloudfrontTypes.CustomHeaders{
+				Quantity: aws.Int32(1),
+				Items: []cloudfrontTypes.OriginCustomHeader{{
+					HeaderName:  aws.String(previewTargetHeader),
+					HeaderValue: aws.String(previewID),
+				}},
+			},
+		}},
+	}
+
+	allMethods := []cloudfrontTypes.Method{
+		cloudfrontTypes.MethodGet, cloudfrontTypes.MethodHead, cloudfrontTypes.MethodOptions,
+		cloudfrontTypes.MethodPut, cloudfrontTypes.MethodPost, cloudfrontTypes.MethodPatch,
+		cloudfrontTypes.MethodDelete,
+	}
+	behavior := &cloudfrontTypes.DefaultCacheBehavior{
+		TargetOriginId:       aws.String(originID),
+		ViewerProtocolPolicy: cloudfrontTypes.ViewerProtocolPolicyAllowAll,
+		AllowedMethods: &cloudfrontTypes.AllowedMethods{
+			Quantity: aws.Int32(int32(len(allMethods))),
+			Items:    allMethods,
+			CachedMethods: &cloudfrontTypes.CachedMethods{
+				Quantity: aws.Int32(2),
+				Items:    []cloudfrontTypes.Method{cloudfrontTypes.MethodGet, cloudfrontTypes.MethodHead},
+			},
+		},
+		CachePolicyId:         aws.String(cachingDisabledPolicyID),
+		OriginRequestPolicyId: aws.String(allViewerOriginRequestPolicyID),
+	}
+
+	return &cloudfrontTypes.DistributionConfig{
+		CallerReference:      aws.String(fmt.Sprintf("preview-ws-%s-%d", previewID, time.Now().Unix())),
+		Comment:              aws.String("Preview distribution for " + previewID),
+		DefaultCacheBehavior: behavior,
+		Enabled:              aws.Bool(true),
+		Origins:              origins,
+		PriceClass:           cloudfrontTypes.PriceClassPriceClassAll,
+	}
 }
 
 // buildAndPushImage builds the image from the agent's build context and pushes it
@@ -418,3 +567,13 @@ func containerName(previewID string) string        { return "pv-c-" + previewID 
 func targetGroupName(previewID string) string      { return "pv-tg-" + previewID } // <=32 chars
 func ecsServiceName(previewID string) string       { return "pv-es-" + previewID }
 func logGroupName(orgID, previewID string) string  { return "pv/" + orgID + "/" + previewID }
+
+// albName is the shared, one-per-org+region ALB name. It must be <=32 chars and
+// alphanumeric/hyphen, so the (variable-length) org id is hashed to fixed width.
+func albName(orgID string) string              { return "pv-alb-" + orgHash(orgID) } // 7+16 = 23 chars
+func albSecurityGroupName(orgID string) string { return "pv-albsg-" + orgID }
+
+func orgHash(orgID string) string {
+	sum := sha256.Sum256([]byte(orgID))
+	return hex.EncodeToString(sum[:])[:16]
+}

--- a/agenttools/deploy_web_service_preview.go
+++ b/agenttools/deploy_web_service_preview.go
@@ -1,0 +1,420 @@
+package agenttools
+
+// deploy_web_service_preview.go is the arg-based, self-contained web-service preview
+// deploy core — the twin of deploy_static.go's DeployStaticSitePreview. Where the
+// static preview stands up S3 + CloudFront, a web-service preview builds/pushes a
+// container image, runs it as a Fargate service behind a target group, and (Cw1b)
+// fronts it with a shared ALB + a per-preview CloudFront distribution.
+//
+// Like the static core it is invoked in-process by the (future, Cw2)
+// deploy_web_service_preview MCP tool handler and is deliberately NOT the
+// production DeployAwsWebService command (a 1348-line monolith welded to the job
+// `parameters` map with a per-service ALB). It references that monolith's SDK
+// calls but is written fresh so the preview can use a shared, cost-optimized
+// ingress. The AWS primitives live in the leaf utils/aws_utils package.
+//
+// Cw1a (this slice) covers the ECS half: image build+push, cluster, execution
+// role, VPC/subnets, task security group, task definition, target group, and the
+// Fargate service. Cw1b appends the ingress half (shared ALB + header-routed
+// listener rule + CloudFront) and populates the URL.
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/cloudfront"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ecr"
+	"github.com/aws/aws-sdk-go-v2/service/ecs"
+	ecsTypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
+	elb "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/deployment-io/deployment-runner/utils/aws_utils"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/image"
+	"github.com/moby/moby/client"
+	"github.com/moby/moby/pkg/archive"
+)
+
+// Fargate defaults for a preview: the smallest valid CPU/memory combo (0.25 vCPU
+// / 0.5 GB) — cheapest for a short-lived, low-traffic preview.
+const (
+	defaultPreviewCPU    = "256"
+	defaultPreviewMemory = "512"
+)
+
+// WebServicePreviewDeployInput is the request for DeployWebServicePreview.
+type WebServicePreviewDeployInput struct {
+	OrgID     string // organization id (resource naming)
+	PreviewID string // the ephemeral preview Deployment's id (per-preview resource naming)
+	Region    string // AWS region string, e.g. "us-east-1" (log config)
+
+	// --- Image build (runner-side; the agent built the source into /work) ---
+	BuildContextDir string            // host path to the build context (the repo dir with the Dockerfile)
+	DockerfilePath  string            // Dockerfile path relative to the context; default "Dockerfile"
+	ImageTag        string            // image tag; default a unix-timestamp tag (unique per redeploy)
+	BuildArgs       map[string]string // docker build args
+
+	// --- Runtime ---
+	Port            int32             // container port the service listens on
+	HealthCheckPath string            // target-group health check path; default "/"
+	Cpu             string            // Fargate CPU units; default "256"
+	Memory          string            // Fargate memory MiB; default "512"
+	EnvVars         map[string]string // runtime env, already resolved by the runner (agent-blind)
+	CpuArchitecture ecsTypes.CPUArchitecture
+	OSFamily        ecsTypes.OSFamily
+
+	// --- Networking (optional; discover the default VPC when VpcID is empty) ---
+	VpcID     string
+	SubnetIDs []string
+
+	// --- Reuse across iterations (empty on the first deploy of a task) ---
+	ExistingClusterArn       string
+	ExistingExecutionRoleArn string
+	ExistingTargetGroupArn   string
+	ExistingEcsServiceArn    string
+
+	// --- Clients (built by the caller from the runner's IAM role + region) ---
+	EcrClient        *ecr.Client
+	EcsClient        *ecs.Client
+	Ec2Client        *ec2.Client
+	ElbClient        *elb.Client
+	IamClient        *iam.Client
+	CloudfrontClient *cloudfront.Client // used by the Cw1b ingress half
+
+	// SkipServiceStableWait leaves the ECS service create/update without blocking
+	// on the stable waiter. Cw1a sets this (the target group can't go healthy
+	// before an ALB health-checks it); Cw1b clears it once the listener rule
+	// attaches the target group to the shared ALB.
+	SkipServiceStableWait bool
+}
+
+// WebServicePreviewDeployResult carries every resource the deploy created or
+// reused, so the (Cw2) tool can persist it via SavePreview for the next
+// iteration. Field names mirror the union deployments.UpdateDeploymentDtoV1 so
+// the mapping in the commands layer is one-to-one.
+type WebServicePreviewDeployResult struct {
+	EcrRepositoryUri  string
+	ImageUri          string // ECR URI including the pushed tag
+	ClusterArn        string
+	ExecutionRoleArn  string
+	TaskDefinitionArn string
+	TargetGroupArn    string
+	EcsServiceArn     string
+	Port              int32
+	VpcID             string
+	TaskRunning       bool // Cw1a signal: at least one task reached RUNNING
+
+	// --- Ingress half (populated by Cw1b) ---
+	LoadBalancerArn           string
+	LoadBalancerDns           string
+	ListenerArn               string
+	ListenerRuleArn           string
+	CloudFrontDistributionID  string
+	CloudFrontDistributionArn string
+	CloudFrontDomainName      string
+	URL                       string
+}
+
+// DeployWebServicePreview builds + pushes the agent's container image and runs it
+// as an ephemeral Fargate service wired to a target group, on the shared
+// per-org ECS cluster. It is idempotent across a task's iterations: reused
+// resource ids are passed back via the Existing* fields and a redeploy registers
+// a fresh task-definition revision + updates the service.
+//
+// Cw1a scope: this returns after the ECS service is created/updated and (best
+// effort) a task reaches RUNNING. The shared ALB + listener rule + CloudFront
+// that make the service publicly reachable — and populate the URL — arrive in
+// Cw1b.
+func DeployWebServicePreview(in WebServicePreviewDeployInput, logsWriter io.Writer) (WebServicePreviewDeployResult, error) {
+	// Defaults.
+	dockerfile := in.DockerfilePath
+	if dockerfile == "" {
+		dockerfile = "Dockerfile"
+	}
+	imageTag := in.ImageTag
+	if imageTag == "" {
+		imageTag = fmt.Sprintf("%d", time.Now().Unix())
+	}
+	cpu := in.Cpu
+	if cpu == "" {
+		cpu = defaultPreviewCPU
+	}
+	memory := in.Memory
+	if memory == "" {
+		memory = defaultPreviewMemory
+	}
+
+	if in.Port <= 0 {
+		return WebServicePreviewDeployResult{}, fmt.Errorf("port is required for a web-service preview")
+	}
+	if _, err := os.Stat(filepath.Join(in.BuildContextDir, dockerfile)); err != nil {
+		return WebServicePreviewDeployResult{}, fmt.Errorf("no %s in build context %s: %w", dockerfile, in.BuildContextDir, err)
+	}
+
+	res := WebServicePreviewDeployResult{Port: in.Port}
+
+	// 1. Build + push the image to a per-preview ECR repo.
+	repoURI, err := aws_utils.EnsureEcrRepository(in.EcrClient, ecrRepositoryName(in.OrgID, in.PreviewID), logsWriter)
+	if err != nil {
+		return res, fmt.Errorf("ensure ECR repository: %w", err)
+	}
+	res.EcrRepositoryUri = repoURI
+	imageURI := repoURI + ":" + imageTag
+	localTag := localImageName(in.OrgID, in.PreviewID, imageTag)
+	if err := buildAndPushImage(in.EcrClient, in.BuildContextDir, dockerfile, localTag, imageURI, in.BuildArgs, logsWriter); err != nil {
+		return res, fmt.Errorf("build and push image: %w", err)
+	}
+	res.ImageUri = imageURI
+
+	// 2. Shared per-org Fargate cluster.
+	clusterArn := in.ExistingClusterArn
+	if clusterArn == "" {
+		clusterArn, err = aws_utils.EnsureEcsCluster(in.EcsClient, clusterName(in.OrgID))
+		if err != nil {
+			return res, fmt.Errorf("ensure ECS cluster: %w", err)
+		}
+	}
+	res.ClusterArn = clusterArn
+
+	// 3. Task execution role (ECR pull + CloudWatch logs).
+	executionRoleArn := in.ExistingExecutionRoleArn
+	if executionRoleArn == "" {
+		executionRoleArn, err = aws_utils.EnsureEcsTaskExecutionRole(in.IamClient, executionRoleName(in.OrgID))
+		if err != nil {
+			return res, fmt.Errorf("ensure task execution role: %w", err)
+		}
+	}
+	res.ExecutionRoleArn = executionRoleArn
+
+	// 4. Resolve the VPC + public subnets the task and (Cw1b) ALB live in.
+	var network aws_utils.VpcNetwork
+	if in.VpcID != "" {
+		network, err = aws_utils.DescribeVpcNetwork(in.Ec2Client, in.VpcID)
+	} else {
+		network, err = aws_utils.DiscoverDefaultVpcNetwork(in.Ec2Client)
+	}
+	if err != nil {
+		return res, fmt.Errorf("resolve VPC network: %w", err)
+	}
+	if len(in.SubnetIDs) > 0 {
+		network.SubnetIDs = in.SubnetIDs
+	}
+	res.VpcID = network.VpcID
+
+	// 5. Shared per-org task security group: reachable from within the VPC (the
+	// ALB fronts it) on all TCP; default egress-all lets it pull ECR / reach out.
+	taskSgID, err := aws_utils.EnsureSecurityGroup(in.Ec2Client, taskSecurityGroupName(in.OrgID),
+		"deployment.io preview task security group", network.VpcID)
+	if err != nil {
+		return res, fmt.Errorf("ensure task security group: %w", err)
+	}
+	if err := aws_utils.AuthorizeTCPIngressFromCIDR(in.Ec2Client, taskSgID, network.VpcCidr, 0, 65535); err != nil {
+		return res, fmt.Errorf("authorize task security group ingress: %w", err)
+	}
+
+	// 6. Task definition (new revision each deploy so a redeploy re-pulls).
+	taskDefArn, err := aws_utils.RegisterWebServiceTaskDefinition(in.EcsClient, aws_utils.TaskDefinitionInput{
+		Family:           taskDefinitionFamily(in.PreviewID),
+		ContainerName:    containerName(in.PreviewID),
+		ImageURI:         imageURI,
+		Port:             in.Port,
+		Cpu:              cpu,
+		Memory:           memory,
+		ExecutionRoleArn: executionRoleArn,
+		EnvVars:          in.EnvVars,
+		LogGroup:         logGroupName(in.OrgID, in.PreviewID),
+		LogRegion:        in.Region,
+		LogStreamPrefix:  "application",
+		CpuArchitecture:  in.CpuArchitecture,
+		OSFamily:         in.OSFamily,
+	})
+	if err != nil {
+		return res, fmt.Errorf("register task definition: %w", err)
+	}
+	res.TaskDefinitionArn = taskDefArn
+
+	// 7. Target group (ECS registers the task ENI IP into it).
+	targetGroupArn := in.ExistingTargetGroupArn
+	if targetGroupArn == "" {
+		targetGroupArn, err = aws_utils.EnsureTargetGroup(in.ElbClient, aws_utils.TargetGroupInput{
+			Name:            targetGroupName(in.PreviewID),
+			Port:            in.Port,
+			VpcID:           network.VpcID,
+			HealthCheckPath: in.HealthCheckPath,
+		})
+		if err != nil {
+			return res, fmt.Errorf("ensure target group: %w", err)
+		}
+	}
+	res.TargetGroupArn = targetGroupArn
+
+	// 8. Create/update the Fargate service, wired to the target group.
+	serviceArn, err := aws_utils.CreateOrUpdateEcsService(in.EcsClient, aws_utils.EcsServiceInput{
+		ClusterArn:        clusterArn,
+		ServiceName:       ecsServiceName(in.PreviewID),
+		TaskDefinitionArn: taskDefArn,
+		ContainerName:     containerName(in.PreviewID),
+		Port:              in.Port,
+		TargetGroupArn:    targetGroupArn,
+		SubnetIDs:         network.SubnetIDs,
+		SecurityGroupIDs:  []string{taskSgID},
+		AssignPublicIP:    true, // public subnets, no NAT
+		WaitForStable:     !in.SkipServiceStableWait,
+	}, logsWriter)
+	if err != nil {
+		return res, fmt.Errorf("create/update ECS service: %w", err)
+	}
+	res.EcsServiceArn = serviceArn
+
+	// Cw1a confirmation: without an ALB the stable waiter can't run, so poll for a
+	// RUNNING task (best effort — a slow first image pull just returns false).
+	if in.SkipServiceStableWait {
+		running, werr := aws_utils.WaitForRunningTask(in.EcsClient, clusterArn, ecsServiceName(in.PreviewID), 5*time.Minute)
+		if werr != nil {
+			return res, fmt.Errorf("await running task: %w", werr)
+		}
+		res.TaskRunning = running
+		if running {
+			io.WriteString(logsWriter, "Preview task is running and registered with the target group\n")
+		} else {
+			io.WriteString(logsWriter, "Preview service created; task not yet running (still pulling/starting)\n")
+		}
+	}
+
+	return res, nil
+}
+
+// buildAndPushImage builds the image from the agent's build context and pushes it
+// to ECR — the runner (which holds the Docker daemon + cloud creds), not
+// agentbox, performs both, mirroring the production build_docker_image /
+// upload_docker_image_to_ecr commands.
+func buildAndPushImage(ecrClient *ecr.Client, buildContextDir, dockerfile, localTag, imageURI string, buildArgs map[string]string, logsWriter io.Writer) error {
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	if err != nil {
+		return err
+	}
+	defer cli.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	defer cancel()
+
+	tar, err := archive.TarWithOptions(buildContextDir, &archive.TarOptions{})
+	if err != nil {
+		return fmt.Errorf("tar build context: %w", err)
+	}
+	io.WriteString(logsWriter, "Building preview image\n")
+	buildRes, err := cli.ImageBuild(ctx, tar, types.ImageBuildOptions{
+		Dockerfile: dockerfile,
+		Tags:       []string{localTag},
+		Remove:     true,
+		BuildArgs:  toBuildArgPointers(buildArgs),
+	})
+	if err != nil {
+		return err
+	}
+	defer buildRes.Body.Close()
+	if err := streamDockerJSONLogs(buildRes.Body, logsWriter); err != nil {
+		return fmt.Errorf("image build: %w", err)
+	}
+
+	if err := cli.ImageTag(ctx, localTag, imageURI); err != nil {
+		return fmt.Errorf("tag image: %w", err)
+	}
+
+	auth, err := aws_utils.EcrDockerAuth(ecrClient)
+	if err != nil {
+		return fmt.Errorf("ecr auth: %w", err)
+	}
+	io.WriteString(logsWriter, fmt.Sprintf("Pushing preview image to ECR: %s\n", imageURI))
+	pushRes, err := cli.ImagePush(ctx, imageURI, image.PushOptions{RegistryAuth: auth})
+	if err != nil {
+		return err
+	}
+	defer pushRes.Close()
+	if err := streamDockerJSONLogs(pushRes, logsWriter); err != nil {
+		return fmt.Errorf("image push: %w", err)
+	}
+	return nil
+}
+
+// toBuildArgPointers adapts a plain build-arg map to docker's map[string]*string.
+func toBuildArgPointers(args map[string]string) map[string]*string {
+	if len(args) == 0 {
+		return nil
+	}
+	out := make(map[string]*string, len(args))
+	for k, v := range args {
+		v := v
+		out[k] = &v
+	}
+	return out
+}
+
+// streamDockerJSONLogs copies a docker build/push JSON-lines stream to the log
+// writer and returns an error if any line reports one. Both the build and push
+// streams surface failures as a trailing {"error":...} / {"errorDetail":...}
+// line rather than a non-nil call error.
+func streamDockerJSONLogs(r io.Reader, logsWriter io.Writer) error {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	var streamErr string
+	for scanner.Scan() {
+		line := scanner.Text()
+		var msg struct {
+			Stream      string `json:"stream"`
+			Status      string `json:"status"`
+			Error       string `json:"error"`
+			ErrorDetail struct {
+				Message string `json:"message"`
+			} `json:"errorDetail"`
+		}
+		if json.Unmarshal([]byte(line), &msg) == nil {
+			switch {
+			case msg.Stream != "":
+				io.WriteString(logsWriter, msg.Stream)
+			case msg.Status != "":
+				io.WriteString(logsWriter, msg.Status+"\n")
+			}
+			if msg.Error != "" {
+				streamErr = msg.Error
+			} else if msg.ErrorDetail.Message != "" {
+				streamErr = msg.ErrorDetail.Message
+			}
+		} else {
+			io.WriteString(logsWriter, line+"\n")
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+	if streamErr != "" {
+		return fmt.Errorf("%s", streamErr)
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Resource naming. Per-preview names key on the previewID (a 24-char deployment
+// id) with short prefixes so they stay under AWS's 32-char ALB/target-group
+// limit; shared names key on the org.
+// ---------------------------------------------------------------------------
+
+func ecrRepositoryName(orgID, previewID string) string { return "ecr-" + orgID + "-" + previewID }
+func localImageName(orgID, previewID, tag string) string {
+	return orgID + "-" + previewID + ":" + tag
+}
+func clusterName(orgID string) string              { return "ecs-" + orgID }
+func executionRoleName(orgID string) string        { return "pv-ecs-exec-" + orgID }
+func taskSecurityGroupName(orgID string) string    { return "pv-tasksg-" + orgID }
+func taskDefinitionFamily(previewID string) string { return "pv-td-" + previewID }
+func containerName(previewID string) string        { return "pv-c-" + previewID }
+func targetGroupName(previewID string) string      { return "pv-tg-" + previewID } // <=32 chars
+func ecsServiceName(previewID string) string       { return "pv-es-" + previewID }
+func logGroupName(orgID, previewID string) string  { return "pv/" + orgID + "/" + previewID }

--- a/agenttools/deploy_web_service_preview_test.go
+++ b/agenttools/deploy_web_service_preview_test.go
@@ -1,0 +1,90 @@
+package agenttools
+
+import (
+	"io"
+	"strings"
+	"testing"
+)
+
+// TestWebServiceResourceNames pins the naming scheme and, critically, guards the
+// AWS 32-char limit on target-group names for a standard 24-hex-char preview id.
+func TestWebServiceResourceNames(t *testing.T) {
+	const org = "org123"
+	const previewID = "64f0c2a1b3d4e5f6a7b8c9d0" // 24-char Mongo object id
+
+	if got := ecrRepositoryName(org, previewID); got != "ecr-org123-64f0c2a1b3d4e5f6a7b8c9d0" {
+		t.Errorf("ecrRepositoryName = %q", got)
+	}
+	if got := clusterName(org); got != "ecs-org123" {
+		t.Errorf("clusterName = %q", got)
+	}
+	if got := ecsServiceName(previewID); got != "pv-es-"+previewID {
+		t.Errorf("ecsServiceName = %q", got)
+	}
+	if got := localImageName(org, previewID, "1700000000"); got != "org123-64f0c2a1b3d4e5f6a7b8c9d0:1700000000" {
+		t.Errorf("localImageName = %q", got)
+	}
+
+	// Target-group names must stay <= 32 chars (AWS limit) for a 24-char id.
+	if got := targetGroupName(previewID); len(got) > 32 {
+		t.Errorf("targetGroupName %q is %d chars, exceeds AWS 32-char limit", got, len(got))
+	}
+}
+
+// TestToBuildArgPointers covers the map[string]string -> map[string]*string
+// adaptation docker expects (nil for empty, distinct pointers per value).
+func TestToBuildArgPointers(t *testing.T) {
+	if got := toBuildArgPointers(nil); got != nil {
+		t.Fatalf("toBuildArgPointers(nil) = %v, want nil", got)
+	}
+	args := map[string]string{"FOO": "1", "BAR": "2"}
+	got := toBuildArgPointers(args)
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2", len(got))
+	}
+	if got["FOO"] == nil || *got["FOO"] != "1" || got["BAR"] == nil || *got["BAR"] != "2" {
+		t.Fatalf("values not adapted correctly: %v", got)
+	}
+	// Each entry must point at its own value, not a shared loop variable.
+	if got["FOO"] == got["BAR"] {
+		t.Fatalf("build-arg pointers alias the same address")
+	}
+}
+
+// TestDeployWebServicePreviewValidation covers the two guards that fire before
+// any AWS client is touched, so they are safe to exercise with a zero-value input.
+func TestDeployWebServicePreviewValidation(t *testing.T) {
+	if _, err := DeployWebServicePreview(WebServicePreviewDeployInput{}, io.Discard); err == nil ||
+		!strings.Contains(err.Error(), "port") {
+		t.Fatalf("missing port: got err %v, want a port error", err)
+	}
+
+	_, err := DeployWebServicePreview(WebServicePreviewDeployInput{
+		Port:            8080,
+		BuildContextDir: "/nonexistent-preview-context-xyz",
+	}, io.Discard)
+	if err == nil || !strings.Contains(err.Error(), "Dockerfile") {
+		t.Fatalf("missing Dockerfile: got err %v, want a Dockerfile error", err)
+	}
+}
+
+// TestStreamDockerJSONLogs covers surfacing a build/push error line and copying
+// stream/status text through.
+func TestStreamDockerJSONLogs(t *testing.T) {
+	var buf strings.Builder
+	ok := `{"stream":"Step 1/2\n"}
+{"status":"Pushing"}`
+	if err := streamDockerJSONLogs(strings.NewReader(ok), &buf); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "Step 1/2") || !strings.Contains(buf.String(), "Pushing") {
+		t.Fatalf("stream/status not copied: %q", buf.String())
+	}
+
+	fail := `{"stream":"Step 1/2\n"}
+{"errorDetail":{"message":"boom"},"error":"boom"}`
+	if err := streamDockerJSONLogs(strings.NewReader(fail), io.Discard); err == nil ||
+		!strings.Contains(err.Error(), "boom") {
+		t.Fatalf("error line not surfaced: got %v", err)
+	}
+}

--- a/agenttools/deploy_web_service_preview_test.go
+++ b/agenttools/deploy_web_service_preview_test.go
@@ -4,6 +4,9 @@ import (
 	"io"
 	"strings"
 	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	cloudfrontTypes "github.com/aws/aws-sdk-go-v2/service/cloudfront/types"
 )
 
 // TestWebServiceResourceNames pins the naming scheme and, critically, guards the
@@ -28,6 +31,75 @@ func TestWebServiceResourceNames(t *testing.T) {
 	// Target-group names must stay <= 32 chars (AWS limit) for a 24-char id.
 	if got := targetGroupName(previewID); len(got) > 32 {
 		t.Errorf("targetGroupName %q is %d chars, exceeds AWS 32-char limit", got, len(got))
+	}
+
+	// ALB names must also stay <= 32 chars; the org id is hashed to fixed width.
+	if got := albName(org); len(got) > 32 {
+		t.Errorf("albName %q is %d chars, exceeds AWS 32-char limit", got, len(got))
+	}
+	if albName("a") == albName("b") {
+		t.Errorf("albName must differ per org")
+	}
+	if albName(org) != albName(org) {
+		t.Errorf("albName must be deterministic")
+	}
+	if got := orgHash(org); len(got) != 16 {
+		t.Errorf("orgHash = %q, want 16 hex chars", got)
+	}
+}
+
+// TestBuildPreviewWebServiceDistributionConfig pins the CloudFront config that
+// makes the shared-ALB routing work: an HTTP-only custom origin at the ALB DNS
+// carrying the X-Preview-Target routing header, caching off, full request
+// forwarded.
+func TestBuildPreviewWebServiceDistributionConfig(t *testing.T) {
+	const albDns = "pv-alb-abc.us-east-1.elb.amazonaws.com"
+	const previewID = "64f0c2a1b3d4e5f6a7b8c9d0"
+	cfg := buildPreviewWebServiceDistributionConfig(albDns, previewID)
+
+	if !aws.ToBool(cfg.Enabled) {
+		t.Errorf("distribution not enabled")
+	}
+	if aws.ToInt32(cfg.Origins.Quantity) != 1 || len(cfg.Origins.Items) != 1 {
+		t.Fatalf("want exactly one origin, got %d", len(cfg.Origins.Items))
+	}
+	origin := cfg.Origins.Items[0]
+	if aws.ToString(origin.DomainName) != albDns {
+		t.Errorf("origin domain = %q, want the ALB DNS %q", aws.ToString(origin.DomainName), albDns)
+	}
+	if origin.CustomOriginConfig == nil {
+		t.Fatalf("want a CustomOriginConfig (ALB origin), got nil")
+	}
+	if origin.CustomOriginConfig.OriginProtocolPolicy != cloudfrontTypes.OriginProtocolPolicyHttpOnly {
+		t.Errorf("origin protocol = %v, want http-only", origin.CustomOriginConfig.OriginProtocolPolicy)
+	}
+	if origin.S3OriginConfig != nil {
+		t.Errorf("web-service origin must not be an S3/OAC origin")
+	}
+
+	// The X-Preview-Target origin custom header is the ALB routing key.
+	if origin.CustomHeaders == nil || aws.ToInt32(origin.CustomHeaders.Quantity) != 1 {
+		t.Fatalf("want exactly one origin custom header")
+	}
+	h := origin.CustomHeaders.Items[0]
+	if aws.ToString(h.HeaderName) != previewTargetHeader || aws.ToString(h.HeaderValue) != previewID {
+		t.Errorf("custom header = %q:%q, want %q:%q",
+			aws.ToString(h.HeaderName), aws.ToString(h.HeaderValue), previewTargetHeader, previewID)
+	}
+
+	b := cfg.DefaultCacheBehavior
+	if aws.ToString(b.TargetOriginId) != aws.ToString(origin.Id) {
+		t.Errorf("behavior target origin %q != origin id %q", aws.ToString(b.TargetOriginId), aws.ToString(origin.Id))
+	}
+	if aws.ToString(b.CachePolicyId) != cachingDisabledPolicyID {
+		t.Errorf("cache policy = %q, want CachingDisabled", aws.ToString(b.CachePolicyId))
+	}
+	if aws.ToString(b.OriginRequestPolicyId) != allViewerOriginRequestPolicyID {
+		t.Errorf("origin request policy = %q, want AllViewer", aws.ToString(b.OriginRequestPolicyId))
+	}
+	// A web service needs write methods, not just GET/HEAD.
+	if aws.ToInt32(b.AllowedMethods.Quantity) != 7 {
+		t.Errorf("allowed methods = %d, want all 7", aws.ToInt32(b.AllowedMethods.Quantity))
 	}
 }
 

--- a/utils/aws_utils/web_service.go
+++ b/utils/aws_utils/web_service.go
@@ -1,0 +1,663 @@
+package aws_utils
+
+// web_service.go holds the arg-based AWS primitives that back the in-process
+// web-service preview deploy (agenttools.DeployWebServicePreview). It is the
+// web-service twin of static_site.go: every helper takes explicit arguments +
+// an already-built AWS client, with NO coupling to the job `parameters` map, so
+// the preview deploy core can reuse them the way the static preview reuses the
+// S3/CloudFront helpers.
+//
+// These are written FRESH against the AWS SDK (referencing, not refactoring, the
+// production monolith jobs/commands/deploy_aws_web_service.go). The production
+// path is per-service (one ALB per deployment, private subnets + NAT + Service
+// Connect); the preview is deliberately leaner and self-contained:
+//
+//   - Fargate tasks run in the account's DEFAULT VPC public subnets with a public
+//     IP (AssignPublicIp=ENABLED) so they pull the ECR image + reach the internet
+//     with NO NAT gateway (a NAT's idle charge is exactly what a cost-optimized
+//     preview avoids).
+//   - One shared per-org task security group (ingress from the VPC CIDR) rather
+//     than a per-service SG + default-SG mutation.
+//   - No Cloud Map / Service Connect (the preview is reached through the shared
+//     ALB + CloudFront, not service-to-service internal DNS).
+//
+// Cw1a covers the ECS half (ECR, cluster, execution role, VPC/subnets, task SG,
+// task definition, target group, service). Cw1b appends the ingress half (shared
+// ALB + header-routed listener rule).
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2Types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/aws/aws-sdk-go-v2/service/ecr"
+	ecrTypes "github.com/aws/aws-sdk-go-v2/service/ecr/types"
+	"github.com/aws/aws-sdk-go-v2/service/ecs"
+	ecsTypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
+	elb "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
+	elbTypes "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamTypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/aws/smithy-go"
+)
+
+// awsCreatedByTag is the marker every production resource carries; previews reuse
+// it so an operator (and the GC sweep) can recognize deployment.io-owned infra.
+const awsCreatedByTag = "deployment.io"
+
+// apiErrCodeIs reports whether err is (or wraps) an AWS API error with one of the
+// given codes — used to make create/authorize calls idempotent (a concurrent or
+// retried first-deploy hits "already exists" instead of a real failure).
+func apiErrCodeIs(err error, codes ...string) bool {
+	var ae smithy.APIError
+	if !errors.As(err, &ae) {
+		return false
+	}
+	for _, c := range codes {
+		if ae.ErrorCode() == c {
+			return true
+		}
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// ECR
+// ---------------------------------------------------------------------------
+
+// EnsureEcrRepository find-or-creates an ECR repository by name and returns its
+// URI. Mirrors the monolith's createEcrRepositoryIfNeeded but arg-based and
+// without the control-plane persistence side effects.
+func EnsureEcrRepository(ecrClient *ecr.Client, repositoryName string, logsWriter io.Writer) (string, error) {
+	describeOut, _ := ecrClient.DescribeRepositories(context.TODO(), &ecr.DescribeRepositoriesInput{
+		RepositoryNames: []string{repositoryName},
+	})
+	if describeOut != nil {
+		for _, repo := range describeOut.Repositories {
+			if aws.ToString(repo.RepositoryName) == repositoryName {
+				return aws.ToString(repo.RepositoryUri), nil
+			}
+		}
+	}
+
+	createOut, err := ecrClient.CreateRepository(context.TODO(), &ecr.CreateRepositoryInput{
+		RepositoryName:     aws.String(repositoryName),
+		ImageTagMutability: ecrTypes.ImageTagMutabilityMutable,
+		Tags: []ecrTypes.Tag{
+			{Key: aws.String("Name"), Value: aws.String(repositoryName)},
+			{Key: aws.String("created by"), Value: aws.String(awsCreatedByTag)},
+		},
+	})
+	if err != nil {
+		// A concurrent first-deploy may have won the race — re-describe.
+		if apiErrCodeIs(err, "RepositoryAlreadyExistsException") {
+			describeOut, derr := ecrClient.DescribeRepositories(context.TODO(), &ecr.DescribeRepositoriesInput{
+				RepositoryNames: []string{repositoryName},
+			})
+			if derr == nil && describeOut != nil && len(describeOut.Repositories) > 0 {
+				return aws.ToString(describeOut.Repositories[0].RepositoryUri), nil
+			}
+		}
+		return "", err
+	}
+	io.WriteString(logsWriter, fmt.Sprintf("Created ECR repository: %s\n", aws.ToString(createOut.Repository.RepositoryUri)))
+	return aws.ToString(createOut.Repository.RepositoryUri), nil
+}
+
+// EcrDockerAuth returns a base64-encoded docker registry auth string for the
+// account's ECR registry (the form docker's ImagePush RegistryAuth expects).
+// Mirrors the monolith's GetAuthorizationToken -> "AWS:<token>" decoding.
+func EcrDockerAuth(ecrClient *ecr.Client) (string, error) {
+	out, err := ecrClient.GetAuthorizationToken(context.TODO(), &ecr.GetAuthorizationTokenInput{})
+	if err != nil {
+		return "", err
+	}
+	if len(out.AuthorizationData) < 1 {
+		return "", fmt.Errorf("no auth token from ECR")
+	}
+	decoded, err := base64.StdEncoding.DecodeString(aws.ToString(out.AuthorizationData[0].AuthorizationToken))
+	if err != nil {
+		return "", err
+	}
+	// The decoded token is "AWS:<password>".
+	full := string(decoded)
+	pw := full
+	for i := 0; i < len(full); i++ {
+		if full[i] == ':' {
+			pw = full[i+1:]
+			break
+		}
+	}
+	authJSON, err := json.Marshal(map[string]string{"username": "AWS", "password": pw})
+	if err != nil {
+		return "", err
+	}
+	return base64.URLEncoding.EncodeToString(authJSON), nil
+}
+
+// ---------------------------------------------------------------------------
+// ECS cluster + task execution role
+// ---------------------------------------------------------------------------
+
+// EnsureEcsCluster find-or-creates a FARGATE ECS cluster by name and returns its
+// ARN. Mirrors create_ecs_cluster.go's createEcsClusterIfNeeded (an INACTIVE
+// cluster of the same name is treated as absent and recreated).
+func EnsureEcsCluster(ecsClient *ecs.Client, clusterName string) (string, error) {
+	describeOut, err := ecsClient.DescribeClusters(context.TODO(), &ecs.DescribeClustersInput{
+		Clusters: []string{clusterName},
+	})
+	if err == nil && describeOut != nil {
+		for _, c := range describeOut.Clusters {
+			if aws.ToString(c.ClusterName) == clusterName && aws.ToString(c.Status) != "INACTIVE" {
+				return aws.ToString(c.ClusterArn), nil
+			}
+		}
+	}
+
+	createOut, err := ecsClient.CreateCluster(context.TODO(), &ecs.CreateClusterInput{
+		ClusterName:       aws.String(clusterName),
+		CapacityProviders: []string{"FARGATE"},
+		Tags:              []ecsTypes.Tag{{Key: aws.String("created by"), Value: aws.String(awsCreatedByTag)}},
+	})
+	if err != nil {
+		return "", err
+	}
+	return aws.ToString(createOut.Cluster.ClusterArn), nil
+}
+
+// ecsTaskExecutionAssumeRolePolicy lets ECS tasks assume the execution role.
+const ecsTaskExecutionAssumeRolePolicy = `{
+  "Version": "2012-10-17",
+  "Statement": [{"Effect": "Allow", "Principal": {"Service": "ecs-tasks.amazonaws.com"}, "Action": "sts:AssumeRole"}]
+}`
+
+// EnsureEcsTaskExecutionRole find-or-creates an ECS task execution role and
+// returns its ARN. The role lets the task pull from ECR and ship logs to
+// CloudWatch; CloudWatchFullAccess is attached in addition to the managed ECS
+// execution policy because the awslogs driver is configured with
+// awslogs-create-group=true (which needs logs:CreateLogGroup). IAM is global, so
+// a per-org role is reused across regions/previews.
+func EnsureEcsTaskExecutionRole(iamClient *iam.Client, roleName string) (string, error) {
+	getOut, err := iamClient.GetRole(context.TODO(), &iam.GetRoleInput{RoleName: aws.String(roleName)})
+	if err == nil && getOut.Role != nil {
+		return aws.ToString(getOut.Role.Arn), nil
+	}
+	if err != nil && !apiErrCodeIs(err, "NoSuchEntity", "NoSuchEntityException") {
+		return "", err
+	}
+
+	createOut, err := iamClient.CreateRole(context.TODO(), &iam.CreateRoleInput{
+		RoleName:                 aws.String(roleName),
+		AssumeRolePolicyDocument: aws.String(ecsTaskExecutionAssumeRolePolicy),
+		Description:              aws.String("ECS task execution role for deployment.io previews"),
+		Tags:                     []iamTypes.Tag{{Key: aws.String("created by"), Value: aws.String(awsCreatedByTag)}},
+	})
+	if err != nil {
+		// Lost the create race — fetch the existing role.
+		if apiErrCodeIs(err, "EntityAlreadyExists", "EntityAlreadyExistsException") {
+			getOut, gerr := iamClient.GetRole(context.TODO(), &iam.GetRoleInput{RoleName: aws.String(roleName)})
+			if gerr == nil && getOut.Role != nil {
+				return aws.ToString(getOut.Role.Arn), nil
+			}
+		}
+		return "", err
+	}
+
+	for _, policyArn := range []string{
+		"arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy",
+		"arn:aws:iam::aws:policy/CloudWatchFullAccess",
+	} {
+		if _, err := iamClient.AttachRolePolicy(context.TODO(), &iam.AttachRolePolicyInput{
+			RoleName:  aws.String(roleName),
+			PolicyArn: aws.String(policyArn),
+		}); err != nil {
+			return "", fmt.Errorf("attach %s: %w", policyArn, err)
+		}
+	}
+	return aws.ToString(createOut.Role.Arn), nil
+}
+
+// ---------------------------------------------------------------------------
+// VPC / subnets
+// ---------------------------------------------------------------------------
+
+// VpcNetwork is the resolved VPC a preview deploys into: the VPC id, its CIDR
+// (for intra-VPC security-group rules), and public subnets across distinct AZs
+// (Fargate tasks + the shared ALB both live here).
+type VpcNetwork struct {
+	VpcID     string
+	VpcCidr   string
+	SubnetIDs []string
+}
+
+// DiscoverDefaultVpcNetwork resolves the account's default VPC in the client's
+// region and its public subnets. The default VPC's subnets have an
+// internet-gateway route, so tasks with a public IP reach ECR/the internet
+// without a NAT. Callers that have deleted their default VPC should pass an
+// explicit VpcID (see DescribeVpcNetwork).
+func DiscoverDefaultVpcNetwork(ec2Client *ec2.Client) (VpcNetwork, error) {
+	out, err := ec2Client.DescribeVpcs(context.TODO(), &ec2.DescribeVpcsInput{
+		Filters: []ec2Types.Filter{{Name: aws.String("isDefault"), Values: []string{"true"}}},
+	})
+	if err != nil {
+		return VpcNetwork{}, err
+	}
+	if len(out.Vpcs) == 0 {
+		return VpcNetwork{}, fmt.Errorf("no default VPC in this region — supply an explicit VpcID for the preview")
+	}
+	return DescribeVpcNetwork(ec2Client, aws.ToString(out.Vpcs[0].VpcId))
+}
+
+// DescribeVpcNetwork resolves an explicit VPC's CIDR + public subnets (one per
+// AZ, preferring auto-assign-public-IP subnets). Used when the caller supplies a
+// VpcID instead of relying on the default VPC.
+func DescribeVpcNetwork(ec2Client *ec2.Client, vpcID string) (VpcNetwork, error) {
+	vpcsOut, err := ec2Client.DescribeVpcs(context.TODO(), &ec2.DescribeVpcsInput{VpcIds: []string{vpcID}})
+	if err != nil {
+		return VpcNetwork{}, err
+	}
+	if len(vpcsOut.Vpcs) == 0 {
+		return VpcNetwork{}, fmt.Errorf("VPC %s not found", vpcID)
+	}
+	cidr := aws.ToString(vpcsOut.Vpcs[0].CidrBlock)
+
+	subnetsOut, err := ec2Client.DescribeSubnets(context.TODO(), &ec2.DescribeSubnetsInput{
+		Filters: []ec2Types.Filter{{Name: aws.String("vpc-id"), Values: []string{vpcID}}},
+	})
+	if err != nil {
+		return VpcNetwork{}, err
+	}
+
+	// One subnet per AZ (an ALB needs >=2 AZs), preferring public (auto-assign
+	// public IP) subnets so a NAT-less task can still egress.
+	perAZ := map[string]string{}     // az -> subnet id (a public one if seen)
+	perAZPublic := map[string]bool{} // az -> whether the chosen subnet is public
+	for _, sn := range subnetsOut.Subnets {
+		az := aws.ToString(sn.AvailabilityZone)
+		id := aws.ToString(sn.SubnetId)
+		isPublic := aws.ToBool(sn.MapPublicIpOnLaunch)
+		if _, ok := perAZ[az]; !ok || (isPublic && !perAZPublic[az]) {
+			perAZ[az] = id
+			perAZPublic[az] = isPublic
+		}
+	}
+	if len(perAZ) == 0 {
+		return VpcNetwork{}, fmt.Errorf("no subnets found in VPC %s", vpcID)
+	}
+	azs := make([]string, 0, len(perAZ))
+	for az := range perAZ {
+		azs = append(azs, az)
+	}
+	sort.Strings(azs) // deterministic subnet ordering
+	subnetIDs := make([]string, 0, len(azs))
+	for _, az := range azs {
+		subnetIDs = append(subnetIDs, perAZ[az])
+	}
+	return VpcNetwork{VpcID: vpcID, VpcCidr: cidr, SubnetIDs: subnetIDs}, nil
+}
+
+// ---------------------------------------------------------------------------
+// Security groups
+// ---------------------------------------------------------------------------
+
+// EnsureSecurityGroup find-or-creates a security group by name within a VPC and
+// returns its id. New groups carry the default allow-all egress rule, which is
+// all a preview needs (tasks egress to ECR/internet; the ALB egresses to tasks).
+func EnsureSecurityGroup(ec2Client *ec2.Client, name, description, vpcID string) (string, error) {
+	describeOut, err := ec2Client.DescribeSecurityGroups(context.TODO(), &ec2.DescribeSecurityGroupsInput{
+		Filters: []ec2Types.Filter{
+			{Name: aws.String("group-name"), Values: []string{name}},
+			{Name: aws.String("vpc-id"), Values: []string{vpcID}},
+		},
+	})
+	if err == nil && describeOut != nil && len(describeOut.SecurityGroups) > 0 {
+		return aws.ToString(describeOut.SecurityGroups[0].GroupId), nil
+	}
+
+	createOut, err := ec2Client.CreateSecurityGroup(context.TODO(), &ec2.CreateSecurityGroupInput{
+		GroupName:   aws.String(name),
+		Description: aws.String(description),
+		VpcId:       aws.String(vpcID),
+		TagSpecifications: []ec2Types.TagSpecification{{
+			ResourceType: ec2Types.ResourceTypeSecurityGroup,
+			Tags: []ec2Types.Tag{
+				{Key: aws.String("Name"), Value: aws.String(name)},
+				{Key: aws.String("created by"), Value: aws.String(awsCreatedByTag)},
+			},
+		}},
+	})
+	if err != nil {
+		// Lost the create race — re-describe.
+		if apiErrCodeIs(err, "InvalidGroup.Duplicate") {
+			describeOut, derr := ec2Client.DescribeSecurityGroups(context.TODO(), &ec2.DescribeSecurityGroupsInput{
+				Filters: []ec2Types.Filter{
+					{Name: aws.String("group-name"), Values: []string{name}},
+					{Name: aws.String("vpc-id"), Values: []string{vpcID}},
+				},
+			})
+			if derr == nil && describeOut != nil && len(describeOut.SecurityGroups) > 0 {
+				return aws.ToString(describeOut.SecurityGroups[0].GroupId), nil
+			}
+		}
+		return "", err
+	}
+	return aws.ToString(createOut.GroupId), nil
+}
+
+// AuthorizeTCPIngressFromCIDR adds a TCP ingress rule (idempotent) allowing the
+// given CIDR to reach [fromPort,toPort] on the security group. A duplicate rule
+// (redeploy / concurrent) is treated as success.
+func AuthorizeTCPIngressFromCIDR(ec2Client *ec2.Client, sgID, cidr string, fromPort, toPort int32) error {
+	_, err := ec2Client.AuthorizeSecurityGroupIngress(context.TODO(), &ec2.AuthorizeSecurityGroupIngressInput{
+		GroupId: aws.String(sgID),
+		IpPermissions: []ec2Types.IpPermission{{
+			IpProtocol: aws.String("tcp"),
+			FromPort:   aws.Int32(fromPort),
+			ToPort:     aws.Int32(toPort),
+			IpRanges:   []ec2Types.IpRange{{CidrIp: aws.String(cidr), Description: aws.String("deployment.io preview")}},
+		}},
+	})
+	if err != nil && !apiErrCodeIs(err, "InvalidPermission.Duplicate") {
+		return err
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Task definition
+// ---------------------------------------------------------------------------
+
+// TaskDefinitionInput describes the Fargate task definition for a preview.
+type TaskDefinitionInput struct {
+	Family           string
+	ContainerName    string
+	ImageURI         string // ECR URI including the tag
+	Port             int32
+	Cpu              string // Fargate CPU units, e.g. "256"
+	Memory           string // Fargate memory (MiB), e.g. "512"
+	ExecutionRoleArn string
+	EnvVars          map[string]string
+	LogGroup         string
+	LogRegion        string
+	LogStreamPrefix  string
+	CpuArchitecture  ecsTypes.CPUArchitecture // default X86_64
+	OSFamily         ecsTypes.OSFamily        // default LINUX
+}
+
+// envMapToKeyValuePairs converts an env map to ECS KeyValuePairs, sorted by key
+// so a redeploy of the same env produces a byte-identical container definition
+// (and the output is deterministic for tests).
+func envMapToKeyValuePairs(env map[string]string) []ecsTypes.KeyValuePair {
+	if len(env) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(env))
+	for k := range env {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	pairs := make([]ecsTypes.KeyValuePair, 0, len(keys))
+	for _, k := range keys {
+		pairs = append(pairs, ecsTypes.KeyValuePair{Name: aws.String(k), Value: aws.String(env[k])})
+	}
+	return pairs
+}
+
+// RegisterWebServiceTaskDefinition registers a new Fargate task-definition
+// revision and returns its ARN. Env vars are injected as plaintext KeyValuePairs
+// exactly as the production monolith does (they arrive already resolved from the
+// runner, which is why the agent never sees them — the runner, not agentbox,
+// performs the injection).
+func RegisterWebServiceTaskDefinition(ecsClient *ecs.Client, in TaskDefinitionInput) (string, error) {
+	cpuArch := in.CpuArchitecture
+	if cpuArch == "" {
+		cpuArch = ecsTypes.CPUArchitectureX8664
+	}
+	osFamily := in.OSFamily
+	if osFamily == "" {
+		osFamily = ecsTypes.OSFamilyLinux
+	}
+
+	container := ecsTypes.ContainerDefinition{
+		Name:         aws.String(in.ContainerName),
+		Image:        aws.String(in.ImageURI),
+		Essential:    aws.Bool(true),
+		Environment:  envMapToKeyValuePairs(in.EnvVars),
+		PortMappings: []ecsTypes.PortMapping{{ContainerPort: aws.Int32(in.Port), Protocol: ecsTypes.TransportProtocolTcp}},
+		LogConfiguration: &ecsTypes.LogConfiguration{
+			LogDriver: ecsTypes.LogDriverAwslogs,
+			Options: map[string]string{
+				"awslogs-create-group":  "true",
+				"awslogs-group":         in.LogGroup,
+				"awslogs-region":        in.LogRegion,
+				"awslogs-stream-prefix": in.LogStreamPrefix,
+			},
+		},
+	}
+
+	out, err := ecsClient.RegisterTaskDefinition(context.TODO(), &ecs.RegisterTaskDefinitionInput{
+		Family:                  aws.String(in.Family),
+		ContainerDefinitions:    []ecsTypes.ContainerDefinition{container},
+		Cpu:                     aws.String(in.Cpu),
+		Memory:                  aws.String(in.Memory),
+		ExecutionRoleArn:        aws.String(in.ExecutionRoleArn),
+		NetworkMode:             ecsTypes.NetworkModeAwsvpc,
+		RequiresCompatibilities: []ecsTypes.Compatibility{ecsTypes.CompatibilityFargate},
+		RuntimePlatform: &ecsTypes.RuntimePlatform{
+			CpuArchitecture:       cpuArch,
+			OperatingSystemFamily: osFamily,
+		},
+		Tags: []ecsTypes.Tag{{Key: aws.String("created by"), Value: aws.String(awsCreatedByTag)}},
+	})
+	if err != nil {
+		return "", err
+	}
+	return aws.ToString(out.TaskDefinition.TaskDefinitionArn), nil
+}
+
+// ---------------------------------------------------------------------------
+// Target group
+// ---------------------------------------------------------------------------
+
+// TargetGroupInput describes an ip-target-type target group for a preview
+// service.
+type TargetGroupInput struct {
+	Name            string
+	Port            int32
+	VpcID           string
+	HealthCheckPath string // default "/"
+}
+
+// EnsureTargetGroup find-or-creates an ip target group and returns its ARN.
+// Target type is ip (required for Fargate/awsvpc); ECS registers the task's ENI
+// IP into it via the service's LoadBalancers block.
+func EnsureTargetGroup(elbClient *elb.Client, in TargetGroupInput) (string, error) {
+	describeOut, err := elbClient.DescribeTargetGroups(context.TODO(), &elb.DescribeTargetGroupsInput{
+		Names: []string{in.Name},
+	})
+	if err == nil && describeOut != nil && len(describeOut.TargetGroups) > 0 {
+		return aws.ToString(describeOut.TargetGroups[0].TargetGroupArn), nil
+	}
+	if err != nil && !apiErrCodeIs(err, "TargetGroupNotFound") {
+		return "", err
+	}
+
+	healthPath := in.HealthCheckPath
+	if healthPath == "" {
+		healthPath = "/"
+	}
+	createOut, err := elbClient.CreateTargetGroup(context.TODO(), &elb.CreateTargetGroupInput{
+		Name:                       aws.String(in.Name),
+		Port:                       aws.Int32(in.Port),
+		Protocol:                   elbTypes.ProtocolEnumHttp,
+		TargetType:                 elbTypes.TargetTypeEnumIp,
+		VpcId:                      aws.String(in.VpcID),
+		HealthCheckEnabled:         aws.Bool(true),
+		HealthCheckProtocol:        elbTypes.ProtocolEnumHttp,
+		HealthCheckPath:            aws.String(healthPath),
+		HealthCheckIntervalSeconds: aws.Int32(30),
+		HealthCheckTimeoutSeconds:  aws.Int32(10),
+		HealthyThresholdCount:      aws.Int32(2),
+		UnhealthyThresholdCount:    aws.Int32(5),
+		Matcher:                    &elbTypes.Matcher{HttpCode: aws.String("200-399")},
+		Tags: []elbTypes.Tag{
+			{Key: aws.String("Name"), Value: aws.String(in.Name)},
+			{Key: aws.String("created by"), Value: aws.String(awsCreatedByTag)},
+		},
+	})
+	if err != nil {
+		return "", err
+	}
+	return aws.ToString(createOut.TargetGroups[0].TargetGroupArn), nil
+}
+
+// ---------------------------------------------------------------------------
+// ECS service
+// ---------------------------------------------------------------------------
+
+// EcsServiceInput describes the Fargate service for a preview.
+type EcsServiceInput struct {
+	ClusterArn        string
+	ServiceName       string
+	TaskDefinitionArn string
+	ContainerName     string
+	Port              int32
+	TargetGroupArn    string // wires container:port -> target group
+	SubnetIDs         []string
+	SecurityGroupIDs  []string
+	AssignPublicIP    bool
+	// WaitForStable blocks on the service reaching a stable state. It only
+	// succeeds once the target group is health-checked by a load balancer, so
+	// Cw1a (no ALB yet) leaves it false; Cw1b sets it once the listener rule
+	// attaches the target group to the shared ALB.
+	WaitForStable bool
+}
+
+// CreateOrUpdateEcsService creates the service if absent, else updates it to the
+// new task definition (forcing a fresh deployment). Returns the service ARN.
+func CreateOrUpdateEcsService(ecsClient *ecs.Client, in EcsServiceInput, logsWriter io.Writer) (string, error) {
+	describeOut, err := ecsClient.DescribeServices(context.TODO(), &ecs.DescribeServicesInput{
+		Cluster:  aws.String(in.ClusterArn),
+		Services: []string{in.ServiceName},
+	})
+	if err != nil {
+		return "", err
+	}
+	var existingArn string
+	for _, svc := range describeOut.Services {
+		if aws.ToString(svc.ServiceName) == in.ServiceName {
+			status := aws.ToString(svc.Status)
+			if status == "ACTIVE" || status == "DRAINING" {
+				existingArn = aws.ToString(svc.ServiceArn)
+			}
+		}
+	}
+
+	if existingArn != "" {
+		io.WriteString(logsWriter, fmt.Sprintf("Updating preview service: %s\n", in.ServiceName))
+		if _, err := ecsClient.UpdateService(context.TODO(), &ecs.UpdateServiceInput{
+			Cluster:            aws.String(in.ClusterArn),
+			Service:            aws.String(in.ServiceName),
+			TaskDefinition:     aws.String(in.TaskDefinitionArn),
+			DesiredCount:       aws.Int32(1),
+			ForceNewDeployment: true,
+			PropagateTags:      ecsTypes.PropagateTagsTaskDefinition,
+		}); err != nil {
+			return "", err
+		}
+		if err := waitEcsServiceStable(ecsClient, in, logsWriter); err != nil {
+			return "", err
+		}
+		return existingArn, nil
+	}
+
+	var loadBalancers []ecsTypes.LoadBalancer
+	var gracePeriod *int32
+	if in.TargetGroupArn != "" {
+		loadBalancers = []ecsTypes.LoadBalancer{{
+			ContainerName:  aws.String(in.ContainerName),
+			ContainerPort:  aws.Int32(in.Port),
+			TargetGroupArn: aws.String(in.TargetGroupArn),
+		}}
+		gracePeriod = aws.Int32(60)
+	}
+	assignPublicIP := ecsTypes.AssignPublicIpDisabled
+	if in.AssignPublicIP {
+		assignPublicIP = ecsTypes.AssignPublicIpEnabled
+	}
+
+	io.WriteString(logsWriter, fmt.Sprintf("Creating preview service: %s\n", in.ServiceName))
+	createOut, err := ecsClient.CreateService(context.TODO(), &ecs.CreateServiceInput{
+		ServiceName:                   aws.String(in.ServiceName),
+		Cluster:                       aws.String(in.ClusterArn),
+		TaskDefinition:                aws.String(in.TaskDefinitionArn),
+		DesiredCount:                  aws.Int32(1),
+		LaunchType:                    ecsTypes.LaunchTypeFargate,
+		SchedulingStrategy:            ecsTypes.SchedulingStrategyReplica,
+		LoadBalancers:                 loadBalancers,
+		HealthCheckGracePeriodSeconds: gracePeriod,
+		PropagateTags:                 ecsTypes.PropagateTagsTaskDefinition,
+		NetworkConfiguration: &ecsTypes.NetworkConfiguration{
+			AwsvpcConfiguration: &ecsTypes.AwsVpcConfiguration{
+				Subnets:        in.SubnetIDs,
+				SecurityGroups: in.SecurityGroupIDs,
+				AssignPublicIp: assignPublicIP,
+			},
+		},
+		Tags: []ecsTypes.Tag{{Key: aws.String("created by"), Value: aws.String(awsCreatedByTag)}},
+	})
+	if err != nil {
+		return "", err
+	}
+	if err := waitEcsServiceStable(ecsClient, in, logsWriter); err != nil {
+		return "", err
+	}
+	return aws.ToString(createOut.Service.ServiceArn), nil
+}
+
+// waitEcsServiceStable optionally blocks until the service is stable.
+func waitEcsServiceStable(ecsClient *ecs.Client, in EcsServiceInput, logsWriter io.Writer) error {
+	if !in.WaitForStable {
+		return nil
+	}
+	io.WriteString(logsWriter, fmt.Sprintf("Waiting for preview service to stabilize: %s\n", in.ServiceName))
+	waiter := ecs.NewServicesStableWaiter(ecsClient)
+	return waiter.Wait(context.TODO(), &ecs.DescribeServicesInput{
+		Cluster:  aws.String(in.ClusterArn),
+		Services: []string{in.ServiceName},
+	}, 15*time.Minute)
+}
+
+// WaitForRunningTask polls the service until it reports at least one RUNNING
+// task or the deadline elapses. Cw1a uses this in place of the stable waiter
+// (which can't succeed before an ALB health-checks the target group) so the
+// deploy core can confirm the task actually launched.
+func WaitForRunningTask(ecsClient *ecs.Client, clusterArn, serviceName string, timeout time.Duration) (bool, error) {
+	deadline := time.Now().Add(timeout)
+	for {
+		out, err := ecsClient.DescribeServices(context.TODO(), &ecs.DescribeServicesInput{
+			Cluster:  aws.String(clusterArn),
+			Services: []string{serviceName},
+		})
+		if err != nil {
+			return false, err
+		}
+		for _, svc := range out.Services {
+			if aws.ToString(svc.ServiceName) == serviceName && svc.RunningCount >= 1 {
+				return true, nil
+			}
+		}
+		if time.Now().After(deadline) {
+			return false, nil
+		}
+		time.Sleep(10 * time.Second)
+	}
+}

--- a/utils/aws_utils/web_service.go
+++ b/utils/aws_utils/web_service.go
@@ -33,6 +33,7 @@ import (
 	"fmt"
 	"io"
 	"sort"
+	"strconv"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -660,4 +661,177 @@ func WaitForRunningTask(ecsClient *ecs.Client, clusterArn, serviceName string, t
 		}
 		time.Sleep(10 * time.Second)
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Shared ALB + header-routed listener rule (ingress half)
+// ---------------------------------------------------------------------------
+
+// SharedAlbInput describes the one-per-org+region ALB that fronts every
+// web-service preview.
+type SharedAlbInput struct {
+	AlbName   string
+	AlbSgName string
+	VpcID     string
+	SubnetIDs []string
+}
+
+// SharedAlbResult carries the shared ALB's resources.
+type SharedAlbResult struct {
+	LoadBalancerArn string
+	LoadBalancerDns string
+	ListenerArn     string // the HTTP:80 listener
+	SecurityGroupID string
+}
+
+// EnsureSharedAlb find-or-creates the shared, internet-facing ALB + its security
+// group (inbound 80 from anywhere — CloudFront reaches the origin over HTTP) + an
+// HTTP:80 listener whose DEFAULT action is a fixed 404 (a request without a
+// matching X-Preview-Target header belongs to no preview). Per-preview target
+// groups attach to this one listener via header-routed rules
+// (EnsurePreviewListenerRule). One ALB serves every preview in the org+region,
+// which is why it's found-or-created by a stable name rather than per preview.
+func EnsureSharedAlb(elbClient *elb.Client, ec2Client *ec2.Client, in SharedAlbInput) (SharedAlbResult, error) {
+	var res SharedAlbResult
+
+	albSgID, err := EnsureSecurityGroup(ec2Client, in.AlbSgName, "deployment.io preview shared ALB", in.VpcID)
+	if err != nil {
+		return res, fmt.Errorf("ensure ALB security group: %w", err)
+	}
+	if err := AuthorizeTCPIngressFromCIDR(ec2Client, albSgID, "0.0.0.0/0", 80, 80); err != nil {
+		return res, fmt.Errorf("authorize ALB ingress: %w", err)
+	}
+	res.SecurityGroupID = albSgID
+
+	// Find-or-create the ALB.
+	descOut, err := elbClient.DescribeLoadBalancers(context.TODO(), &elb.DescribeLoadBalancersInput{Names: []string{in.AlbName}})
+	if err == nil && descOut != nil && len(descOut.LoadBalancers) > 0 {
+		res.LoadBalancerArn = aws.ToString(descOut.LoadBalancers[0].LoadBalancerArn)
+		res.LoadBalancerDns = aws.ToString(descOut.LoadBalancers[0].DNSName)
+	} else if err != nil && !apiErrCodeIs(err, "LoadBalancerNotFound") {
+		return res, err
+	}
+	if res.LoadBalancerArn == "" {
+		createOut, err := elbClient.CreateLoadBalancer(context.TODO(), &elb.CreateLoadBalancerInput{
+			Name:           aws.String(in.AlbName),
+			Type:           elbTypes.LoadBalancerTypeEnumApplication,
+			Scheme:         elbTypes.LoadBalancerSchemeEnumInternetFacing,
+			IpAddressType:  elbTypes.IpAddressTypeIpv4,
+			SecurityGroups: []string{albSgID},
+			Subnets:        in.SubnetIDs,
+			Tags: []elbTypes.Tag{
+				{Key: aws.String("Name"), Value: aws.String(in.AlbName)},
+				{Key: aws.String("created by"), Value: aws.String(awsCreatedByTag)},
+			},
+		})
+		if err != nil {
+			return res, err
+		}
+		res.LoadBalancerArn = aws.ToString(createOut.LoadBalancers[0].LoadBalancerArn)
+		res.LoadBalancerDns = aws.ToString(createOut.LoadBalancers[0].DNSName)
+		if err := elb.NewLoadBalancerAvailableWaiter(elbClient).Wait(context.TODO(),
+			&elb.DescribeLoadBalancersInput{LoadBalancerArns: []string{res.LoadBalancerArn}}, 5*time.Minute); err != nil {
+			return res, fmt.Errorf("wait ALB available: %w", err)
+		}
+	}
+
+	// Find-or-create the HTTP:80 listener with a default 404.
+	listenersOut, err := elbClient.DescribeListeners(context.TODO(), &elb.DescribeListenersInput{LoadBalancerArn: aws.String(res.LoadBalancerArn)})
+	if err != nil {
+		return res, err
+	}
+	for _, l := range listenersOut.Listeners {
+		if aws.ToInt32(l.Port) == 80 {
+			res.ListenerArn = aws.ToString(l.ListenerArn)
+			break
+		}
+	}
+	if res.ListenerArn == "" {
+		createListenerOut, err := elbClient.CreateListener(context.TODO(), &elb.CreateListenerInput{
+			LoadBalancerArn: aws.String(res.LoadBalancerArn),
+			Port:            aws.Int32(80),
+			Protocol:        elbTypes.ProtocolEnumHttp,
+			DefaultActions: []elbTypes.Action{{
+				Type: elbTypes.ActionTypeEnumFixedResponse,
+				FixedResponseConfig: &elbTypes.FixedResponseActionConfig{
+					StatusCode:  aws.String("404"),
+					ContentType: aws.String("text/plain"),
+					MessageBody: aws.String("No matching preview"),
+				},
+			}},
+		})
+		if err != nil {
+			return res, err
+		}
+		res.ListenerArn = aws.ToString(createListenerOut.Listeners[0].ListenerArn)
+	}
+	return res, nil
+}
+
+// EnsurePreviewListenerRule find-or-creates the header-routed rule that forwards
+// requests carrying `<headerName>: <previewID>` to the preview's target group,
+// returning the rule ARN. Idempotent: an existing rule for this previewID is
+// reused; otherwise the lowest free priority is taken (retrying if a concurrent
+// deploy grabs it first). The X-Preview-Target header is injected by the
+// preview's CloudFront distribution as an origin custom header, so only that
+// preview's own CloudFront can reach its target group through the shared ALB.
+func EnsurePreviewListenerRule(elbClient *elb.Client, listenerArn, headerName, previewID, targetGroupArn string) (string, error) {
+	rulesOut, err := elbClient.DescribeRules(context.TODO(), &elb.DescribeRulesInput{ListenerArn: aws.String(listenerArn)})
+	if err != nil {
+		return "", err
+	}
+	used := map[int]bool{}
+	for _, r := range rulesOut.Rules {
+		for _, c := range r.Conditions {
+			if aws.ToString(c.Field) == "http-header" && c.HttpHeaderConfig != nil &&
+				aws.ToString(c.HttpHeaderConfig.HttpHeaderName) == headerName {
+				for _, v := range c.HttpHeaderConfig.Values {
+					if v == previewID {
+						return aws.ToString(r.RuleArn), nil
+					}
+				}
+			}
+		}
+		if p, perr := strconv.Atoi(aws.ToString(r.Priority)); perr == nil {
+			used[p] = true
+		}
+	}
+
+	condition := elbTypes.RuleCondition{
+		Field: aws.String("http-header"),
+		HttpHeaderConfig: &elbTypes.HttpHeaderConditionConfig{
+			HttpHeaderName: aws.String(headerName),
+			Values:         []string{previewID},
+		},
+	}
+	action := elbTypes.Action{Type: elbTypes.ActionTypeEnumForward, TargetGroupArn: aws.String(targetGroupArn)}
+
+	priority := 1
+	for attempt := 0; attempt < 50; attempt++ {
+		for used[priority] {
+			priority++
+		}
+		if priority > 50000 { // ALB max rule priority
+			return "", fmt.Errorf("no free ALB listener-rule priority available")
+		}
+		out, err := elbClient.CreateRule(context.TODO(), &elb.CreateRuleInput{
+			ListenerArn: aws.String(listenerArn),
+			Priority:    aws.Int32(int32(priority)),
+			Conditions:  []elbTypes.RuleCondition{condition},
+			Actions:     []elbTypes.Action{action},
+			Tags: []elbTypes.Tag{
+				{Key: aws.String("created by"), Value: aws.String(awsCreatedByTag)},
+				{Key: aws.String("preview"), Value: aws.String(previewID)},
+			},
+		})
+		if err == nil {
+			return aws.ToString(out.Rules[0].RuleArn), nil
+		}
+		if apiErrCodeIs(err, "PriorityInUse") {
+			used[priority] = true
+			continue
+		}
+		return "", err
+	}
+	return "", fmt.Errorf("could not allocate a listener-rule priority after retries")
 }

--- a/utils/aws_utils/web_service_test.go
+++ b/utils/aws_utils/web_service_test.go
@@ -1,0 +1,49 @@
+package aws_utils
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/smithy-go"
+)
+
+// TestEnvMapToKeyValuePairs covers deterministic (key-sorted) conversion and the
+// empty -> nil case (so a no-env container definition stays byte-stable).
+func TestEnvMapToKeyValuePairs(t *testing.T) {
+	if got := envMapToKeyValuePairs(nil); got != nil {
+		t.Fatalf("empty map -> %v, want nil", got)
+	}
+	pairs := envMapToKeyValuePairs(map[string]string{"ZED": "z", "ALPHA": "a", "MID": "m"})
+	if len(pairs) != 3 {
+		t.Fatalf("len = %d, want 3", len(pairs))
+	}
+	wantKeys := []string{"ALPHA", "MID", "ZED"} // sorted
+	wantVals := []string{"a", "m", "z"}
+	for i, p := range pairs {
+		if aws.ToString(p.Name) != wantKeys[i] || aws.ToString(p.Value) != wantVals[i] {
+			t.Errorf("pair[%d] = (%q,%q), want (%q,%q)", i,
+				aws.ToString(p.Name), aws.ToString(p.Value), wantKeys[i], wantVals[i])
+		}
+	}
+}
+
+// TestApiErrCodeIs covers the idempotency helper matching an AWS error code.
+func TestApiErrCodeIs(t *testing.T) {
+	dup := &smithy.GenericAPIError{Code: "InvalidPermission.Duplicate", Message: "exists"}
+	if !apiErrCodeIs(dup, "InvalidPermission.Duplicate") {
+		t.Errorf("expected match on exact code")
+	}
+	if !apiErrCodeIs(dup, "Other", "InvalidPermission.Duplicate") {
+		t.Errorf("expected match when code is among the list")
+	}
+	if apiErrCodeIs(dup, "InvalidGroup.Duplicate") {
+		t.Errorf("unexpected match on a different code")
+	}
+	if apiErrCodeIs(nil, "InvalidPermission.Duplicate") {
+		t.Errorf("nil error should not match")
+	}
+	if apiErrCodeIs(errors.New("plain error"), "InvalidPermission.Duplicate") {
+		t.Errorf("non-API error should not match")
+	}
+}


### PR DESCRIPTION
## What

`Cw1b` — the **ingress half** that completes `DeployWebServicePreview`, so a web-service preview is publicly reachable and the deploy returns an `https://<x>.cloudfront.net` URL.

### Relationship to #83 / how to merge

This branch is built on top of [#83](https://github.com/deployment-io/deployment-runner/pull/83) (Cw1a), so against `master` it carries **both** commits — i.e. this PR is the **complete Cw1**, reviewable in one place:

| commit | what |
|---|---|
| `preview: … ECS half (Cw1a)` | = all of #83 |
| `preview: … ingress (Cw1b)` | the ingress half, reviewed here |

Either merge path works:
- **Merge #83, then this** — once #83 lands, this PR's diff automatically reduces to the Cw1b commit only (the repo merges with merge commits, so the Cw1a commit is already an ancestor — no conflict, no duplication).
- **Or merge just this one** — it contains all of Cw1; then close #83 as superseded.

Review the Cw1b commit alone for just the ingress diff.

## The ingress half

Adds to `utils/aws_utils/web_service.go`:
- **`EnsureSharedAlb`** — one internet-facing ALB **per org+region** (found-or-created by a stable, hashed name — an idle ALB has a base charge, so it's shared, not per-preview) + its SG (inbound 80 — CloudFront reaches the origin over HTTP) + an **HTTP:80 listener whose default action is a fixed 404** (a request with no matching header belongs to no preview).
- **`EnsurePreviewListenerRule`** — a header-routed rule (`X-Preview-Target == <previewID>` → the preview's target group) at the lowest free priority (with a retry if a concurrent deploy grabs it). One shared ALB fans out to many previews' target groups by header.

Adds to `agenttools/deploy_web_service_preview.go`:
- **`buildPreviewWebServiceDistributionConfig`** — the per-preview CloudFront distribution: a **`CustomOriginConfig`** at the ALB DNS (HTTP-only) that injects the **`X-Preview-Target` origin custom header**, caching off (the same managed `CachingDisabled` policy static uses), the managed **AllViewer** origin-request policy (forward the full request), all HTTP methods. The static twin's S3-OAC origin becomes an ALB CustomOrigin; the CachingDisabled policy + price class + create/return flow are reused.
- Wires it into `DeployWebServicePreview`: `… target group → shared ALB + listener rule → service → CloudFront → URL`.

## Design (per the plan's "Web services: CloudFront-fronts-ALB")

```
ECS service → target group → shared ALB (HTTP) → CloudFront → https://<x>.cloudfront.net
```

- **No custom domain / no ACM / no Route53** — CloudFront gives the free `*.cloudfront.net` name + managed HTTPS to the viewer and reaches the ALB over plain HTTP.
- **Ordering**: the listener rule attaches the target group to the ALB *before* the service is created, so its targets get health-checked and the service can reach a stable state.
- **Multi-preview isolation**: `X-Preview-Target` is a CloudFront **origin custom header** — CloudFront overwrites any viewer-supplied value, so one preview's CloudFront can only reach its own target group (and previewIDs are unguessable regardless).
- Because the public surface stays a CloudFront distribution, `verify_preview_reachable` (its `*.cloudfront.net` allowlist), the GC CloudFront teardown, and the `PreviewStore`/`PreviewState`/`EnsureV1` seam are all reused **unchanged** (Cw2/Cw3/Cw4).
- Reuse: shared ALB + rule by identity (idempotent find-or-create); per-preview CloudFront via `ExistingDistID`. Returns without blocking on CloudFront propagation (verify polls).

## Verification

- `GOWORK=off go build ./...` ✓ · `go vet` ✓ · `gofmt` clean ✓
- `GOWORK=off go test ./utils/aws_utils/ ./agenttools/` ✓ — new tests pin the CloudFront config (HTTP-only ALB custom origin, the `X-Preview-Target` origin header == previewID, CachingDisabled + AllViewer policies, all 7 methods) and the ALB name's 32-char hash bound.
- A full **live** run (CloudFront URL → ALB → healthy Fargate task) needs the runner's cloud; that E2E is the reviewer's to run — this is the first slice where the URL is end-to-end reachable.

Runner-only; no drk change. Review-only — I won't merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)