### PR TITLE
Fail the Step when agent changes land outside the repository

### DIFF
--- a/jobs/commands/commit_and_push.go
+++ b/jobs/commands/commit_and_push.go
@@ -55,6 +55,9 @@ func (cap *CommitAndPush) Run(parameters map[string]interface{}, logsWriter io.W
 	if err != nil {
 		return parameters, err
 	}
+	if err := detectOrphanedChanges(parameters, repoOutputs, logsWriter); err != nil {
+		return parameters, err
+	}
 	if err := tcp.mergeRepositoriesIntoJobOutput(parameters, repoOutputs); err != nil {
 		return parameters, fmt.Errorf("error merging repositories into job output: %s", err)
 	}
@@ -211,6 +214,43 @@ func (tcp *taskCommitPush) subjectAndBody() (string, string) {
 	return fmt.Sprintf("Tasks Step %d: %s", tcp.ctx.StepIndex+1, tcp.ctx.TaskTitle), ""
 }
 
+// detectOrphanedChanges fails the Step when the agent reported changed files but
+// none landed in any repository — the "wrote outside the repo directory" failure
+// (the agent creates files at the /work root instead of /work/<owner>/<repo>, so
+// the per-repo git diff is empty). Without this the Step silently succeeds with
+// no commit and no PR, which looks like success but produced nothing. A genuine
+// no-op (the agent changed nothing) has empty files_changed and is left alone.
+func detectOrphanedChanges(parameters map[string]interface{}, repoOutputs []repoOutput, logsWriter io.Writer) error {
+	for _, r := range repoOutputs {
+		if r.HasChanges {
+			return nil // at least one repo changed — normal path
+		}
+	}
+	filesChanged := readAgentFilesChangedFromJobOutput(parameters)
+	if len(filesChanged) == 0 {
+		return nil // genuine no-op — the agent reported no changed files
+	}
+	joined := strings.Join(filesChanged, ", ")
+	io.WriteString(logsWriter, fmt.Sprintf(
+		"Agent reported %d changed file(s) but none landed in any repository — they were likely written outside the repository directory (e.g. at /work instead of /work/<owner>/<repo>) and cannot be committed. Files: %s\n",
+		len(filesChanged), joined))
+	return fmt.Errorf("agent changes were written outside the repository — nothing to commit (files: %s)", joined)
+}
+
+// readAgentFilesChangedFromJobOutput pulls the agent.files_changed list from the
+// JobOutput envelope (written by RunAgentStep). Empty on any parse miss.
+func readAgentFilesChangedFromJobOutput(parameters map[string]interface{}) []string {
+	existing, err := jobs.GetParameterValue[string](parameters, parameters_enums.JobOutput)
+	if err != nil || len(existing) == 0 {
+		return nil
+	}
+	var data jobOutputData
+	if err := json.Unmarshal([]byte(existing), &data); err != nil || data.Agent == nil {
+		return nil
+	}
+	return data.Agent.FilesChanged
+}
+
 // readAgentSummaryFromJobOutput pulls the agent.changes_summary field
 // out of the accumulated JobOutput envelope. RunAgentStep populates
 // this before CommitAndPush + OpenPullRequest run; both commands call
@@ -306,8 +346,12 @@ type jobOutputData struct {
 }
 
 type agentOutput struct {
-	ChangesSummary string     `json:"changes_summary,omitempty"`
-	TokenUsage     tokenUsage `json:"token_usage"`
+	ChangesSummary string `json:"changes_summary,omitempty"`
+	// FilesChanged is the agent's self-reported changed-file list. Used by
+	// CommitAndPush to detect the "reported changes but none landed in a repo"
+	// failure (files written outside the repo dir → nothing to commit).
+	FilesChanged []string   `json:"files_changed,omitempty"`
+	TokenUsage   tokenUsage `json:"token_usage"`
 	// Turns is the per-run turn count agentbox writes to /result.json.
 	// Surfaced on the JobOutput envelope so app-server's projection
 	// can populate AgentRunSummary.Turns for completed runs — the

--- a/jobs/commands/orphaned_changes_test.go
+++ b/jobs/commands/orphaned_changes_test.go
@@ -1,0 +1,56 @@
+package commands
+
+import (
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/deployment-io/deployment-runner-kit/enums/parameters_enums"
+	"github.com/deployment-io/deployment-runner-kit/jobs"
+)
+
+// paramsWithFilesChanged builds a JobOutput envelope carrying the agent's
+// files_changed list, as RunAgentStep would have written before CommitAndPush.
+func paramsWithFilesChanged(t *testing.T, files []string) map[string]interface{} {
+	t.Helper()
+	b, err := json.Marshal(jobOutputData{SchemaVersion: 1, Agent: &agentOutput{FilesChanged: files}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	params := map[string]interface{}{}
+	jobs.SetParameterValue[string](params, parameters_enums.JobOutput, string(b))
+	return params
+}
+
+// The failure this guards: the agent wrote files (files_changed non-empty) but
+// they landed outside every repo (all repos clean) — so nothing commits and no
+// PR opens. Must become a visible error, not a silent success.
+func TestDetectOrphanedChanges_ErrorsWhenChangesReportedButNoRepoChanged(t *testing.T) {
+	params := paramsWithFilesChanged(t, []string{"/work/HELLO_OPENCODE.md"})
+	repos := []repoOutput{{Name: "dashboard", HasChanges: false}}
+	err := detectOrphanedChanges(params, repos, io.Discard)
+	if err == nil {
+		t.Fatal("expected an error when the agent reported files but no repo changed")
+	}
+	if !strings.Contains(err.Error(), "outside the repository") {
+		t.Errorf("error should explain the out-of-repo write: %v", err)
+	}
+}
+
+func TestDetectOrphanedChanges_NoErrorWhenARepoChanged(t *testing.T) {
+	params := paramsWithFilesChanged(t, []string{"/work/0-org/repo/x.go"})
+	repos := []repoOutput{{Name: "repo", HasChanges: true}}
+	if err := detectOrphanedChanges(params, repos, io.Discard); err != nil {
+		t.Errorf("no error expected when a repo changed: %v", err)
+	}
+}
+
+func TestDetectOrphanedChanges_NoErrorOnGenuineNoOp(t *testing.T) {
+	// Empty files_changed = the agent legitimately made no change; must not error.
+	params := paramsWithFilesChanged(t, nil)
+	repos := []repoOutput{{Name: "repo", HasChanges: false}}
+	if err := detectOrphanedChanges(params, repos, io.Discard); err != nil {
+		t.Errorf("genuine no-op (empty files_changed) must not error: %v", err)
+	}
+}

--- a/jobs/commands/run_agent_step.go
+++ b/jobs/commands/run_agent_step.go
@@ -907,7 +907,11 @@ type agentResult struct {
 	ExitCode       int        `json:"exit_code"`
 	AgentVersion   string     `json:"agent_version,omitempty"`
 	ChangesSummary string     `json:"changes_summary,omitempty"`
-	TokenUsage     tokenUsage `json:"token_usage"`
+	// FilesChanged is the agent's self-reported list of changed files. Carried
+	// through to agentOutput so CommitAndPush can detect the "agent reported
+	// changes but nothing landed in a repo" failure (writes outside the repo dir).
+	FilesChanged []string   `json:"files_changed,omitempty"`
+	TokenUsage   tokenUsage `json:"token_usage"`
 	// Turns is agentbox's per-run turn count (internal/result.Outcome.Turns,
 	// emitted as "turns"). The runner previously declared this as TurnCount
 	// with json:"turn_count" — neither name matched agentbox's wire shape,
@@ -1007,6 +1011,7 @@ func mergeAgentResultIntoJobOutput(parameters map[string]interface{}, result age
 	data.SchemaVersion = jobOutputSchemaVersion
 	data.Agent = &agentOutput{
 		ChangesSummary: result.ChangesSummary,
+		FilesChanged:   result.FilesChanged,
 		TokenUsage:     result.TokenUsage,
 		Turns:          result.Turns,
 		CostUSD:        result.CostUSD,


### PR DESCRIPTION
**Runner-side safety-net** — the companion to the agentbox repo-anchor prompt (agentbox#36).

The agent runs `cwd=/work` but repos live in `/work/<owner>/<repo>` subdirs. A file written at the `/work` root is outside every repo, so the per-repo git diff is empty and CommitAndPush **silently skips — the Step succeeds with no commit and no PR**. Reproduced with both claude-code and opencode; the worst failure mode (looks like success, produced nothing).

This threads the agent's `files_changed` through JobOutput and, when **every repo is clean but files_changed is non-empty**, fails the Step with a clear message listing the orphaned files — turning the silent no-op into a visible, debuggable failure. A genuine no-op (empty `files_changed`) is left untouched. 3 unit tests.

The anchor prompt (agentbox#36) reduces how often agents escape; this makes any residual escape loud instead of silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)