### PR TITLE
Assume dr-bedrock-role and inject scoped creds for Bedrock tasks

### DIFF
--- a/jobs/commands/bedrock_creds_test.go
+++ b/jobs/commands/bedrock_creds_test.go
@@ -1,0 +1,30 @@
+package commands
+
+import (
+	"io"
+	"testing"
+)
+
+// Both guards return before any AWS/RunnerData access, so they're safe to unit
+// test. The AssumeRole+inject path needs live AWS creds and is covered by the
+// end-to-end dogfood on a Bedrock-enabled runner.
+
+func TestApplyBedrockCredsIfNeeded_NoOpWhenNotBedrock(t *testing.T) {
+	env := map[string]string{"MODEL": "us.anthropic.claude-sonnet-4-6"}
+	applyBedrockCredsIfNeeded(env, io.Discard)
+	if _, ok := env["AWS_ACCESS_KEY_ID"]; ok {
+		t.Error("must not inject creds when CLAUDE_CODE_USE_BEDROCK is absent")
+	}
+	if _, ok := env["ANTHROPIC_MODEL"]; ok {
+		t.Error("must not touch env at all when not in Bedrock mode")
+	}
+}
+
+func TestApplyBedrockCredsIfNeeded_NoOpWhenRoleArnMissing(t *testing.T) {
+	t.Setenv("BedrockRoleArn", "") // stack predates Bedrock support
+	env := map[string]string{"CLAUDE_CODE_USE_BEDROCK": "1"}
+	applyBedrockCredsIfNeeded(env, io.Discard)
+	if _, ok := env["AWS_ACCESS_KEY_ID"]; ok {
+		t.Error("must not inject creds when BedrockRoleArn is unset")
+	}
+}

--- a/jobs/commands/bedrock_creds_test.go
+++ b/jobs/commands/bedrock_creds_test.go
@@ -28,3 +28,29 @@ func TestApplyBedrockCredsIfNeeded_NoOpWhenRoleArnMissing(t *testing.T) {
 		t.Error("must not inject creds when BedrockRoleArn is unset")
 	}
 }
+
+// The requested session duration is a cross-repo constraint, not a local knob:
+// STS rejects the whole AssumeRole call if it exceeds dr-bedrock-role's
+// MaxSessionDuration, and the caller then runs the task credential-free. These
+// pin the invariant so that changing defaultWallClockTimeout — which reads as a
+// plain task-timeout constant — cannot silently break Bedrock.
+func TestBedrockSessionSeconds_WithinStsAndRoleBounds(t *testing.T) {
+	const stsMinSeconds = 900
+	got := bedrockSessionSeconds()
+	if got > bedrockMaxSessionSeconds {
+		t.Errorf("session %ds exceeds the dr-bedrock-role ceiling of %ds — AssumeRole would fail outright", got, bedrockMaxSessionSeconds)
+	}
+	if got < stsMinSeconds {
+		t.Errorf("session %ds is below the STS minimum of %ds", got, stsMinSeconds)
+	}
+}
+
+func TestBedrockSessionSeconds_UsesFullTaskCapToday(t *testing.T) {
+	// defaultWallClockTimeout is 4h and the role ceiling is also 14400, so the
+	// clamp is a no-op right now and creds last exactly as long as the task may.
+	// If this fails, the two have drifted apart — check whether the template's
+	// MaxSessionDuration still matches bedrockMaxSessionSeconds.
+	if got := bedrockSessionSeconds(); got != int32(defaultWallClockTimeout.Seconds()) {
+		t.Errorf("bedrockSessionSeconds() = %d, want the full task cap %d", got, int32(defaultWallClockTimeout.Seconds()))
+	}
+}

--- a/jobs/commands/run_agent_step.go
+++ b/jobs/commands/run_agent_step.go
@@ -15,9 +15,11 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/cloudfront"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/deployment-io/deployment-runner-kit/cloud_api_clients"
 	"github.com/deployment-io/deployment-runner-kit/deployments"
 	"github.com/deployment-io/deployment-runner-kit/enums/build_enums"
@@ -400,11 +402,70 @@ func buildAgentSpawnEnvVars(parameters map[string]interface{}, logsWriter io.Wri
 	if allowed != "" {
 		env["ADDITIONAL_ALLOWED_HOSTS"] = allowed
 	}
+	// Bedrock: when the org is in Bedrock mode (CLAUDE_CODE_USE_BEDROCK marker in
+	// AgentEnvVars), assume dr-bedrock-role and inject its scoped short-lived creds.
+	applyBedrockCredsIfNeeded(env, logsWriter)
 	// Optionally swap the injected ANTHROPIC_API_KEY for a Claude Code
 	// subscription OAuth token read from this runner's own AWS Secrets Manager.
 	// Engages only when the org is in subscription mode (marker in AgentEnvVars).
 	maybeApplyClaudeSubscriptionAuth(env, logsWriter)
 	return mapToEnvSlice(env), nil
+}
+
+// bedrockRoleArnEnvVar names the env var the CloudFormation runner task def sets
+// to the dr-bedrock-role ARN (see cloud-formation-one-click). Empty means the
+// runner's stack predates Bedrock support.
+const bedrockRoleArnEnvVar = "BedrockRoleArn"
+
+// applyBedrockCredsIfNeeded switches a claude-code task to AWS Bedrock. When
+// deployment-server has injected the CLAUDE_CODE_USE_BEDROCK=1 marker (from the
+// org's Bedrock provider — see kit's ClaudeAuth.ResolveAgentEnvVars), the runner
+// assumes the minimal dr-bedrock-role and injects the short-lived, Bedrock-only
+// credentials into the agent container. No long-lived secret is stored, and the
+// agent receives creds that can invoke Bedrock and nothing else. The Bedrock API
+// host is added to the egress allowlist. On any failure the task proceeds without
+// creds (and fails auth in the container) rather than crashing the runner.
+func applyBedrockCredsIfNeeded(env map[string]string, logsWriter io.Writer) {
+	if env["CLAUDE_CODE_USE_BEDROCK"] != "1" {
+		return
+	}
+	roleArn := strings.TrimSpace(os.Getenv(bedrockRoleArnEnvVar))
+	if roleArn == "" {
+		io.WriteString(logsWriter, "Bedrock: BedrockRoleArn is not set on this runner — update the CloudFormation stack to add the Bedrock role.\n")
+		return
+	}
+	region := utils.RunnerData.Get().RunnerRegion
+	cfg, err := config.LoadDefaultConfig(context.TODO(), config.WithRegion(region))
+	if err != nil {
+		io.WriteString(logsWriter, fmt.Sprintf("Bedrock: could not load AWS config: %s\n", err))
+		return
+	}
+	out, err := sts.NewFromConfig(cfg).AssumeRole(context.TODO(), &sts.AssumeRoleInput{
+		RoleArn:         aws.String(roleArn),
+		RoleSessionName: aws.String("agentbox-bedrock"),
+	})
+	if err != nil || out.Credentials == nil {
+		io.WriteString(logsWriter, fmt.Sprintf("Bedrock: AssumeRole %s failed: %s\n", roleArn, err))
+		return
+	}
+	c := out.Credentials
+	env["AWS_ACCESS_KEY_ID"] = aws.ToString(c.AccessKeyId)
+	env["AWS_SECRET_ACCESS_KEY"] = aws.ToString(c.SecretAccessKey)
+	env["AWS_SESSION_TOKEN"] = aws.ToString(c.SessionToken)
+	env["AWS_REGION"] = region
+	// claude-code in Bedrock mode takes the model from ANTHROPIC_MODEL (an
+	// inference-profile id). Pass the selected model through.
+	if m := env["MODEL"]; m != "" {
+		env["ANTHROPIC_MODEL"] = m
+	}
+	// Allowlist the Bedrock data-plane host — agentbox's proxy gates egress.
+	bedrockHost := "bedrock-runtime." + region + ".amazonaws.com"
+	if existing := env["ADDITIONAL_ALLOWED_HOSTS"]; existing != "" {
+		env["ADDITIONAL_ALLOWED_HOSTS"] = existing + "," + bedrockHost
+	} else {
+		env["ADDITIONAL_ALLOWED_HOSTS"] = bedrockHost
+	}
+	io.WriteString(logsWriter, fmt.Sprintf("Bedrock: assumed %s; agent will use Bedrock in %s.\n", roleArn, region))
 }
 
 // Subscription-mode contract with the control plane.

--- a/jobs/commands/run_agent_step.go
+++ b/jobs/commands/run_agent_step.go
@@ -443,6 +443,13 @@ func applyBedrockCredsIfNeeded(env map[string]string, logsWriter io.Writer) {
 	out, err := sts.NewFromConfig(cfg).AssumeRole(context.TODO(), &sts.AssumeRoleInput{
 		RoleArn:         aws.String(roleArn),
 		RoleSessionName: aws.String("agentbox-bedrock"),
+		// Match the per-task wall-clock cap. These creds are injected as env
+		// vars and do NOT auto-refresh, so a session shorter than the task
+		// would expire mid-run. AssumeRole defaults to 1h when this is unset,
+		// regardless of the role's MaxSessionDuration - so both this and the
+		// role's ceiling (set in the CloudFormation template) are required.
+		// STS caps this at the role's MaxSessionDuration if that is lower.
+		DurationSeconds: aws.Int32(int32(defaultWallClockTimeout.Seconds())),
 	})
 	if err != nil || out.Credentials == nil {
 		io.WriteString(logsWriter, fmt.Sprintf("Bedrock: AssumeRole %s failed: %s\n", roleArn, err))

--- a/jobs/commands/run_agent_step.go
+++ b/jobs/commands/run_agent_step.go
@@ -448,7 +448,19 @@ func applyBedrockCredsIfNeeded(env map[string]string, logsWriter io.Writer) {
 		// would expire mid-run. AssumeRole defaults to 1h when this is unset,
 		// regardless of the role's MaxSessionDuration - so both this and the
 		// role's ceiling (set in the CloudFormation template) are required.
-		// STS caps this at the role's MaxSessionDuration if that is lower.
+		//
+		// STS does NOT clamp this to the role's MaxSessionDuration — asking for
+		// more than the role allows FAILS the call outright ("The requested
+		// DurationSeconds exceeds the MaxSessionDuration set for this role").
+		// So the two are ORDER-DEPENDENT across repos: a runner carrying this
+		// value against a stack whose dr-bedrock-role still has the 1h default
+		// gets a hard AssumeRole failure on every Bedrock task, and the guard
+		// below logs it and runs the task credential-free. Update the
+		// CloudFormation stack BEFORE deploying a runner that requests 4h.
+		//
+		// Runners auto-upgrade but customer stacks do not, so before Bedrock is
+		// customer-reachable this should fall back to a shorter duration on
+		// ValidationError rather than relying on deploy discipline.
 		DurationSeconds: aws.Int32(int32(defaultWallClockTimeout.Seconds())),
 	})
 	if err != nil || out.Credentials == nil {

--- a/jobs/commands/run_agent_step.go
+++ b/jobs/commands/run_agent_step.go
@@ -417,6 +417,36 @@ func buildAgentSpawnEnvVars(parameters map[string]interface{}, logsWriter io.Wri
 // runner's stack predates Bedrock support.
 const bedrockRoleArnEnvVar = "BedrockRoleArn"
 
+// bedrockMaxSessionSeconds mirrors MaxSessionDuration on dr-bedrock-role in
+// the CloudFormation template (cloud-formation-one-click/go-formation-amd).
+//
+// This is a CROSS-REPO CONSTRAINT, not a local tuning knob. STS does not clamp
+// DurationSeconds to the role's ceiling — asking for more FAILS the call
+// ("The requested DurationSeconds exceeds the MaxSessionDuration set for this
+// role"), after which every Bedrock task runs credential-free. Without the
+// clamp below, raising defaultWallClockTimeout — a plain task-timeout constant
+// with nothing about it suggesting an IAM coupling — would silently break
+// Bedrock, with the symptom nowhere near the cause. Raise this only together
+// with the template (and its own 12h AWS ceiling).
+const bedrockMaxSessionSeconds = 14400
+
+// bedrockSessionSeconds is how long a vended Bedrock session should last:
+// the per-task wall-clock cap, clamped to what the role permits. These creds
+// are injected as env vars and do NOT auto-refresh, so a session shorter than
+// the task expires mid-run — hence asking for the full cap where allowed.
+// STS also rejects anything below 900s, so guard that end too.
+func bedrockSessionSeconds() int32 {
+	const stsMinSeconds = 900
+	d := int32(defaultWallClockTimeout.Seconds())
+	if d > bedrockMaxSessionSeconds {
+		return bedrockMaxSessionSeconds
+	}
+	if d < stsMinSeconds {
+		return stsMinSeconds
+	}
+	return d
+}
+
 // applyBedrockCredsIfNeeded switches a claude-code task to AWS Bedrock. When
 // deployment-server has injected the CLAUDE_CODE_USE_BEDROCK=1 marker (from the
 // org's Bedrock provider — see kit's ClaudeAuth.ResolveAgentEnvVars), the runner
@@ -450,18 +480,17 @@ func applyBedrockCredsIfNeeded(env map[string]string, logsWriter io.Writer) {
 		// role's ceiling (set in the CloudFormation template) are required.
 		//
 		// STS does NOT clamp this to the role's MaxSessionDuration — asking for
-		// more than the role allows FAILS the call outright ("The requested
-		// DurationSeconds exceeds the MaxSessionDuration set for this role").
-		// So the two are ORDER-DEPENDENT across repos: a runner carrying this
-		// value against a stack whose dr-bedrock-role still has the 1h default
-		// gets a hard AssumeRole failure on every Bedrock task, and the guard
-		// below logs it and runs the task credential-free. Update the
-		// CloudFormation stack BEFORE deploying a runner that requests 4h.
+		// more than the role allows FAILS the call outright, after which the
+		// guard below logs and runs the task credential-free. bedrockSessionSeconds
+		// clamps to what the role permits so that cannot happen; see its comment.
 		//
-		// Runners auto-upgrade but customer stacks do not, so before Bedrock is
-		// customer-reachable this should fall back to a shorter duration on
-		// ValidationError rather than relying on deploy discipline.
-		DurationSeconds: aws.Int32(int32(defaultWallClockTimeout.Seconds())),
+		// The clamp does NOT remove the deploy-order requirement: a stack whose
+		// dr-bedrock-role still has the 1h default will reject the 4h request
+		// regardless. Update the CloudFormation stack BEFORE deploying a runner
+		// that requests 4h. Runners auto-upgrade while customer stacks do not,
+		// so before Bedrock is customer-reachable this should also retry at a
+		// shorter duration on ValidationError rather than rely on that order.
+		DurationSeconds: aws.Int32(bedrockSessionSeconds()),
 	})
 	if err != nil || out.Credentials == nil {
 		io.WriteString(logsWriter, fmt.Sprintf("Bedrock: AssumeRole %s failed: %s\n", roleArn, err))


### PR DESCRIPTION
**Phase 8 — the runner-vends-creds core.** When deployment-server injects the `CLAUDE_CODE_USE_BEDROCK=1` marker (org's Bedrock provider, via kit#202), the runner:
- `sts:AssumeRole`s the minimal **`dr-bedrock-role`** (ARN from the `BedrockRoleArn` env the CFN task def sets — cloud-formation-one-click#3),
- injects the short-lived, **Bedrock-only** `AWS_ACCESS_KEY_ID`/`SECRET`/`SESSION_TOKEN` + `AWS_REGION` into the agent container,
- sets `ANTHROPIC_MODEL` from the selected model,
- allowlists `bedrock-runtime.<region>`.

The agent gets creds that can invoke Bedrock and **nothing else** (the role is scoped); no long-lived secret is stored anywhere. Any failure degrades to no-creds (auth fails in the container) rather than crashing the runner. Guard-path unit tests added; the AssumeRole path is covered by the end-to-end dogfood.

**Depends on** kit#202 (the marker). **Needs, to test:** deploy this runner + stack-update the CFN (cloud-formation-one-click#3) on a Bedrock-enabled account, set the org to the Bedrock provider, run a claude-code task with a Bedrock inference-profile model.

Note: no kit import here, so no go.mod bump needed — the runner only checks the marker *string*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)