### PR TITLE
Cap the Bedrock session at 1h — role chaining, not MaxSessionDuration

### DIFF
--- a/jobs/commands/bedrock_creds_test.go
+++ b/jobs/commands/bedrock_creds_test.go
@@ -29,28 +29,36 @@ func TestApplyBedrockCredsIfNeeded_NoOpWhenRoleArnMissing(t *testing.T) {
 	}
 }
 
-// The requested session duration is a cross-repo constraint, not a local knob:
-// STS rejects the whole AssumeRole call if it exceeds dr-bedrock-role's
-// MaxSessionDuration, and the caller then runs the task credential-free. These
-// pin the invariant so that changing defaultWallClockTimeout — which reads as a
-// plain task-timeout constant — cannot silently break Bedrock.
-func TestBedrockSessionSeconds_WithinStsAndRoleBounds(t *testing.T) {
+// The requested session duration is governed by AWS role chaining, not by
+// dr-bedrock-role's MaxSessionDuration: the runner is already an assumed role,
+// so assuming another role is chained and hard-capped at 1 hour. Exceeding it
+// fails the whole AssumeRole call and the task then runs credential-free.
+// These pin the limit so it cannot drift back up.
+func TestBedrockSessionSeconds_WithinStsAndChainingBounds(t *testing.T) {
 	const stsMinSeconds = 900
 	got := bedrockSessionSeconds()
 	if got > bedrockMaxSessionSeconds {
-		t.Errorf("session %ds exceeds the dr-bedrock-role ceiling of %ds — AssumeRole would fail outright", got, bedrockMaxSessionSeconds)
+		t.Errorf("session %ds exceeds the role-chaining limit of %ds — AssumeRole would fail outright", got, bedrockMaxSessionSeconds)
 	}
 	if got < stsMinSeconds {
 		t.Errorf("session %ds is below the STS minimum of %ds", got, stsMinSeconds)
 	}
 }
 
-func TestBedrockSessionSeconds_UsesFullTaskCapToday(t *testing.T) {
-	// defaultWallClockTimeout is 4h and the role ceiling is also 14400, so the
-	// clamp is a no-op right now and creds last exactly as long as the task may.
-	// If this fails, the two have drifted apart — check whether the template's
-	// MaxSessionDuration still matches bedrockMaxSessionSeconds.
-	if got := bedrockSessionSeconds(); got != int32(defaultWallClockTimeout.Seconds()) {
-		t.Errorf("bedrockSessionSeconds() = %d, want the full task cap %d", got, int32(defaultWallClockTimeout.Seconds()))
+func TestBedrockSessionSeconds_ClampedToOneHourNotTheTaskCap(t *testing.T) {
+	// Regression guard for the first live Bedrock run, which requested the full
+	// 4h task cap and was rejected with "exceeds the 1 hour session limit for
+	// roles assumed by role chaining". The clamp must bite here — asserting the
+	// concrete 3600 rather than just "<= the constant" so that raising the
+	// constant fails this test instead of silently reintroducing the bug.
+	const roleChainingLimit = 3600
+	if got := bedrockSessionSeconds(); got != roleChainingLimit {
+		t.Errorf("bedrockSessionSeconds() = %d, want %d (AWS role-chaining cap)", got, roleChainingLimit)
+	}
+	// And it must genuinely be shorter than the task cap — i.e. the clamp is
+	// doing work, not coincidentally agreeing. Bedrock creds therefore expire
+	// mid-run on long tasks; refresh is the deferred fix, not a longer session.
+	if int32(defaultWallClockTimeout.Seconds()) <= roleChainingLimit {
+		t.Skip("task cap no longer exceeds the chaining limit; mid-run expiry note is stale")
 	}
 }

--- a/jobs/commands/run_agent_step.go
+++ b/jobs/commands/run_agent_step.go
@@ -424,23 +424,37 @@ func buildAgentSpawnEnvVars(parameters map[string]interface{}, logsWriter io.Wri
 // runner's stack predates Bedrock support.
 const bedrockRoleArnEnvVar = "BedrockRoleArn"
 
-// bedrockMaxSessionSeconds mirrors MaxSessionDuration on dr-bedrock-role in
-// the CloudFormation template (cloud-formation-one-click/go-formation-amd).
+// bedrockMaxSessionSeconds is the ROLE CHAINING limit — 1 hour, hard.
 //
-// This is a CROSS-REPO CONSTRAINT, not a local tuning knob. STS does not clamp
-// DurationSeconds to the role's ceiling — asking for more FAILS the call
-// ("The requested DurationSeconds exceeds the MaxSessionDuration set for this
-// role"), after which every Bedrock task runs credential-free. Without the
-// clamp below, raising defaultWallClockTimeout — a plain task-timeout constant
-// with nothing about it suggesting an IAM coupling — would silently break
-// Bedrock, with the symptom nowhere near the cause. Raise this only together
-// with the template (and its own 12h AWS ceiling).
-const bedrockMaxSessionSeconds = 14400
+// ⚠️ This is NOT dr-bedrock-role's MaxSessionDuration, and raising that will
+// not raise this. The runner already runs as an assumed role (its ECS task
+// role), so using those credentials to assume dr-bedrock-role is *role
+// chaining*, which AWS caps at 1 hour regardless of what either role permits.
+// Asking for more fails the whole call:
+//
+//	ValidationError: The requested DurationSeconds exceeds the 1 hour session
+//	limit for roles assumed by role chaining.
+//
+// after which the guard below logs and the task runs credential-free —
+// agentbox then fail-fasts on the missing AWS_* vars. Observed on the first
+// live Bedrock run (2026-07-28), which had requested 4h.
+//
+// The template's MaxSessionDuration: 14400 is therefore moot for this path.
+// It is left in place because it is harmless and would matter if the assume
+// ever stopped being chained, but it is NOT what governs here.
+//
+// CONSEQUENCE — creds expire 1h into a task that may run 4h, and env-injected
+// credentials do not auto-refresh. A Bedrock task still running past the hour
+// loses access mid-run. Raising this constant cannot fix that; the fix is
+// refresh over the existing agentbox<->runner RPC channel (a local
+// credential_process), which PLAN_opencode_completion_and_bedrock.md scopes
+// and defers. Ship v1 at 1h and revisit if long-task expiry is actually hit.
+const bedrockMaxSessionSeconds = 3600
 
-// bedrockSessionSeconds is how long a vended Bedrock session should last:
-// the per-task wall-clock cap, clamped to what the role permits. These creds
-// are injected as env vars and do NOT auto-refresh, so a session shorter than
-// the task expires mid-run — hence asking for the full cap where allowed.
+// bedrockSessionSeconds is how long a vended Bedrock session should last: the
+// per-task wall-clock cap, clamped to the role-chaining limit above. These
+// creds are injected as env vars and do NOT auto-refresh, so a session shorter
+// than the task expires mid-run — hence asking for as much as is allowed.
 // STS also rejects anything below 900s, so guard that end too.
 func bedrockSessionSeconds() int32 {
 	const stsMinSeconds = 900


### PR DESCRIPTION
First live Bedrock run failed at `AssumeRole`:

```
ValidationError: The requested DurationSeconds exceeds the 1 hour session
limit for roles assumed by role chaining.
```

## The constraint I had wrong

The runner already runs **as an assumed role** — its ECS task role. Using those credentials to assume `dr-bedrock-role` is therefore **role chaining**, which AWS hard-caps at **1 hour**, regardless of what either role's `MaxSessionDuration` permits.

The earlier work treated `dr-bedrock-role`'s `MaxSessionDuration` as the binding constraint and raised both it and the request to 4h ([cloud-formation #3](https://github.com/deployment-io/cloud-formation-one-click/pull/3), runner #87). That premise was wrong: no `MaxSessionDuration` value can lift a chaining cap. The template's `MaxSessionDuration: 14400` is **moot for this path** — left in place because it's harmless and would matter if the assume ever stopped being chained, but it is not what governs.

## What the failure also proved

The degradation path worked exactly as designed, which is worth recording:

1. `AssumeRole` failed → guard logged the reason and returned rather than crashing the runner
2. Task proceeded without creds
3. agentbox fail-fasted: `CLAUDE_CODE_USE_BEDROCK=1 requires AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and AWS_REGION`

No silent unauthenticated run, and the error named the missing thing precisely. The credential-injection contract between runner and agentbox is sound; only the duration was wrong.

## Consequence this does NOT fix

Creds now expire **1h into a task that may run 4h**, and env-injected credentials do not auto-refresh. A Bedrock task still running past the hour loses access mid-run.

No session length can fix this — 1h is the ceiling. The fix is credential *refresh* over the existing agentbox↔runner RPC channel (a local `credential_process`), which `PLAN_opencode_completion_and_bedrock.md` already scopes and defers. Shipping v1 at 1h and revisiting if long-task expiry is actually hit.

## Tests

Assert the concrete `3600` rather than `<= bedrockMaxSessionSeconds`, so raising the constant fails loudly instead of silently reintroducing the bug. The bounds test also pins the STS 900s floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
