### PR TITLE
Bedrock: allowlist the control-plane host, and discover inference-profile ids (B2)

### DIFF
--- a/jobs/commands/run_agent_step.go
+++ b/jobs/commands/run_agent_step.go
@@ -527,12 +527,28 @@ func applyBedrockCredsIfNeeded(env map[string]string, logsWriter io.Writer) {
 	if m := env["MODEL"]; m != "" {
 		env["ANTHROPIC_MODEL"] = m
 	}
-	// Allowlist the Bedrock data-plane host — agentbox's proxy gates egress.
-	bedrockHost := "bedrock-runtime." + region + ".amazonaws.com"
+	// Allowlist BOTH Bedrock hosts — agentbox's proxy gates egress, and
+	// claude-code uses both planes:
+	//
+	//   bedrock-runtime.<region> — data plane (InvokeModel*), the obvious one
+	//   bedrock.<region>         — control plane (model/inference-profile
+	//                              lookups) which claude-code calls at startup
+	//
+	// The control-plane host was initially judged unnecessary "for pure
+	// inference". That was wrong: the first live run logged
+	// `denied:bedrock.eu-west-1.amazonaws.com` before the agent had issued a
+	// single completion. Both are required.
+	//
+	// The proxy denies rather than fails closed, so omitting a host degrades
+	// oddly instead of erroring clearly — worth keeping both in step with the
+	// dr-bedrock-role policy, which already grants ListInferenceProfiles and
+	// GetInferenceProfile (control-plane calls).
+	bedrockHosts := "bedrock-runtime." + region + ".amazonaws.com" +
+		",bedrock." + region + ".amazonaws.com"
 	if existing := env["ADDITIONAL_ALLOWED_HOSTS"]; existing != "" {
-		env["ADDITIONAL_ALLOWED_HOSTS"] = existing + "," + bedrockHost
+		env["ADDITIONAL_ALLOWED_HOSTS"] = existing + "," + bedrockHosts
 	} else {
-		env["ADDITIONAL_ALLOWED_HOSTS"] = bedrockHost
+		env["ADDITIONAL_ALLOWED_HOSTS"] = bedrockHosts
 	}
 	io.WriteString(logsWriter, fmt.Sprintf("Bedrock: assumed %s; agent will use Bedrock in %s.\n", roleArn, region))
 }


### PR DESCRIPTION
Two fixes from the live Bedrock smoke test, both found by running it rather than reading it.

## 1. Allowlist the Bedrock control-plane host

The first run where `AssumeRole` succeeded logged this before the agent issued a single completion:

```
[agentbox proxy] denied:bedrock.eu-west-1.amazonaws.com
```

Only `bedrock-runtime.<region>` (data plane) was allowlisted. claude-code also calls `bedrock.<region>` (control plane) at startup. I had explicitly judged that host unnecessary "for pure inference" during review — wrong, it's hit before inference begins.

The IAM side always implied it: `dr-bedrock-role` already grants `ListInferenceProfiles` and `GetInferenceProfile`, both control-plane calls. The allowlist simply didn't match the permissions we'd granted.

## 2. Discover inference-profile ids instead of deriving them (B2)

The next run got further and failed on the model:

```
API Error (claude-opus-4-8): 400 The provided model identifier is invalid.
```

The runner passed `MODEL` straight to `ANTHROPIC_MODEL`. **No prefix rule can bridge that gap** — real Bedrock ids carry a version and revision, and the same account showed two different shapes:

- `anthropic.claude-sonnet-5`
- `anthropic.claude-sonnet-4-5-20250929-v1:0`

Those suffixes change as models ship and differ per region. A static map would need a runner release per Bedrock model launch, failing at task time in between.

**Split on what actually changes:**

| Layer | Where | Changes |
|---|---|---|
| logical id → family token (`claude-opus-4-8` → `claude-opus-4`) | runner map | rarely |
| family token → concrete profile id for this region | `ListInferenceProfiles` at spawn | often, per-account |

Three paths through `resolveBedrockModelID`:

1. **Dotted model → passed through verbatim.** Our logical ids never contain dots, so this is unambiguous. It's the escape hatch for pinning an exact revision by hand — and what the smoke test itself uses.
2. **Known logical id → resolved** against the profiles this account can actually see in this region.
3. **Anything else → passed through** so Bedrock's own error surfaces, which beats us guessing.

**Discovery failure is never fatal.** A wrong model produces a legible Bedrock error; failing the Step here would bury the cause a layer up. Every fallback logs why.

### Note on where the map lives

The plan said to keep it in a kit helper. That isn't possible — **deployment-runner does not import kit**, the same constraint that forces the subscription-marker literals to be duplicated across repos. It lives in the runner, in one place. Plan corrected.

## Dependency note

Adds `aws-sdk-go-v2/service/bedrock`, which transitively bumps `smithy-go` 1.22.2 → 1.27.6. Worth a look given the monorepo's dependency-alignment rule, though the runner builds standalone. Full build and test suite pass — the single failure (`query_code`, non-constant format string) is pre-existing on master and unrelated.

## Tests

Eight passing. The pure logic is covered — the dot rule against both real id shapes, the region→prefix mapping (including `apac.`, which is *not* `ap.`), unknown-id pass-through, and a guard that the family map never gains a version or revision. The `ListInferenceProfiles` branch needs live AWS and is covered by the smoke test.

Concrete-id pass-through is asserted with a zero `aws.Config`, which proves it short-circuits before touching the SDK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
