### PR TITLE
Discover Bedrock inference-profile ids instead of deriving them (B2)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.31.1
 	github.com/aws/aws-sdk-go-v2/service/sts v1.28.6
 	github.com/aws/smithy-go v1.27.6
-	github.com/deployment-io/deployment-runner-kit v0.0.0-20260716054714-28558a103f33
+	github.com/deployment-io/deployment-runner-kit v0.0.0-20260804072212-c98a9b6ea1b5
 	github.com/deployment-io/team-ai v0.0.0-20250917084912-bdbad6a834e1
 	github.com/docker/docker v27.3.0+incompatible
 	github.com/go-git/go-git/v5 v5.12.0

--- a/go.mod
+++ b/go.mod
@@ -9,9 +9,10 @@ require (
 	github.com/ankit-arora/langchaingo v0.0.0-20250213122302-122a5007324f
 	github.com/ankit-arora/markdown v0.0.0-20240801070227-28eff2aa6649
 	github.com/ankit-arora/nixpacks-go v0.0.0-20240925063829-e4f7ef9412db
-	github.com/aws/aws-sdk-go-v2 v1.34.0
+	github.com/aws/aws-sdk-go-v2 v1.43.3
 	github.com/aws/aws-sdk-go-v2/config v1.27.11
 	github.com/aws/aws-sdk-go-v2/service/acm v1.25.4
+	github.com/aws/aws-sdk-go-v2/service/bedrock v1.66.3
 	github.com/aws/aws-sdk-go-v2/service/cloudfront v1.36.0
 	github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.38.6
 	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.45.6
@@ -25,7 +26,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.31.1
 	github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.31.1
 	github.com/aws/aws-sdk-go-v2/service/sts v1.28.6
-	github.com/aws/smithy-go v1.22.2
+	github.com/aws/smithy-go v1.27.6
 	github.com/deployment-io/deployment-runner-kit v0.0.0-20260716054714-28558a103f33
 	github.com/deployment-io/team-ai v0.0.0-20250917084912-bdbad6a834e1
 	github.com/docker/docker v27.3.0+incompatible
@@ -52,8 +53,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.7 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.11 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.1 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.29 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.29 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.34 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.34 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.0 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.3.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/autoscaling v1.40.5 // indirect

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.31.1
 	github.com/aws/aws-sdk-go-v2/service/sts v1.28.6
 	github.com/aws/smithy-go v1.27.6
-	github.com/deployment-io/deployment-runner-kit v0.0.0-20260804072212-c98a9b6ea1b5
+	github.com/deployment-io/deployment-runner-kit v0.0.0-20260804115737-e2d8747cdfbc
 	github.com/deployment-io/team-ai v0.0.0-20250917084912-bdbad6a834e1
 	github.com/docker/docker v27.3.0+incompatible
 	github.com/go-git/go-git/v5 v5.12.0

--- a/go.sum
+++ b/go.sum
@@ -155,6 +155,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/deployment-io/deployment-runner-kit v0.0.0-20260716054714-28558a103f33 h1:8h8FOc+KeJbedPMbsOB85Prd3p+cbx+f0fWwPVP/unk=
 github.com/deployment-io/deployment-runner-kit v0.0.0-20260716054714-28558a103f33/go.mod h1:OEoIfAAL2cUkK4Rf0rpW32YqHw7Mgx2aaC7o07IGAhQ=
+github.com/deployment-io/deployment-runner-kit v0.0.0-20260804072212-c98a9b6ea1b5 h1:0abv3v0A/gnG2nz6zaW6qCFBL6hR5U9pbrqC31rV7s0=
+github.com/deployment-io/deployment-runner-kit v0.0.0-20260804072212-c98a9b6ea1b5/go.mod h1:OEoIfAAL2cUkK4Rf0rpW32YqHw7Mgx2aaC7o07IGAhQ=
 github.com/deployment-io/team-ai v0.0.0-20250917084912-bdbad6a834e1 h1:gfeNqym19IiO38sQ84WPMmZXrdDisu64qQP3Xs0N2RM=
 github.com/deployment-io/team-ai v0.0.0-20250917084912-bdbad6a834e1/go.mod h1:B0fxmLJICi0qP2R2m3I2tR1uRIKQxn4ekK67lyBRHjw=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=

--- a/go.sum
+++ b/go.sum
@@ -153,10 +153,8 @@ github.com/cyphar/filepath-securejoin v0.2.5/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxG
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deployment-io/deployment-runner-kit v0.0.0-20260716054714-28558a103f33 h1:8h8FOc+KeJbedPMbsOB85Prd3p+cbx+f0fWwPVP/unk=
-github.com/deployment-io/deployment-runner-kit v0.0.0-20260716054714-28558a103f33/go.mod h1:OEoIfAAL2cUkK4Rf0rpW32YqHw7Mgx2aaC7o07IGAhQ=
-github.com/deployment-io/deployment-runner-kit v0.0.0-20260804072212-c98a9b6ea1b5 h1:0abv3v0A/gnG2nz6zaW6qCFBL6hR5U9pbrqC31rV7s0=
-github.com/deployment-io/deployment-runner-kit v0.0.0-20260804072212-c98a9b6ea1b5/go.mod h1:OEoIfAAL2cUkK4Rf0rpW32YqHw7Mgx2aaC7o07IGAhQ=
+github.com/deployment-io/deployment-runner-kit v0.0.0-20260804115737-e2d8747cdfbc h1:e7JZQHIRtd/Zo4Ggj2HYXv1zObPS3MnZOPKnSTQT5fc=
+github.com/deployment-io/deployment-runner-kit v0.0.0-20260804115737-e2d8747cdfbc/go.mod h1:wKTz63GqLOHVXT173zlW/zJFRLi9krn7dqXoDm/BXFI=
 github.com/deployment-io/team-ai v0.0.0-20250917084912-bdbad6a834e1 h1:gfeNqym19IiO38sQ84WPMmZXrdDisu64qQP3Xs0N2RM=
 github.com/deployment-io/team-ai v0.0.0-20250917084912-bdbad6a834e1/go.mod h1:B0fxmLJICi0qP2R2m3I2tR1uRIKQxn4ekK67lyBRHjw=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=

--- a/go.sum
+++ b/go.sum
@@ -56,8 +56,8 @@ github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFI
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/aws/aws-sdk-go-v2 v1.34.0 h1:9iyL+cjifckRGEVpRKZP3eIxVlL06Qk1Tk13vreaVQU=
-github.com/aws/aws-sdk-go-v2 v1.34.0/go.mod h1:JgstGg0JjWU1KpVJjD5H0y0yyAIpSdKEq556EI6yOOM=
+github.com/aws/aws-sdk-go-v2 v1.43.3 h1:XJIcfv8uDs2ukdQsoAC8/Ebu1ejxwzlayl2ZsiFns2A=
+github.com/aws/aws-sdk-go-v2 v1.43.3/go.mod h1:70vwSy16txshwG+g55WkpgPKDIByzHI8ccBsOteo3bQ=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.7 h1:lL7IfaFzngfx0ZwUGOZdsFFnQ5uLvR0hWqqhyE7Q9M8=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.7/go.mod h1:QraP0UcVlQJsmHfioCrveWOC1nbiWUl3ej08h4mXWoc=
 github.com/aws/aws-sdk-go-v2/config v1.27.11 h1:f47rANd2LQEYHda2ddSCKYId18/8BhSRM4BULGmfgNA=
@@ -66,10 +66,10 @@ github.com/aws/aws-sdk-go-v2/credentials v1.17.11 h1:YuIB1dJNf1Re822rriUOTxopaHH
 github.com/aws/aws-sdk-go-v2/credentials v1.17.11/go.mod h1:AQtFPsDH9bI2O+71anW6EKL+NcD7LG3dpKGMV4SShgo=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.1 h1:FVJ0r5XTHSmIHJV6KuDmdYhEpvlHpiSd38RQWhut5J4=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.1/go.mod h1:zusuAeqezXzAB24LGuzuekqMAEgWkVYukBec3kr3jUg=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.29 h1:Ej0Rf3GMv50Qh4G4852j2djtoDb7AzQ7MuQeFHa3D70=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.29/go.mod h1:oeNTC7PwJNoM5AznVr23wxhLnuJv0ZDe5v7w0wqIs9M=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.29 h1:6e8a71X+9GfghragVevC5bZqvATtc3mAMgxpSNbgzF0=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.29/go.mod h1:c4jkZiQ+BWpNqq7VtrxjwISrLrt/VvPq3XiopkUIolI=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.34 h1:vuIfjzoeqhQMGJyOBU3t0ZEjn2jrN8Bbg1N4CgjzM5Q=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.34/go.mod h1:hP28cN4CPJLZHirdQPrZR50JcLN4ApRJP2tzG8cRlhY=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.34 h1:9faHsnqxJ1vDvB4wMZy/ajIDyz5QhllQjjc72RJpXAw=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.34/go.mod h1:Yp6nIyejpa23nzlB/LhT63KTla9Jdi06nv/HH/OkAH8=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.0 h1:hT8rVHwugYE2lEfdFE0QWVo81lF7jMrYJVDWI+f+VxU=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.0/go.mod h1:8tu/lYfQfFe6IGnaOdrpVgEL2IrrDOf6/m9RQum4NkY=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.3.5 h1:81KE7vaZzrl7yHBYHVEzYB8sypz11NMOZ40YlWvPxsU=
@@ -78,6 +78,8 @@ github.com/aws/aws-sdk-go-v2/service/acm v1.25.4 h1:Hc7j0FECuM+/jsQ0vY54sEFxCc1v
 github.com/aws/aws-sdk-go-v2/service/acm v1.25.4/go.mod h1:kTFYiaoqqRsZC+BYdciI5tFLtuodontKG5jGjCGtPUg=
 github.com/aws/aws-sdk-go-v2/service/autoscaling v1.40.5 h1:vhdJymxlWS2qftzLiuCjSswjXBRLGfzo/BEE9LDveBA=
 github.com/aws/aws-sdk-go-v2/service/autoscaling v1.40.5/go.mod h1:ZErgk/bPaaZIpj+lUWGlwI1A0UFhSIscgnCPzTLnb2s=
+github.com/aws/aws-sdk-go-v2/service/bedrock v1.66.3 h1:XipaRLJ12/xg+Q2m9K4OkjOrySZuI61HU7bJFVamcNw=
+github.com/aws/aws-sdk-go-v2/service/bedrock v1.66.3/go.mod h1:T46juyeeEVRrIMNFhe3P7h7B8bbROERSebRlwPE+K8Q=
 github.com/aws/aws-sdk-go-v2/service/cloudfront v1.36.0 h1:KbT1H0KXc26/M6km03gBWz5v1M5aOq4Cwo+aXJ2BpfM=
 github.com/aws/aws-sdk-go-v2/service/cloudfront v1.36.0/go.mod h1:Pphkts8iBnexoEpcMti5fUvN3/yoGRLtl2heOeppF70=
 github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.38.6 h1:UVjxYe8VGpwXYcmBcciBHlQrNssdEvntXCPWmnRR15U=
@@ -118,8 +120,8 @@ github.com/aws/aws-sdk-go-v2/service/ssooidc v1.23.4 h1:Jux+gDDyi1Lruk+KHF91tK2K
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.23.4/go.mod h1:mUYPBhaF2lGiukDEjJX2BLRRKTmoUSitGDUgM4tRxak=
 github.com/aws/aws-sdk-go-v2/service/sts v1.28.6 h1:cwIxeBttqPN3qkaAjcEcsh8NYr8n2HZPkcKgPAi1phU=
 github.com/aws/aws-sdk-go-v2/service/sts v1.28.6/go.mod h1:FZf1/nKNEkHdGGJP/cI2MoIMquumuRK6ol3QQJNDxmw=
-github.com/aws/smithy-go v1.22.2 h1:6D9hW43xKFrRx/tXXfAlIZc4JI+yQe6snnWcQyxSyLQ=
-github.com/aws/smithy-go v1.22.2/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxYa/cJHg=
+github.com/aws/smithy-go v1.27.6 h1:0zjT8jgK3jbrTT7JJ3EE6JsMhX8JTrZ+f1sEndYDXrA=
+github.com/aws/smithy-go v1.27.6/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/bitly/go-simplejson v0.5.0/go.mod h1:cXHtHw4XUPsvGaxgjIAn8PhEWG9NfngEKAMDJEczWVA=

--- a/jobs/commands/bedrock_creds_test.go
+++ b/jobs/commands/bedrock_creds_test.go
@@ -3,10 +3,10 @@ package commands
 import (
 	"context"
 	"io"
-	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/deployment-io/deployment-runner-kit/enums/llm_provider_enums"
 )
 
 // Both guards return before any AWS/RunnerData access, so they're safe to unit
@@ -76,17 +76,26 @@ func TestBedrockRegionPrefix(t *testing.T) {
 	}
 }
 
-func TestBedrockModelFamilies_AreFamilyTokensNotConcreteIDs(t *testing.T) {
-	// The whole point of the map is that it stops at the family: a version or
-	// revision baked in here would need a runner release per Bedrock model
-	// launch, and would fail at task time in between.
-	for logical, family := range bedrockModelFamilies {
-		if strings.Contains(family, ".") || strings.Contains(family, ":") {
-			t.Errorf("family %q for %q looks like a concrete profile id; it must be a family token only", family, logical)
-		}
-		if strings.Contains(logical, ".") {
-			t.Errorf("logical id %q contains a dot, which resolveBedrockModelID treats as an already-concrete id", logical)
-		}
+func TestResolveBedrockModelID_UsesTheSharedCatalogue(t *testing.T) {
+	// The logical -> family map is no longer duplicated here; it comes from
+	// deployment-runner-kit, which the control plane also imports. Pin the seam
+	// so a catalogue change that drops a family is visible from this side too.
+	m, err := llm_provider_enums.GetModel("claude-opus-4-8")
+	if err != nil {
+		t.Fatalf("catalogue no longer knows claude-opus-4-8: %v", err)
+	}
+	if m.BedrockFamily() == "" {
+		t.Error("claude-opus-4-8 has no Bedrock family in the catalogue; discovery cannot resolve it")
+	}
+	// A model the catalogue does not know must pass through, not panic or guess.
+	const unknown = "some-future-model"
+	if got := resolveBedrockModelID(context.Background(), aws.Config{}, unknown, "eu-west-1", io.Discard); got != unknown {
+		t.Errorf("resolveBedrockModelID(%q) = %q, want it passed through unchanged", unknown, got)
+	}
+	// A known model that Bedrock does not serve must also pass through — gpt-5.5
+	// is in the catalogue but has no family token.
+	if got := resolveBedrockModelID(context.Background(), aws.Config{}, "gpt-5.5", "eu-west-1", io.Discard); got != "gpt-5.5" {
+		t.Errorf("resolveBedrockModelID(gpt-5.5) = %q, want it passed through unchanged", got)
 	}
 }
 

--- a/jobs/commands/bedrock_creds_test.go
+++ b/jobs/commands/bedrock_creds_test.go
@@ -1,8 +1,12 @@
 package commands
 
 import (
+	"context"
 	"io"
+	"strings"
 	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
 )
 
 // Both guards return before any AWS/RunnerData access, so they're safe to unit
@@ -26,6 +30,63 @@ func TestApplyBedrockCredsIfNeeded_NoOpWhenRoleArnMissing(t *testing.T) {
 	applyBedrockCredsIfNeeded(env, io.Discard)
 	if _, ok := env["AWS_ACCESS_KEY_ID"]; ok {
 		t.Error("must not inject creds when BedrockRoleArn is unset")
+	}
+}
+
+// Model resolution: the dot rule and the region prefix are pure logic and
+// testable; the ListInferenceProfiles branch needs live AWS and is covered by
+// the smoke test. The dot rule is what keeps a hand-pinned profile id working,
+// so it is worth pinning precisely.
+func TestResolveBedrockModelID_PassesThroughConcreteProfileIDs(t *testing.T) {
+	// Both real shapes seen in the wild — a clean id and a dated/revisioned one.
+	for _, id := range []string{
+		"eu.anthropic.claude-sonnet-4-5-20250929-v1:0",
+		"anthropic.claude-sonnet-5",
+		"us.anthropic.claude-opus-4-1-20250805-v1:0",
+	} {
+		// A concrete id must short-circuit BEFORE any AWS call — passing a zero
+		// aws.Config proves it never reaches the SDK.
+		if got := resolveBedrockModelID(context.Background(), aws.Config{}, id, "eu-west-1", io.Discard); got != id {
+			t.Errorf("resolveBedrockModelID(%q) = %q, want it passed through unchanged", id, got)
+		}
+	}
+}
+
+func TestResolveBedrockModelID_UnknownLogicalIDPassesThrough(t *testing.T) {
+	// Not in the family map and not dotted: hand it to Bedrock so its own error
+	// message surfaces, rather than guessing a profile.
+	const model = "some-future-model"
+	if got := resolveBedrockModelID(context.Background(), aws.Config{}, model, "eu-west-1", io.Discard); got != model {
+		t.Errorf("resolveBedrockModelID(%q) = %q, want it passed through unchanged", model, got)
+	}
+}
+
+func TestBedrockRegionPrefix(t *testing.T) {
+	cases := map[string]string{
+		"eu-west-1":      "eu.",
+		"eu-central-1":   "eu.",
+		"ap-southeast-2": "apac.", // NOT "ap." — Bedrock groups APAC under one prefix
+		"us-east-1":      "us.",
+		"ca-central-1":   "us.", // Americas fall back to the us. geography
+	}
+	for region, want := range cases {
+		if got := bedrockRegionPrefix(region); got != want {
+			t.Errorf("bedrockRegionPrefix(%q) = %q, want %q", region, got, want)
+		}
+	}
+}
+
+func TestBedrockModelFamilies_AreFamilyTokensNotConcreteIDs(t *testing.T) {
+	// The whole point of the map is that it stops at the family: a version or
+	// revision baked in here would need a runner release per Bedrock model
+	// launch, and would fail at task time in between.
+	for logical, family := range bedrockModelFamilies {
+		if strings.Contains(family, ".") || strings.Contains(family, ":") {
+			t.Errorf("family %q for %q looks like a concrete profile id; it must be a family token only", family, logical)
+		}
+		if strings.Contains(logical, ".") {
+			t.Errorf("logical id %q contains a dot, which resolveBedrockModelID treats as an already-concrete id", logical)
+		}
 	}
 }
 

--- a/jobs/commands/run_agent_step.go
+++ b/jobs/commands/run_agent_step.go
@@ -26,6 +26,7 @@ import (
 	"github.com/deployment-io/deployment-runner-kit/deployments"
 	"github.com/deployment-io/deployment-runner-kit/enums/build_enums"
 	"github.com/deployment-io/deployment-runner-kit/enums/iam_policy_enums"
+	"github.com/deployment-io/deployment-runner-kit/enums/llm_provider_enums"
 	"github.com/deployment-io/deployment-runner-kit/enums/parameters_enums"
 	"github.com/deployment-io/deployment-runner-kit/enums/region_enums"
 	"github.com/deployment-io/deployment-runner-kit/iam_policies"
@@ -452,25 +453,6 @@ const bedrockRoleArnEnvVar = "BedrockRoleArn"
 // and defers. Ship v1 at 1h and revisit if long-task expiry is actually hit.
 const bedrockMaxSessionSeconds = 3600
 
-// bedrockModelFamilies maps our logical model ids to the Bedrock "family token"
-// shared by every concrete profile for that model.
-//
-// It deliberately stops at the family. Real Bedrock ids carry a version and
-// revision that we do NOT hardcode — the live run turned up two shapes,
-// `anthropic.claude-sonnet-5` and `anthropic.claude-sonnet-4-5-20250929-v1:0` —
-// and those suffixes change as models ship and differ per region. Pinning them
-// here would mean a runner release per Bedrock model launch, failing at task
-// time in between. The volatile half comes from ListInferenceProfiles instead.
-//
-// NOTE: this map cannot live in kit — deployment-runner does not import it (the
-// same constraint that forces the subscription-marker literals to be duplicated
-// across repos). Keep it here, in one place.
-var bedrockModelFamilies = map[string]string{
-	"claude-opus-4-8":   "claude-opus-4",
-	"claude-sonnet-4-6": "claude-sonnet-4",
-	"claude-haiku-4-5":  "claude-haiku-4",
-}
-
 // bedrockRegionPrefix returns the cross-region inference prefix for an AWS
 // region. Bedrock groups regions into geographies, so this is a coarse mapping
 // of the region's first segment, not a per-region lookup.
@@ -504,9 +486,19 @@ func resolveBedrockModelID(ctx context.Context, cfg aws.Config, model, region st
 	if strings.Contains(model, ".") {
 		return model
 	}
-	family, known := bedrockModelFamilies[model]
-	if !known {
-		io.WriteString(logsWriter, fmt.Sprintf("Bedrock: no profile mapping for model %q; passing it through unchanged.\n", model))
+	// The logical model -> Bedrock family map lives in the shared catalogue, not
+	// here: deployment-runner-kit is the one module both the control plane and
+	// the runner import, so a second copy in this file was exactly the drift the
+	// catalogue exists to prevent. It also carries the guard that any model
+	// claiming Bedrock has a family token.
+	m, err := llm_provider_enums.GetModel(model)
+	if err != nil {
+		io.WriteString(logsWriter, fmt.Sprintf("Bedrock: %q is not a catalogue model; passing it through unchanged.\n", model))
+		return model
+	}
+	family := m.BedrockFamily()
+	if family == "" {
+		io.WriteString(logsWriter, fmt.Sprintf("Bedrock: model %q is not served by Bedrock; passing it through unchanged.\n", model))
 		return model
 	}
 	out, err := bedrock.NewFromConfig(cfg).ListInferenceProfiles(ctx, &bedrock.ListInferenceProfilesInput{
@@ -1178,10 +1170,10 @@ func removeContainer(ctx context.Context, cli *client.Client, containerID string
 // dashboard can surface "add these to your allowlist" suggestions.
 // Empty when no allowlist denies happened during the run.
 type agentResult struct {
-	Status         string     `json:"status"`
-	ExitCode       int        `json:"exit_code"`
-	AgentVersion   string     `json:"agent_version,omitempty"`
-	ChangesSummary string     `json:"changes_summary,omitempty"`
+	Status         string `json:"status"`
+	ExitCode       int    `json:"exit_code"`
+	AgentVersion   string `json:"agent_version,omitempty"`
+	ChangesSummary string `json:"changes_summary,omitempty"`
 	// FilesChanged is the agent's self-reported list of changed files. Carried
 	// through to agentOutput so CommitAndPush can detect the "agent reported
 	// changes but nothing landed in a repo" failure (writes outside the repo dir).

--- a/jobs/commands/run_agent_step.go
+++ b/jobs/commands/run_agent_step.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/bedrock"
 	"github.com/aws/aws-sdk-go-v2/service/cloudfront"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
@@ -451,6 +452,90 @@ const bedrockRoleArnEnvVar = "BedrockRoleArn"
 // and defers. Ship v1 at 1h and revisit if long-task expiry is actually hit.
 const bedrockMaxSessionSeconds = 3600
 
+// bedrockModelFamilies maps our logical model ids to the Bedrock "family token"
+// shared by every concrete profile for that model.
+//
+// It deliberately stops at the family. Real Bedrock ids carry a version and
+// revision that we do NOT hardcode — the live run turned up two shapes,
+// `anthropic.claude-sonnet-5` and `anthropic.claude-sonnet-4-5-20250929-v1:0` —
+// and those suffixes change as models ship and differ per region. Pinning them
+// here would mean a runner release per Bedrock model launch, failing at task
+// time in between. The volatile half comes from ListInferenceProfiles instead.
+//
+// NOTE: this map cannot live in kit — deployment-runner does not import it (the
+// same constraint that forces the subscription-marker literals to be duplicated
+// across repos). Keep it here, in one place.
+var bedrockModelFamilies = map[string]string{
+	"claude-opus-4-8":   "claude-opus-4",
+	"claude-sonnet-4-6": "claude-sonnet-4",
+	"claude-haiku-4-5":  "claude-haiku-4",
+}
+
+// bedrockRegionPrefix returns the cross-region inference prefix for an AWS
+// region. Bedrock groups regions into geographies, so this is a coarse mapping
+// of the region's first segment, not a per-region lookup.
+func bedrockRegionPrefix(region string) string {
+	switch {
+	case strings.HasPrefix(region, "eu-"):
+		return "eu."
+	case strings.HasPrefix(region, "ap-"):
+		return "apac."
+	default:
+		return "us."
+	}
+}
+
+// resolveBedrockModelID turns the Task's model into a Bedrock inference-profile
+// id, discovering the concrete id rather than deriving it.
+//
+// Three paths, in order:
+//  1. A model containing a "." is already a Bedrock id — passed through
+//     verbatim. Our logical ids never contain dots, so this is unambiguous, and
+//     it is the escape hatch that lets an exact revision be pinned by hand.
+//  2. A known logical id is matched against the profiles this account can
+//     actually see in this region.
+//  3. Anything else is passed through so Bedrock rejects it with its own
+//     message, which is more useful than us guessing.
+//
+// Discovery failures are NEVER fatal: the original model is returned and the
+// reason logged. A wrong model produces a legible Bedrock error, whereas
+// failing the Step here would hide the cause one layer up.
+func resolveBedrockModelID(ctx context.Context, cfg aws.Config, model, region string, logsWriter io.Writer) string {
+	if strings.Contains(model, ".") {
+		return model
+	}
+	family, known := bedrockModelFamilies[model]
+	if !known {
+		io.WriteString(logsWriter, fmt.Sprintf("Bedrock: no profile mapping for model %q; passing it through unchanged.\n", model))
+		return model
+	}
+	out, err := bedrock.NewFromConfig(cfg).ListInferenceProfiles(ctx, &bedrock.ListInferenceProfilesInput{
+		MaxResults: aws.Int32(100),
+	})
+	if err != nil {
+		io.WriteString(logsWriter, fmt.Sprintf("Bedrock: could not list inference profiles (%s); passing %q through unchanged.\n", err, model))
+		return model
+	}
+	prefix := bedrockRegionPrefix(region)
+	var matches []string
+	for _, p := range out.InferenceProfileSummaries {
+		id := aws.ToString(p.InferenceProfileId)
+		if strings.HasPrefix(id, prefix) && strings.Contains(id, family) {
+			matches = append(matches, id)
+		}
+	}
+	if len(matches) == 0 {
+		io.WriteString(logsWriter, fmt.Sprintf("Bedrock: no %s inference profile for %q in %s — check model access for this account/region. Passing it through unchanged.\n", prefix, model, region))
+		return model
+	}
+	// Descending so the newest revision wins: the date and -vN:0 suffixes sort
+	// lexicographically within a family. Logged because a silent pick between
+	// several revisions is hard to reconstruct from a failure later.
+	sort.Sort(sort.Reverse(sort.StringSlice(matches)))
+	io.WriteString(logsWriter, fmt.Sprintf("Bedrock: resolved model %q -> %s.\n", model, matches[0]))
+	return matches[0]
+}
+
 // bedrockSessionSeconds is how long a vended Bedrock session should last: the
 // per-task wall-clock cap, clamped to the role-chaining limit above. These
 // creds are injected as env vars and do NOT auto-refresh, so a session shorter
@@ -522,10 +607,12 @@ func applyBedrockCredsIfNeeded(env map[string]string, logsWriter io.Writer) {
 	env["AWS_SECRET_ACCESS_KEY"] = aws.ToString(c.SecretAccessKey)
 	env["AWS_SESSION_TOKEN"] = aws.ToString(c.SessionToken)
 	env["AWS_REGION"] = region
-	// claude-code in Bedrock mode takes the model from ANTHROPIC_MODEL (an
-	// inference-profile id). Pass the selected model through.
+	// claude-code in Bedrock mode takes the model from ANTHROPIC_MODEL, which
+	// must be a concrete inference-profile id — a logical id like
+	// "claude-opus-4-8" reaches Bedrock verbatim and is rejected with
+	// "The provided model identifier is invalid". Resolve it here.
 	if m := env["MODEL"]; m != "" {
-		env["ANTHROPIC_MODEL"] = m
+		env["ANTHROPIC_MODEL"] = resolveBedrockModelID(context.TODO(), cfg, m, region, logsWriter)
 	}
 	// Allowlist BOTH Bedrock hosts — agentbox's proxy gates egress, and
 	// claude-code uses both planes:


### PR DESCRIPTION
B2 — resolve Bedrock inference-profile ids instead of deriving them.

## The problem

The live smoke test got past auth and egress, then failed on the model:

```
API Error (claude-opus-4-8): 400 The provided model identifier is invalid.
```

The runner passed `MODEL` straight to `ANTHROPIC_MODEL`. **No prefix rule can bridge that gap** — real Bedrock ids carry a version and revision, and the same account showed two different shapes:

- `anthropic.claude-sonnet-5`
- `anthropic.claude-sonnet-4-5-20250929-v1:0`

Those suffixes change as models ship and differ per region. A static map in code would need a runner release per Bedrock model launch, failing at task time in between.

## The shape: split on what actually changes

| Layer | Where | Changes |
|---|---|---|
| logical id → family token | **the shared catalogue** (drk) | rarely |
| family token → concrete profile id for this region | `ListInferenceProfiles` at spawn | often, per-account |

Three paths through `resolveBedrockModelID`:

1. **Dotted model → passed through verbatim.** Our logical ids never contain dots, so this is unambiguous. It's the escape hatch for pinning an exact revision by hand — and what the smoke test uses.
2. **Known logical id → resolved** against the profiles this account can actually see in this region.
3. **Anything else → passed through**, so Bedrock's own error surfaces rather than us guessing.

**Discovery failure is never fatal.** A wrong model produces a legible Bedrock error; failing the Step here would bury the cause a layer up. Every fallback logs its reason — including "no profile in this region, check model access", which is the one a customer is most likely to hit.

## The family map is not duplicated here

An earlier revision of this PR carried its own `bedrockModelFamilies`, because the plan's "keep it in a kit helper" isn't possible — **deployment-runner cannot import kit**.

That's now resolved properly. `deployment-runner-kit` is the one module both the control plane and the runner import, and it gained the provider/model/harness catalogue (drk #49), so the mapping comes from `llm_provider_enums.Model.BedrockFamily()`. Shipping the local map would have reintroduced exactly the duplication that work had just removed.

It also inherits the catalogue's guard that any model claiming `AWSBedrock` as a provider has a family token — nothing enforced that while the map lived here.

## Dependency note

Adds `aws-sdk-go-v2/service/bedrock` (control plane), which transitively bumps `smithy-go` 1.22.2 → 1.27.6, and pulls drk forward to the catalogue commit. The monorepo-wide SDK alignment to these versions is in flight separately (drk #48, kit #204, app-server #216, controller #7).

## Tests

Eight passing, covering the pure logic:

- the dot rule against **both** real id shapes
- region → prefix, including `apac.` which is *not* `ap.`
- unknown-id pass-through
- the catalogue seam: a known Bedrock model has a family; a catalogue model with no family (`gpt-5.5`) passes through as "not served by Bedrock"

Concrete-id pass-through is asserted with a **zero `aws.Config`**, proving it short-circuits before touching the SDK rather than returning the right string by luck.

The `ListInferenceProfiles` branch needs live AWS. It'll be exercised by the opencode-on-Bedrock smoke test, which routes around the pending Anthropic use-case approval by using a non-Anthropic model.

Full build and suite pass; the one failure (`query_code`, non-constant format string) is pre-existing on master and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
