### PR TITLE
Give claude-code on Bedrock the resolved model, not the logical one

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.31.1
 	github.com/aws/aws-sdk-go-v2/service/sts v1.28.6
 	github.com/aws/smithy-go v1.27.6
-	github.com/deployment-io/deployment-runner-kit v0.0.0-20260806121742-4b9861f75224
+	github.com/deployment-io/deployment-runner-kit v0.0.0-20260807071207-19af9fb7acc6
 	github.com/deployment-io/team-ai v0.0.0-20250917084912-bdbad6a834e1
 	github.com/docker/docker v27.3.0+incompatible
 	github.com/go-git/go-git/v5 v5.12.0

--- a/go.sum
+++ b/go.sum
@@ -153,14 +153,8 @@ github.com/cyphar/filepath-securejoin v0.2.5/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxG
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deployment-io/deployment-runner-kit v0.0.0-20260805084335-9e73ab19f56f h1:MtWCHlLuVcQW7//i1M/BuldXWoumw4E5O8htNqVsn54=
-github.com/deployment-io/deployment-runner-kit v0.0.0-20260805084335-9e73ab19f56f/go.mod h1:wKTz63GqLOHVXT173zlW/zJFRLi9krn7dqXoDm/BXFI=
-github.com/deployment-io/deployment-runner-kit v0.0.0-20260806071544-75b3caf37e47 h1:3GeAupZT5GCUAp2ecXSclLp6kiHfdG6RhlXpRT4RJY4=
-github.com/deployment-io/deployment-runner-kit v0.0.0-20260806071544-75b3caf37e47/go.mod h1:wKTz63GqLOHVXT173zlW/zJFRLi9krn7dqXoDm/BXFI=
-github.com/deployment-io/deployment-runner-kit v0.0.0-20260806080844-872b42bd3201 h1:u/3J6T2N0D35mn6eACkxWvSFXHBgIg/0QF5oeK53mpQ=
-github.com/deployment-io/deployment-runner-kit v0.0.0-20260806080844-872b42bd3201/go.mod h1:wKTz63GqLOHVXT173zlW/zJFRLi9krn7dqXoDm/BXFI=
-github.com/deployment-io/deployment-runner-kit v0.0.0-20260806121742-4b9861f75224 h1:tjtfOV5mAGFRShnqFMj/CiYcODZ41AOv89xJEQLMZDg=
-github.com/deployment-io/deployment-runner-kit v0.0.0-20260806121742-4b9861f75224/go.mod h1:wKTz63GqLOHVXT173zlW/zJFRLi9krn7dqXoDm/BXFI=
+github.com/deployment-io/deployment-runner-kit v0.0.0-20260807071207-19af9fb7acc6 h1:3tkw44ULqkeKBq3F4YgGKSpPOVYhLdmXKRyxIhTpgtM=
+github.com/deployment-io/deployment-runner-kit v0.0.0-20260807071207-19af9fb7acc6/go.mod h1:wKTz63GqLOHVXT173zlW/zJFRLi9krn7dqXoDm/BXFI=
 github.com/deployment-io/team-ai v0.0.0-20250917084912-bdbad6a834e1 h1:gfeNqym19IiO38sQ84WPMmZXrdDisu64qQP3Xs0N2RM=
 github.com/deployment-io/team-ai v0.0.0-20250917084912-bdbad6a834e1/go.mod h1:B0fxmLJICi0qP2R2m3I2tR1uRIKQxn4ekK67lyBRHjw=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=

--- a/jobs/commands/agent_providers.go
+++ b/jobs/commands/agent_providers.go
@@ -169,10 +169,12 @@ func applyAgentModelEnv(env map[string]string, spawn agentSpawn, resolve modelRe
 		}
 		id = rendered
 	}
-	// WHICH variable carries the model is the catalogue's call, not ours: it is
-	// the same fact as claude-code's Bedrock switch, and the two must agree —
-	// an agent in Bedrock mode reading the wrong variable is broken either way.
-	// This file wrote that rule out itself and got it wrong, keying on the
-	// provider alone so codex on Bedrock was pointed at claude-code's variable.
-	env[llm_provider_enums.ModelEnvVar(provider, spawn.agentType)] = id
+	// WHERE the model goes is the catalogue's call, not ours: it is the same
+	// fact as claude-code's Bedrock switch, and the two must agree — an agent in
+	// Bedrock mode reading the wrong variable is broken either way. This file
+	// wrote that rule out itself and got it wrong twice: once keying on the
+	// provider alone, so codex on Bedrock was pointed at claude-code's
+	// variable, and once writing ANTHROPIC_MODEL *instead of* MODEL, which left
+	// agentbox passing the unresolved logical id as --model.
+	llm_provider_enums.ApplyModelEnv(env, id, provider, spawn.agentType)
 }

--- a/jobs/commands/agent_providers_test.go
+++ b/jobs/commands/agent_providers_test.go
@@ -235,3 +235,28 @@ func TestApplyAgentModelEnv_OnlyClaudeCodeReadsTheModelFromAnthropicModel(t *tes
 		t.Error("claude-code on Bedrock takes its model from ANTHROPIC_MODEL")
 	}
 }
+
+// The bug this fixes: agentbox reads MODEL and passes it as --model for every
+// agent, so writing only ANTHROPIC_MODEL left claude-code being told to run the
+// unresolved LOGICAL id against Bedrock — a flag overriding the inference
+// profile discovery had just resolved. Opencode was unaffected (it writes
+// MODEL), which is why a Nova smoke test would have gone green over it.
+func TestApplyAgentModelEnv_BedrockClaudeCodeGetsTheResolvedIDInBothVars(t *testing.T) {
+	const resolved = "eu.anthropic.claude-sonnet-4-6-20260101-v1:0"
+	env := map[string]string{}
+	resolve := modelResolver(func(context.Context, llm_provider_enums.Model) string { return resolved })
+	spawn := agentSpawn{
+		provider:  llm_provider_enums.AWSBedrock,
+		agentType: llm_provider_enums.ClaudeCode,
+		model:     "claude-sonnet-4-6",
+	}
+	applyAgentModelEnv(env, spawn, resolve, io.Discard)
+
+	if env["ANTHROPIC_MODEL"] != resolved {
+		t.Errorf("ANTHROPIC_MODEL = %q, want the resolved profile", env["ANTHROPIC_MODEL"])
+	}
+	// The one that was wrong: agentbox turns this into --model.
+	if env["MODEL"] != resolved {
+		t.Errorf("MODEL = %q, want the resolved profile — agentbox passes it as --model, so a logical id here overrides ANTHROPIC_MODEL", env["MODEL"])
+	}
+}


### PR DESCRIPTION
Found reviewing the provider chain end to end. Depends on drk #57 (merged).

### The bug

agentbox reads `MODEL` and passes it as `--model` for **every** agent it spawns:

```go
// agentbox internal/claude/driver.go
cfg.Model = os.Getenv("MODEL")
if cfg.Model != "" { args = append(args, "--model", cfg.Model) }
```

The runner wrote the resolved inference profile to `ANTHROPIC_MODEL` and left `MODEL` holding the **logical** id. So claude-code on Bedrock was invoked with `--model claude-sonnet-4-6` — a CLI flag overriding the profile the discovery step had just resolved.

Everything that step does — pagination, the `SYSTEM_DEFINED` filter, the version-pinned prefix that stops `claude-sonnet-4` matching a 4.5 profile — was dead weight on the one path that needs it.

### Why it survived

It predates the provider refactor; the old code did exactly the same. claude-code-on-Bedrock has never completed a live run, and **opencode is unaffected** because it writes `MODEL` — so the planned Nova smoke test would have gone green straight over this.

### The fix

drk #57's `ApplyModelEnv` writes `MODEL` always and `ANTHROPIC_MODEL` additionally — an extra input, not an alternative — so the runner makes one call and no longer decides which variable carries the model.

Regression test asserts both variables hold the resolved id.