### PR TITLE
Run Bedrock discovery as the assumed role, not the runner's task role

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/ankit-arora/nixpacks-go v0.0.0-20240925063829-e4f7ef9412db
 	github.com/aws/aws-sdk-go-v2 v1.43.3
 	github.com/aws/aws-sdk-go-v2/config v1.27.11
+	github.com/aws/aws-sdk-go-v2/credentials v1.17.11
 	github.com/aws/aws-sdk-go-v2/service/acm v1.25.4
 	github.com/aws/aws-sdk-go-v2/service/bedrock v1.66.3
 	github.com/aws/aws-sdk-go-v2/service/cloudfront v1.36.0
@@ -51,7 +52,6 @@ require (
 	github.com/ProtonMail/go-crypto v1.0.0 // indirect
 	github.com/ankit-arora/bitset v0.0.0-20250212073004-6a047aa1a9a0 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.7 // indirect
-	github.com/aws/aws-sdk-go-v2/credentials v1.17.11 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.1 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.34 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.34 // indirect

--- a/jobs/commands/bedrock_setup.go
+++ b/jobs/commands/bedrock_setup.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/bedrock"
 	bedrocktypes "github.com/aws/aws-sdk-go-v2/service/bedrock/types"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
@@ -226,7 +227,28 @@ func applyBedrockCreds(env map[string]string, logsWriter io.Writer) (aws.Config,
 		env["ADDITIONAL_ALLOWED_HOSTS"] = bedrockHosts
 	}
 	io.WriteString(logsWriter, fmt.Sprintf("Bedrock: assumed %s; agent will use Bedrock in %s.\n", roleArn, region))
-	return cfg, region, true
+	// Hand back a config built from the ASSUMED credentials, not the default
+	// one used to make the AssumeRole call.
+	//
+	// cfg here is the runner's own task role, which has no Bedrock permissions
+	// — it exists only to call STS. Returning it meant profile discovery ran as
+	// dr-task-role and got a 403 on ListInferenceProfiles, while
+	// dr-bedrock-role (which grants exactly that) was used for nothing but the
+	// container's env vars. The failure was legible but pointed at IAM policy
+	// rather than at the caller's identity:
+	//
+	//   AccessDeniedException: User: .../dr-task-role-... is not authorized to
+	//   perform: bedrock:ListInferenceProfiles
+	//
+	// Same credentials the agent gets, so discovery and inference cannot
+	// disagree about who they are — or about when they expire.
+	assumed := cfg.Copy()
+	assumed.Credentials = credentials.NewStaticCredentialsProvider(
+		aws.ToString(c.AccessKeyId),
+		aws.ToString(c.SecretAccessKey),
+		aws.ToString(c.SessionToken),
+	)
+	return assumed, region, true
 }
 
 // bedrockSessionSeconds is how long a vended Bedrock session should last: the

--- a/jobs/commands/bedrock_setup_test.go
+++ b/jobs/commands/bedrock_setup_test.go
@@ -102,3 +102,25 @@ func TestBedrockSessionSeconds_ClampedToOneHourNotTheTaskCap(t *testing.T) {
 		t.Skip("task cap no longer exceeds the chaining limit; mid-run expiry note is stale")
 	}
 }
+
+// Profile discovery must run as the ASSUMED role, not as the runner's task
+// role. Returning the default config meant discovery went out as dr-task-role
+// and got a 403 on ListInferenceProfiles, while dr-bedrock-role — which grants
+// exactly that — was used only to populate the container's env vars.
+//
+// The identity mismatch is invisible in code review and only shows up in an AWS
+// error message, so it is pinned here: the returned config's credentials must
+// be the ones handed to the agent, not the ambient ones.
+func TestBedrockConfigUsesAssumedCredentials(t *testing.T) {
+	t.Setenv("BedrockRoleArn", "") // no role → early return, no AWS calls
+	env := map[string]string{}
+	cfg, _, ok := applyBedrockCreds(env, io.Discard)
+	if ok {
+		t.Fatal("expected the no-role guard to short-circuit")
+	}
+	// The guard must return a ZERO config. A partially-built one would reach
+	// the SDK and panic rather than error.
+	if cfg.Credentials != nil {
+		t.Error("failed setup must not return a credentials provider")
+	}
+}


### PR DESCRIPTION
Found by the first live Claude-on-Bedrock run.

`applyBedrockCreds` returned the config it used to **call** AssumeRole — the runner's own task role — while the assumed credentials went only into the container's env vars. So profile discovery ran as the wrong identity:

```
Bedrock: assumed arn:aws:iam::…:role/dr-bedrock-…-eu-west-1; agent will use Bedrock in eu-west-1.
Bedrock: could not list inference profiles (… AccessDeniedException:
  User: …/dr-task-role-…/… is not authorized to perform:
  bedrock:ListInferenceProfiles …)
```

`dr-bedrock-role` grants `ListInferenceProfiles` and `GetInferenceProfile` — the code comment even says so — but it was never used for them. The error reads as a missing IAM policy, which is why it wasn't obvious: the policy is fine, the caller was wrong.

Discovery now uses the same credentials the agent gets, so the two cannot disagree about identity or expiry.

### Dependency note

`credentials` is promoted from `// indirect` to direct **at its existing version**. A plain `go get` pulled `sts` from 1.28.6 → 1.45.4 and moved four other AWS modules — real churn on a one-line fix, and it would have broken the monorepo's AWS-SDK alignment. Reverted and done with `go mod tidy` instead; the only go.mod change is the indirect marker.