### PR TITLE
Bump drk so the runner knows the 4.5-generation models

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.31.1
 	github.com/aws/aws-sdk-go-v2/service/sts v1.28.6
 	github.com/aws/smithy-go v1.27.6
-	github.com/deployment-io/deployment-runner-kit v0.0.0-20260807071207-19af9fb7acc6
+	github.com/deployment-io/deployment-runner-kit v0.0.0-20260809065752-d1a22cbdba34
 	github.com/deployment-io/team-ai v0.0.0-20250917084912-bdbad6a834e1
 	github.com/docker/docker v27.3.0+incompatible
 	github.com/go-git/go-git/v5 v5.12.0

--- a/go.sum
+++ b/go.sum
@@ -153,8 +153,8 @@ github.com/cyphar/filepath-securejoin v0.2.5/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxG
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deployment-io/deployment-runner-kit v0.0.0-20260807071207-19af9fb7acc6 h1:3tkw44ULqkeKBq3F4YgGKSpPOVYhLdmXKRyxIhTpgtM=
-github.com/deployment-io/deployment-runner-kit v0.0.0-20260807071207-19af9fb7acc6/go.mod h1:wKTz63GqLOHVXT173zlW/zJFRLi9krn7dqXoDm/BXFI=
+github.com/deployment-io/deployment-runner-kit v0.0.0-20260809065752-d1a22cbdba34 h1:0KXBtgLOcy+3qVPJdkIqbwa3i/ZUdsxKnAVqssJJE3o=
+github.com/deployment-io/deployment-runner-kit v0.0.0-20260809065752-d1a22cbdba34/go.mod h1:wKTz63GqLOHVXT173zlW/zJFRLi9krn7dqXoDm/BXFI=
 github.com/deployment-io/team-ai v0.0.0-20250917084912-bdbad6a834e1 h1:gfeNqym19IiO38sQ84WPMmZXrdDisu64qQP3Xs0N2RM=
 github.com/deployment-io/team-ai v0.0.0-20250917084912-bdbad6a834e1/go.mod h1:B0fxmLJICi0qP2R2m3I2tR1uRIKQxn4ekK67lyBRHjw=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=


### PR DESCRIPTION
A live Bedrock run failed on version skew:

```
Bedrock: assumed arn:…:role/dr-bedrock-…; agent will use Bedrock in eu-west-1.
Model "claude-sonnet-4-5" is not in the catalogue; passing it through unchanged.
[init] model=claude-sonnet-4-5
API Error (claude-sonnet-4-5): 400 The provided model identifier is invalid.
```

app-server was on the drk carrying Sonnet 4.5 and offered it in the picker; the **runner** was still on the drk from before #60, so `GetModel` missed and it handed the logical id straight to claude-code.

Two things follow from that, and the second is why this blocks the retest:

1. Not a code fault — every piece behaved correctly for the catalogue it had.
2. **Discovery never ran.** `GetModel` failing returns *before* the resolve step, so the run could not exercise the credentials fix from #94 either — the 403 that failed the previous attempt simply never had a chance to occur.

Confirmed after the bump: `claude-sonnet-4-5` resolves with prefix `claude-sonnet-4-5`, `legacy=true`, `tier=balanced`.