### PR TITLE
Pass the model's vendor when rendering an opencode id

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.31.1
 	github.com/aws/aws-sdk-go-v2/service/sts v1.28.6
 	github.com/aws/smithy-go v1.27.6
-	github.com/deployment-io/deployment-runner-kit v0.0.0-20260809065752-d1a22cbdba34
+	github.com/deployment-io/deployment-runner-kit v0.0.0-20260810125648-0ccd80682696
 	github.com/deployment-io/team-ai v0.0.0-20250917084912-bdbad6a834e1
 	github.com/docker/docker v27.3.0+incompatible
 	github.com/go-git/go-git/v5 v5.12.0

--- a/go.sum
+++ b/go.sum
@@ -153,8 +153,8 @@ github.com/cyphar/filepath-securejoin v0.2.5/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxG
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deployment-io/deployment-runner-kit v0.0.0-20260809065752-d1a22cbdba34 h1:0KXBtgLOcy+3qVPJdkIqbwa3i/ZUdsxKnAVqssJJE3o=
-github.com/deployment-io/deployment-runner-kit v0.0.0-20260809065752-d1a22cbdba34/go.mod h1:wKTz63GqLOHVXT173zlW/zJFRLi9krn7dqXoDm/BXFI=
+github.com/deployment-io/deployment-runner-kit v0.0.0-20260810125648-0ccd80682696 h1:fRqoqptnFDcXfqWyeTQCemjgDdwYfmehuZjb8CEDVR4=
+github.com/deployment-io/deployment-runner-kit v0.0.0-20260810125648-0ccd80682696/go.mod h1:wKTz63GqLOHVXT173zlW/zJFRLi9krn7dqXoDm/BXFI=
 github.com/deployment-io/team-ai v0.0.0-20250917084912-bdbad6a834e1 h1:gfeNqym19IiO38sQ84WPMmZXrdDisu64qQP3Xs0N2RM=
 github.com/deployment-io/team-ai v0.0.0-20250917084912-bdbad6a834e1/go.mod h1:B0fxmLJICi0qP2R2m3I2tR1uRIKQxn4ekK67lyBRHjw=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=

--- a/jobs/commands/agent_providers.go
+++ b/jobs/commands/agent_providers.go
@@ -130,6 +130,11 @@ func prepareProvider(env map[string]string, p llm_provider_enums.Provider, logsW
 //	ResolvesModelIDAtRuntime   — whether the concrete id must be discovered
 //	OpencodeModelID            — the "provider/model" rendering
 //
+// The one thing the provider does NOT decide is whether a Bedrock id keeps its
+// cross-region geography prefix. That is a property of the model's VENDOR, so
+// the vendor is read off the catalogue here and handed to the renderer rather
+// than inferred from the id's own text.
+//
 // Adding Vertex later means setting that property and supplying its discovery;
 // nothing here changes.
 func applyAgentModelEnv(env map[string]string, spawn agentSpawn, resolve modelResolver, logsWriter io.Writer) {
@@ -144,9 +149,17 @@ func applyAgentModelEnv(env map[string]string, spawn agentSpawn, resolve modelRe
 		return
 	}
 
+	// The vendor travels with the id because opencode's rendering depends on
+	// WHO MAKES the model, not on how it is reached — models.dev lists some
+	// vendors' Bedrock ids under their cross-region geography prefix and others
+	// only bare. VendorUnknown is the honest answer for a model outside the
+	// catalogue, and means the id is passed through untouched.
+	vendor := llm_provider_enums.VendorUnknown
+
 	id := logical
 	if model, err := llm_provider_enums.GetModel(logical); err == nil {
 		id = model.IDFor(provider)
+		vendor = model.Vendor()
 		if provider.ResolvesModelIDAtRuntime() {
 			// Two different questions, deliberately kept apart: the provider
 			// says whether an id must be DISCOVERED, and a nil resolver says
@@ -163,7 +176,7 @@ func applyAgentModelEnv(env map[string]string, spawn agentSpawn, resolve modelRe
 	}
 
 	if spawn.agentType == llm_provider_enums.Opencode {
-		rendered := llm_provider_enums.OpencodeModelID(id, provider)
+		rendered := llm_provider_enums.OpencodeModelID(id, provider, vendor)
 		if rendered == "" {
 			return // unroutable; leave what the Task asked for so the error names it
 		}

--- a/jobs/commands/agent_providers_test.go
+++ b/jobs/commands/agent_providers_test.go
@@ -178,7 +178,48 @@ func TestApplyAgentModelEnv_UsesTheRegisteredResolver(t *testing.T) {
 	if called != "nova-pro-v1" {
 		t.Errorf("resolver received %q, want the logical model", called)
 	}
-	if want := "amazon-bedrock/eu.amazon.nova-pro-v1:0"; env["MODEL"] != want {
+	// The geography discovery found is gone, because Nova is an AMAZON-vendor
+	// model and opencode's registry has no prefixed entry for it. This
+	// assertion previously demanded eu.amazon.nova-pro-v1:0 — the id a live run
+	// failed on with ProviderModelNotFoundError. The test was pinning the bug.
+	if want := "amazon-bedrock/amazon.nova-pro-v1:0"; env["MODEL"] != want {
+		t.Errorf("MODEL = %q, want %q", env["MODEL"], want)
+	}
+}
+
+// The vendor reaches the renderer, and comes from the CATALOGUE rather than
+// from the id's text. Claude on Bedrock keeps its geography prefix — there the
+// prefixed id IS the cross-region inference profile — so this case and the Nova
+// one above must disagree while going through identical code.
+func TestApplyAgentModelEnv_KeepsGeographyForAnthropicVendorModels(t *testing.T) {
+	resolve := modelResolver(func(_ context.Context, _ llm_provider_enums.Model) string {
+		return "eu.anthropic.claude-sonnet-4-5-20250929-v1:0"
+	})
+	env := map[string]string{}
+	applyAgentModelEnv(env, agentSpawn{
+		provider:  llm_provider_enums.AWSBedrock,
+		agentType: llm_provider_enums.Opencode,
+		model:     "claude-sonnet-4-5",
+	}, resolve, io.Discard)
+
+	if want := "amazon-bedrock/eu.anthropic.claude-sonnet-4-5-20250929-v1:0"; env["MODEL"] != want {
+		t.Errorf("MODEL = %q, want %q — stripping here would ask Bedrock for "+
+			"on-demand throughput the model may not offer", env["MODEL"], want)
+	}
+}
+
+// A model outside the catalogue has no vendor, and an unknown vendor must not
+// be rewritten on a guess — the id is passed through as the Task asked for it,
+// so the failure names what was requested.
+func TestApplyAgentModelEnv_UnknownModelKeepsItsIDVerbatim(t *testing.T) {
+	env := map[string]string{}
+	applyAgentModelEnv(env, agentSpawn{
+		provider:  llm_provider_enums.AWSBedrock,
+		agentType: llm_provider_enums.Opencode,
+		model:     "eu.acme.not-in-the-catalogue-v1:0",
+	}, nil, io.Discard)
+
+	if want := "amazon-bedrock/eu.acme.not-in-the-catalogue-v1:0"; env["MODEL"] != want {
 		t.Errorf("MODEL = %q, want %q", env["MODEL"], want)
 	}
 }


### PR DESCRIPTION
Call-site half of deployment-io/deployment-runner-kit#61.

## Why

`OpencodeModelID` takes a `Vendor` now. Whether a Bedrock id keeps its cross-region geography prefix is a property of **who makes the model**, not of the id's text — models.dev lists some vendors' Bedrock ids prefixed and others only bare.

The vendor comes off the catalogue entry `applyAgentModelEnv` was already looking up, so nothing new is fetched. `VendorUnknown` is the honest answer for a model outside the catalogue and leaves the id untouched.

## A test was pinning the bug

`TestApplyAgentModelEnv_UsesTheRegisteredResolver` asserted `amazon-bedrock/eu.amazon.nova-pro-v1:0` — the exact id the live Nova run failed on with `ProviderModelNotFoundError`. It now expects the stripped form, plus two cases for the halves that must disagree through identical code:

- an Anthropic-vendor model **keeps** its prefix (there the prefixed id *is* the inference profile)
- an unknown model passes through **verbatim**

`TestApplyAgentModelEnv_BedrockClaudeCodeGetsTheResolvedIDInBothVars` still passes untouched — claude-code reaches Bedrock directly and is unaffected.

## Merge order

⚠️ **Draft: will not compile until drk#61 merges.** Then:

1. merge drk#61
2. bump `deployment-runner-kit` here, un-draft
3. merge + deploy the runner
4. re-run the Nova task, and an opencode + Sonnet 4.5 task — the second is the case a vendor-blind strip would have broken, and no Nova test could catch

Verified locally against the drk branch via a temporary `replace` (not committed): `go build ./...` and `go test ./jobs/commands/` both green.