### PR TITLE
Record what a run cost, at completion, with its provenance

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.31.1
 	github.com/aws/aws-sdk-go-v2/service/sts v1.28.6
 	github.com/aws/smithy-go v1.27.6
-	github.com/deployment-io/deployment-runner-kit v0.0.0-20260810125648-0ccd80682696
+	github.com/deployment-io/deployment-runner-kit v0.0.0-20260810162459-83a3943d34a4
 	github.com/deployment-io/team-ai v0.0.0-20250917084912-bdbad6a834e1
 	github.com/docker/docker v27.3.0+incompatible
 	github.com/go-git/go-git/v5 v5.12.0

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.31.1
 	github.com/aws/aws-sdk-go-v2/service/sts v1.28.6
 	github.com/aws/smithy-go v1.27.6
-	github.com/deployment-io/deployment-runner-kit v0.0.0-20260809065752-d1a22cbdba34
+	github.com/deployment-io/deployment-runner-kit v0.0.0-20260810125648-0ccd80682696
 	github.com/deployment-io/team-ai v0.0.0-20250917084912-bdbad6a834e1
 	github.com/docker/docker v27.3.0+incompatible
 	github.com/go-git/go-git/v5 v5.12.0

--- a/go.sum
+++ b/go.sum
@@ -153,8 +153,8 @@ github.com/cyphar/filepath-securejoin v0.2.5/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxG
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deployment-io/deployment-runner-kit v0.0.0-20260809065752-d1a22cbdba34 h1:0KXBtgLOcy+3qVPJdkIqbwa3i/ZUdsxKnAVqssJJE3o=
-github.com/deployment-io/deployment-runner-kit v0.0.0-20260809065752-d1a22cbdba34/go.mod h1:wKTz63GqLOHVXT173zlW/zJFRLi9krn7dqXoDm/BXFI=
+github.com/deployment-io/deployment-runner-kit v0.0.0-20260810125648-0ccd80682696 h1:fRqoqptnFDcXfqWyeTQCemjgDdwYfmehuZjb8CEDVR4=
+github.com/deployment-io/deployment-runner-kit v0.0.0-20260810125648-0ccd80682696/go.mod h1:wKTz63GqLOHVXT173zlW/zJFRLi9krn7dqXoDm/BXFI=
 github.com/deployment-io/team-ai v0.0.0-20250917084912-bdbad6a834e1 h1:gfeNqym19IiO38sQ84WPMmZXrdDisu64qQP3Xs0N2RM=
 github.com/deployment-io/team-ai v0.0.0-20250917084912-bdbad6a834e1/go.mod h1:B0fxmLJICi0qP2R2m3I2tR1uRIKQxn4ekK67lyBRHjw=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=

--- a/go.sum
+++ b/go.sum
@@ -153,8 +153,8 @@ github.com/cyphar/filepath-securejoin v0.2.5/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxG
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deployment-io/deployment-runner-kit v0.0.0-20260810125648-0ccd80682696 h1:fRqoqptnFDcXfqWyeTQCemjgDdwYfmehuZjb8CEDVR4=
-github.com/deployment-io/deployment-runner-kit v0.0.0-20260810125648-0ccd80682696/go.mod h1:wKTz63GqLOHVXT173zlW/zJFRLi9krn7dqXoDm/BXFI=
+github.com/deployment-io/deployment-runner-kit v0.0.0-20260810162459-83a3943d34a4 h1:K+zUvNb5PLTFqtTgGTaSfpUdNEGZ8g2YReMZZt3tPxA=
+github.com/deployment-io/deployment-runner-kit v0.0.0-20260810162459-83a3943d34a4/go.mod h1:wKTz63GqLOHVXT173zlW/zJFRLi9krn7dqXoDm/BXFI=
 github.com/deployment-io/team-ai v0.0.0-20250917084912-bdbad6a834e1 h1:gfeNqym19IiO38sQ84WPMmZXrdDisu64qQP3Xs0N2RM=
 github.com/deployment-io/team-ai v0.0.0-20250917084912-bdbad6a834e1/go.mod h1:B0fxmLJICi0qP2R2m3I2tR1uRIKQxn4ekK67lyBRHjw=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=

--- a/jobs/commands/agent_providers.go
+++ b/jobs/commands/agent_providers.go
@@ -130,6 +130,11 @@ func prepareProvider(env map[string]string, p llm_provider_enums.Provider, logsW
 //	ResolvesModelIDAtRuntime   — whether the concrete id must be discovered
 //	OpencodeModelID            — the "provider/model" rendering
 //
+// The one thing the provider does NOT decide is whether a Bedrock id keeps its
+// cross-region geography prefix. That is a property of the model's VENDOR, so
+// the vendor is read off the catalogue here and handed to the renderer rather
+// than inferred from the id's own text.
+//
 // Adding Vertex later means setting that property and supplying its discovery;
 // nothing here changes.
 func applyAgentModelEnv(env map[string]string, spawn agentSpawn, resolve modelResolver, logsWriter io.Writer) {
@@ -144,9 +149,17 @@ func applyAgentModelEnv(env map[string]string, spawn agentSpawn, resolve modelRe
 		return
 	}
 
+	// The vendor travels with the id because opencode's rendering depends on
+	// WHO MAKES the model, not on how it is reached — models.dev lists some
+	// vendors' Bedrock ids under their cross-region geography prefix and others
+	// only bare. VendorUnknown is the honest answer for a model outside the
+	// catalogue, and means the id is passed through untouched.
+	vendor := llm_provider_enums.VendorUnknown
+
 	id := logical
 	if model, err := llm_provider_enums.GetModel(logical); err == nil {
 		id = model.IDFor(provider)
+		vendor = model.Vendor()
 		if provider.ResolvesModelIDAtRuntime() {
 			// Two different questions, deliberately kept apart: the provider
 			// says whether an id must be DISCOVERED, and a nil resolver says
@@ -163,7 +176,7 @@ func applyAgentModelEnv(env map[string]string, spawn agentSpawn, resolve modelRe
 	}
 
 	if spawn.agentType == llm_provider_enums.Opencode {
-		rendered := llm_provider_enums.OpencodeModelID(id, provider)
+		rendered := llm_provider_enums.OpencodeModelID(id, provider, vendor)
 		if rendered == "" {
 			return // unroutable; leave what the Task asked for so the error names it
 		}

--- a/jobs/commands/agent_providers_test.go
+++ b/jobs/commands/agent_providers_test.go
@@ -178,7 +178,48 @@ func TestApplyAgentModelEnv_UsesTheRegisteredResolver(t *testing.T) {
 	if called != "nova-pro-v1" {
 		t.Errorf("resolver received %q, want the logical model", called)
 	}
-	if want := "amazon-bedrock/eu.amazon.nova-pro-v1:0"; env["MODEL"] != want {
+	// The geography discovery found is gone, because Nova is an AMAZON-vendor
+	// model and opencode's registry has no prefixed entry for it. This
+	// assertion previously demanded eu.amazon.nova-pro-v1:0 — the id a live run
+	// failed on with ProviderModelNotFoundError. The test was pinning the bug.
+	if want := "amazon-bedrock/amazon.nova-pro-v1:0"; env["MODEL"] != want {
+		t.Errorf("MODEL = %q, want %q", env["MODEL"], want)
+	}
+}
+
+// The vendor reaches the renderer, and comes from the CATALOGUE rather than
+// from the id's text. Claude on Bedrock keeps its geography prefix — there the
+// prefixed id IS the cross-region inference profile — so this case and the Nova
+// one above must disagree while going through identical code.
+func TestApplyAgentModelEnv_KeepsGeographyForAnthropicVendorModels(t *testing.T) {
+	resolve := modelResolver(func(_ context.Context, _ llm_provider_enums.Model) string {
+		return "eu.anthropic.claude-sonnet-4-5-20250929-v1:0"
+	})
+	env := map[string]string{}
+	applyAgentModelEnv(env, agentSpawn{
+		provider:  llm_provider_enums.AWSBedrock,
+		agentType: llm_provider_enums.Opencode,
+		model:     "claude-sonnet-4-5",
+	}, resolve, io.Discard)
+
+	if want := "amazon-bedrock/eu.anthropic.claude-sonnet-4-5-20250929-v1:0"; env["MODEL"] != want {
+		t.Errorf("MODEL = %q, want %q — stripping here would ask Bedrock for "+
+			"on-demand throughput the model may not offer", env["MODEL"], want)
+	}
+}
+
+// A model outside the catalogue has no vendor, and an unknown vendor must not
+// be rewritten on a guess — the id is passed through as the Task asked for it,
+// so the failure names what was requested.
+func TestApplyAgentModelEnv_UnknownModelKeepsItsIDVerbatim(t *testing.T) {
+	env := map[string]string{}
+	applyAgentModelEnv(env, agentSpawn{
+		provider:  llm_provider_enums.AWSBedrock,
+		agentType: llm_provider_enums.Opencode,
+		model:     "eu.acme.not-in-the-catalogue-v1:0",
+	}, nil, io.Discard)
+
+	if want := "amazon-bedrock/eu.acme.not-in-the-catalogue-v1:0"; env["MODEL"] != want {
 		t.Errorf("MODEL = %q, want %q", env["MODEL"], want)
 	}
 }

--- a/jobs/commands/commit_and_push.go
+++ b/jobs/commands/commit_and_push.go
@@ -343,7 +343,43 @@ type jobOutputData struct {
 	SchemaVersion int          `json:"schema_version"`
 	Agent         *agentOutput `json:"agent,omitempty"`
 	Repositories  []repoOutput `json:"repositories,omitempty"`
+	// Cost is what the run cost, RESOLVED ONCE HERE and never recomputed.
+	//
+	// Deliberately outside Agent: that block is agentbox's result.json passed
+	// through verbatim, and this is our resolution of it — sometimes the
+	// agent's own figure, sometimes our arithmetic. Mixing the two would lose
+	// the distinction between what was measured and what was inferred.
+	Cost *costOutput `json:"cost,omitempty"`
 }
+
+// costOutput is a run's cost with its PROVENANCE.
+//
+// Source matters as much as the number. An agent-reported cost came from the
+// vendor that billed it; an estimate is our arithmetic over token counts and a
+// rate table, and is wrong whenever the table is stale. Rendering them
+// identically tells a customer we know something we do not.
+//
+// Recorded at completion rather than derived on read, because a Task's cost is
+// a fact about when it ran. app-server previously recomputed codex costs during
+// response mapping, so editing a rate silently rewrote every past Task.
+type costOutput struct {
+	USD float64 `json:"usd"`
+	// Source is "agent" (the agent reported it) or "estimated" (we priced it
+	// from token counts). Absent Cost means neither was possible — render an
+	// unknown cost, never zero.
+	Source string `json:"source"`
+	// Model and Provider are recorded so a later question about a surprising
+	// figure can be answered without guessing which rate applied. They are also
+	// the only durable record of WHICH provider served a run, since the same
+	// model costs different amounts by route.
+	Model    string `json:"model,omitempty"`
+	Provider string `json:"provider,omitempty"`
+}
+
+const (
+	costSourceAgent     = "agent"
+	costSourceEstimated = "estimated"
+)
 
 type agentOutput struct {
 	ChangesSummary string `json:"changes_summary,omitempty"`

--- a/jobs/commands/run_agent_cost_test.go
+++ b/jobs/commands/run_agent_cost_test.go
@@ -1,0 +1,78 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/deployment-io/deployment-runner-kit/enums/llm_provider_enums"
+	"github.com/deployment-io/deployment-runner-kit/enums/parameters_enums"
+	"github.com/deployment-io/deployment-runner-kit/jobs"
+)
+
+func costParams(model string, p llm_provider_enums.Provider) map[string]interface{} {
+	parameters := map[string]interface{}{}
+	jobs.SetParameterValue[string](parameters, parameters_enums.Model, model)
+	jobs.SetParameterValue[string](parameters, parameters_enums.AgentProvider, p.Key())
+	return parameters
+}
+
+// A cost the agent reported wins outright, and is marked as measured. This is
+// the case that must never be overwritten by our arithmetic: the vendor that
+// billed the run is a better source than a rate table we maintain by hand.
+func TestResolveRunCost_AgentReportedWins(t *testing.T) {
+	reported := 1.2345
+	got := resolveRunCost(
+		costParams("claude-opus-5", llm_provider_enums.AnthropicDirect),
+		agentResult{CostUSD: &reported, TokenUsage: tokenUsage{InputTokens: 999999, OutputTokens: 999999}},
+	)
+	if got == nil || got.USD != reported || got.Source != costSourceAgent {
+		t.Fatalf("resolveRunCost = %+v, want the reported %.4f marked %q", got, reported, costSourceAgent)
+	}
+	// Recorded so a later question about a surprising figure does not require
+	// guessing which route was taken.
+	if got.Provider != llm_provider_enums.AnthropicDirect.String() || got.Model != "claude-opus-5" {
+		t.Errorf("cost = %+v, want the model and provider recorded", got)
+	}
+}
+
+// codex reports tokens only, so the run is priced here — once — and marked as
+// an estimate rather than presented as measured.
+func TestResolveRunCost_EstimatesWhenTheAgentReportsNone(t *testing.T) {
+	got := resolveRunCost(
+		costParams("gpt-5.5", llm_provider_enums.OpenAIDirect),
+		agentResult{TokenUsage: tokenUsage{InputTokens: 1_000_000, CacheReadTokens: 600_000, OutputTokens: 100_000}},
+	)
+	if got == nil {
+		t.Fatal("resolveRunCost = nil; a priced pair must produce an estimate")
+	}
+	// 400k fresh @ $5 + 600k cached @ $0.50 + 100k output @ $30.
+	if want := 0.4*5.00 + 0.6*0.50 + 0.1*30.00; got.USD < want-1e-9 || got.USD > want+1e-9 {
+		t.Errorf("USD = %.6f, want %.6f", got.USD, want)
+	}
+	if got.Source != costSourceEstimated {
+		t.Errorf("Source = %q, want %q — an estimate must not present as measured", got.Source, costSourceEstimated)
+	}
+}
+
+// nil, never zero. A run we cannot price has an UNKNOWN cost; recording 0.0
+// would tell a customer it was free.
+func TestResolveRunCost_UnpriceableIsNilNotZero(t *testing.T) {
+	cases := []struct {
+		name  string
+		model string
+		p     llm_provider_enums.Provider
+	}{
+		// No per-token price exists for a subscription at all.
+		{"subscription", "claude-opus-5", llm_provider_enums.AnthropicSubscription},
+		// Priced pair exists for OpenAI, but not through this route.
+		{"unpriced route", "claude-opus-5", llm_provider_enums.AWSBedrock},
+		{"model outside the catalogue", "some-model-we-retired", llm_provider_enums.OpenAIDirect},
+		{"no model at all", "", llm_provider_enums.OpenAIDirect},
+	}
+	for _, c := range cases {
+		if got := resolveRunCost(costParams(c.model, c.p), agentResult{
+			TokenUsage: tokenUsage{InputTokens: 500_000, OutputTokens: 50_000},
+		}); got != nil {
+			t.Errorf("%s: resolveRunCost = %+v, want nil so the cost renders as unknown", c.name, got)
+		}
+	}
+}

--- a/jobs/commands/run_agent_step.go
+++ b/jobs/commands/run_agent_step.go
@@ -1054,6 +1054,60 @@ func readAgentResult(workDirHost string) (agentResult, error) {
 	return result, nil
 }
 
+// resolveRunCost prices this run ONCE, at completion.
+//
+// Two sources, and which one applied is recorded rather than inferred:
+//
+//	the agent said so    — Claude Code and opencode both report a total, and a
+//	                       figure from the vendor that billed it beats any
+//	                       arithmetic of ours
+//	we priced it         — codex reports token counts only, so the catalogue's
+//	                       (model, provider) rate turns them into dollars
+//
+// nil when neither is possible: an unpriced pair, an unknown model, or a
+// subscription, which has no per-token price at all. Callers must render that
+// as an unknown cost — a confident zero tells a customer their run was free.
+//
+// The provider comes from the Job's own parameter, so the rate is the one for
+// the route actually taken. That is the whole reason rates are keyed by
+// (model, provider): the same model costs different amounts through Bedrock, a
+// direct API, or a gateway.
+func resolveRunCost(parameters map[string]interface{}, result agentResult) *costOutput {
+	logical, _ := jobs.GetParameterValue[string](parameters, parameters_enums.Model)
+	provider := resolveJobProvider(parameters, io.Discard)
+
+	// The agent's own figure wins outright, and is recorded even when we could
+	// also have estimated one — measured beats inferred.
+	if result.CostUSD != nil {
+		return &costOutput{
+			USD:      *result.CostUSD,
+			Source:   costSourceAgent,
+			Model:    logical,
+			Provider: provider.String(),
+		}
+	}
+
+	model, err := llm_provider_enums.GetModel(logical)
+	if err != nil {
+		return nil
+	}
+	rate, ok := model.RateFor(provider)
+	if !ok {
+		return nil
+	}
+	// Cache WRITES are passed as zero because the runner's tokenUsage does not
+	// carry them — agentbox reports cache_creation_tokens, but this struct
+	// never picked the field up. Harmless for the only models priced here
+	// (codex, where OpenAI does not bill a separate cache-write rate) and worth
+	// fixing before anything Anthropic-shaped is priced from a table.
+	return &costOutput{
+		USD:      rate.CostUSD(result.TokenUsage.InputTokens, result.TokenUsage.CacheReadTokens, 0, result.TokenUsage.OutputTokens),
+		Source:   costSourceEstimated,
+		Model:    logical,
+		Provider: provider.String(),
+	}
+}
+
 // mergeAgentResultIntoJobOutput writes the agent block of the JobOutput
 // envelope. CommitAndPush + OpenPullRequest later extend the same
 // envelope's repositories block; the merge-then-write pattern preserves
@@ -1064,6 +1118,7 @@ func mergeAgentResultIntoJobOutput(parameters map[string]interface{}, result age
 		_ = json.Unmarshal([]byte(existing), &data)
 	}
 	data.SchemaVersion = jobOutputSchemaVersion
+	data.Cost = resolveRunCost(parameters, result)
 	data.Agent = &agentOutput{
 		ChangesSummary: result.ChangesSummary,
 		FilesChanged:   result.FilesChanged,


### PR DESCRIPTION
Stacked on #96. Needs deployment-io/deployment-runner-kit#63 for `Model.RateFor`.

## Why

app-server derives codex costs during **response mapping**, and there is no stored cost field — so editing a rate silently rewrites the cost of every past Task. No migration, no audit trail, and the dashboard quietly disagreeing with the invoice. A Task's cost is a fact about when it ran.

## What

`resolveRunCost` resolves it once, at completion, and records which source applied:

| source | when | meaning |
|---|---|---|
| `agent` | claude-code, opencode | the vendor that billed it reported it |
| `estimated` | codex | our arithmetic over tokens × the (model, provider) rate |
| *absent* | unpriced pair, unknown model, subscription | unknown — **never zero** |

The agent's own figure wins outright, even where we could also have estimated one: measured beats inferred.

## Provenance is the point

Measured and inferred are different claims and currently render identically — a user seeing "$0.42" cannot tell which they have. That matters more with gateways coming, where our arithmetic is the most likely to be wrong. Model and provider are recorded alongside, since they are the only durable answer to "which rate applied".

The `cost` block sits **outside** `agent` deliberately: that block is agentbox's `result.json` verbatim, and this is our resolution of it. Merging them would lose exactly the distinction the field exists to record.

## Known gap, commented at the call site

Cache **writes** are priced as zero: the runner's `tokenUsage` never picked up agentbox's `cache_creation_tokens`. Harmless for codex — the only thing priced here, and OpenAI bills no separate cache-write rate — and worth fixing before anything Anthropic-shaped is priced from a table.

## Follow-up

app-server reads `Output["cost"]` and keeps `estimateCodexCostUSD` **only** as a fallback for Jobs completed before this ships. Deleting it would blank the cost on every historical codex Task.