### PR TITLE
Stop dropping cache-write tokens between agentbox and Job.Output

### DIFF
--- a/jobs/commands/run_agent_cost_test.go
+++ b/jobs/commands/run_agent_cost_test.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/deployment-io/deployment-runner-kit/enums/llm_provider_enums"
@@ -74,5 +75,48 @@ func TestResolveRunCost_UnpriceableIsNilNotZero(t *testing.T) {
 		}); got != nil {
 			t.Errorf("%s: resolveRunCost = %+v, want nil so the cost renders as unknown", c.name, got)
 		}
+	}
+}
+
+// Cache-write tokens must survive the trip from agentbox to Job.Output.
+//
+// They were silently dropped here for a while: agentbox emits
+// cache_creation_tokens and app-server reads it, but this package's tokenUsage
+// had no such field, so the middle of the chain zeroed it. A struct field
+// missing from a passthrough type is invisible in review and in tests that only
+// assert on the fields that exist — hence a test that decodes the real wire
+// shape rather than constructing the struct.
+func TestTokenUsage_CarriesCacheCreationTokens(t *testing.T) {
+	const resultJSON = `{
+		"status": "success",
+		"token_usage": {
+			"input_tokens": 1000,
+			"output_tokens": 200,
+			"cache_read_tokens": 300,
+			"cache_creation_tokens": 400
+		}
+	}`
+	var got agentResult
+	if err := json.Unmarshal([]byte(resultJSON), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.TokenUsage.CacheCreationTokens != 400 {
+		t.Errorf("CacheCreationTokens = %d, want 400 — agentbox reports this and app-server reads it; dropping it here understates every cache-heavy run",
+			got.TokenUsage.CacheCreationTokens)
+	}
+
+	// And it must survive re-encoding into the JobOutput envelope under the key
+	// app-server looks for.
+	encoded, err := json.Marshal(agentOutput{TokenUsage: got.TokenUsage})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var envelope map[string]interface{}
+	if err := json.Unmarshal(encoded, &envelope); err != nil {
+		t.Fatalf("re-unmarshal: %v", err)
+	}
+	usage, _ := envelope["token_usage"].(map[string]interface{})
+	if v, _ := usage["cache_creation_tokens"].(float64); v != 400 {
+		t.Errorf("token_usage.cache_creation_tokens = %v, want 400 — this is the key app-server extracts", usage["cache_creation_tokens"])
 	}
 }

--- a/jobs/commands/run_agent_step.go
+++ b/jobs/commands/run_agent_step.go
@@ -1011,6 +1011,17 @@ type tokenUsage struct {
 	InputTokens     int `json:"input_tokens"`
 	OutputTokens    int `json:"output_tokens"`
 	CacheReadTokens int `json:"cache_read_tokens"`
+	// CacheCreationTokens is cache-WRITE input, which Anthropic bills at a
+	// premium over fresh input and separately from cache reads.
+	//
+	// This field was missing, so the value was dropped HERE — in the middle of
+	// a chain where both ends already handled it. agentbox emits
+	// cache_creation_tokens and its Claude and opencode parsers populate it;
+	// app-server reads the same key out of Job.Output. Only this struct never
+	// carried it, so every cache write silently became zero and the dashboard
+	// has been under-reporting cache-heavy runs since the field was added
+	// upstream.
+	CacheCreationTokens int `json:"cache_creation_tokens"`
 }
 
 // formatAgentFailure produces the error returned when agentbox reports
@@ -1095,13 +1106,19 @@ func resolveRunCost(parameters map[string]interface{}, result agentResult) *cost
 	if !ok {
 		return nil
 	}
-	// Cache WRITES are passed as zero because the runner's tokenUsage does not
-	// carry them — agentbox reports cache_creation_tokens, but this struct
-	// never picked the field up. Harmless for the only models priced here
-	// (codex, where OpenAI does not bill a separate cache-write rate) and worth
-	// fixing before anything Anthropic-shaped is priced from a table.
+	// Cache writes bill at the fresh-input rate, which UNDERSTATES a
+	// cache-heavy Anthropic run — Anthropic charges a premium for them, and
+	// Rate has no separate field yet. Harmless for the only models priced here
+	// (codex, where cached tokens are a subset of input rather than a
+	// separately-billed bucket, so this count is zero), and the count is now
+	// passed through so adding that field is the only remaining step.
 	return &costOutput{
-		USD:      rate.CostUSD(result.TokenUsage.InputTokens, result.TokenUsage.CacheReadTokens, 0, result.TokenUsage.OutputTokens),
+		USD: rate.CostUSD(
+			result.TokenUsage.InputTokens,
+			result.TokenUsage.CacheReadTokens,
+			result.TokenUsage.CacheCreationTokens,
+			result.TokenUsage.OutputTokens,
+		),
 		Source:   costSourceEstimated,
 		Model:    logical,
 		Provider: provider.String(),


### PR DESCRIPTION
Follow-up to #97, found while checking whether agentbox needed changes for cost output. It didn't — **the runner did**.

## The gap

Both ends of the chain already handled this field:

- **agentbox** emits `cache_creation_tokens`, and its Claude and opencode parsers populate it
- **app-server** reads `cache_creation_tokens` out of `Job.Output`

Only this package's `tokenUsage` had no such field, so the value was zeroed in the middle. Every cache-heavy run has been under-reported since the field was added upstream — silently, because both ends look correct in isolation.

## Why it stayed hidden

A missing field on a passthrough struct is invisible in review, and invisible to any test that constructs the struct and asserts on the fields that exist. So the new case decodes the **real `result.json` wire shape**, then re-encodes the `JobOutput` envelope and checks the key app-server actually extracts — a test that could only pass if the field survives the whole round trip.

## Cost impact

`resolveRunCost` now passes the count through. Cache writes still bill at the fresh-input rate, which **understates a cache-heavy Anthropic run** — Anthropic charges a premium and `Rate` has no separate field yet — but with the count no longer lost, adding that field is the only remaining step.

Nothing changes for codex, the only thing priced today: its cached tokens are a subset of `input_tokens` rather than a separately-billed bucket, so this value is zero.

No drk bump needed.