### PR TITLE
Fail fast when a Bedrock model cannot be resolved

### DIFF
--- a/jobs/commands/agent_providers.go
+++ b/jobs/commands/agent_providers.go
@@ -137,16 +137,16 @@ func prepareProvider(env map[string]string, p llm_provider_enums.Provider, logsW
 //
 // Adding Vertex later means setting that property and supplying its discovery;
 // nothing here changes.
-func applyAgentModelEnv(env map[string]string, spawn agentSpawn, resolve modelResolver, logsWriter io.Writer) {
+func applyAgentModelEnv(env map[string]string, spawn agentSpawn, resolve modelResolver, logsWriter io.Writer) error {
 	provider := spawn.provider
 	logical := spawn.model
 	if logical == "" {
-		return
+		return nil
 	}
 	if !provider.IsValid() {
 		// No recognisable credential. Leave the model untouched so the agent
 		// fails on the missing credential rather than on a mangled id.
-		return
+		return nil
 	}
 
 	// The vendor travels with the id because opencode's rendering depends on
@@ -166,9 +166,40 @@ func applyAgentModelEnv(env map[string]string, spawn agentSpawn, resolve modelRe
 			// whether we can discover right now. Collapsing them would make a
 			// credential failure look like "this provider needs no discovery".
 			if resolve == nil {
+				// CREDENTIALS, not model access — and the two must not be
+				// collapsed, which is what the paragraph above is warning
+				// about. Degrades to the logical id so the agent reports a
+				// credential problem in its own words. Telling the user to
+				// enable model access here would name the wrong cause.
 				io.WriteString(logsWriter, fmt.Sprintf("%s: cannot resolve %q — credentials unavailable; leaving the model unchanged.\n", provider, logical))
 			} else if resolved := resolve(context.TODO(), model); resolved != "" {
 				id = resolved
+			} else if model.BedrockProfilePrefix() != "" {
+				// FAIL FAST: discovery RAN and found nothing.
+				//
+				// A profile prefix means the concrete id can ONLY come from
+				// discovery — the catalogue guarantees a model has a prefix or
+				// a declared id, never both. So an empty result leaves the
+				// LOGICAL id ("claude-opus-5"), which no provider accepts. The
+				// run is already lost; the only question is whether it is lost
+				// here or several minutes later.
+				//
+				// It used to be later: we logged the reason, spawned the
+				// container, cloned the repo, installed the CLI, and let the
+				// agent fail on an error that never mentioned model access. The
+				// explanation sat in the job logs while the Task error said
+				// nothing useful — a live opencode run showed exactly that
+				// shape. Returning here makes the actionable message the error
+				// itself.
+				//
+				// Guarded on the PREFIX, not the provider. The Bedrock-only
+				// lineup (Qwen, DeepSeek, GLM, MiniMax, Grok) has no profile
+				// and declares its id, so discovery finding nothing is CORRECT
+				// for them — guarding on provider would break every one.
+				return fmt.Errorf(
+					"model %q could not be resolved at %s: no matching inference profile in this account/region. "+
+						"Enable model access for it in the AWS console, or pick a different model",
+					logical, provider)
 			}
 		}
 	} else {
@@ -178,7 +209,13 @@ func applyAgentModelEnv(env map[string]string, spawn agentSpawn, resolve modelRe
 	if spawn.agentType == llm_provider_enums.Opencode {
 		rendered := llm_provider_enums.OpencodeModelID(id, provider, vendor)
 		if rendered == "" {
-			return // unroutable; leave what the Task asked for so the error names it
+			// Unroutable — opencode has no name for this provider. Returns
+			// WITHOUT writing the env, so MODEL keeps what the Task asked for
+			// and the resulting error names that rather than a half-resolved
+			// id. Deliberately not an error like the discovery case above:
+			// this is a catalogue contradiction, not an account problem, so
+			// there is nothing the user could act on.
+			return nil
 		}
 		id = rendered
 	}
@@ -190,4 +227,5 @@ func applyAgentModelEnv(env map[string]string, spawn agentSpawn, resolve modelRe
 	// variable, and once writing ANTHROPIC_MODEL *instead of* MODEL, which left
 	// agentbox passing the unresolved logical id as --model.
 	llm_provider_enums.ApplyModelEnv(env, id, provider, spawn.agentType)
+	return nil
 }

--- a/jobs/commands/agent_providers_test.go
+++ b/jobs/commands/agent_providers_test.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/deployment-io/deployment-runner-kit/enums/llm_provider_enums"
@@ -299,5 +300,70 @@ func TestApplyAgentModelEnv_BedrockClaudeCodeGetsTheResolvedIDInBothVars(t *test
 	// The one that was wrong: agentbox turns this into --model.
 	if env["MODEL"] != resolved {
 		t.Errorf("MODEL = %q, want the resolved profile — agentbox passes it as --model, so a logical id here overrides ANTHROPIC_MODEL", env["MODEL"])
+	}
+}
+
+// A model that NEEDS discovery and did not get it fails HERE, not minutes later
+// inside a container that was always going to fail.
+//
+// The catalogue guarantees a Bedrock model has a profile prefix or a declared
+// id, never both — so an empty discovery result leaves the LOGICAL id, which no
+// provider accepts. Before this, the run continued: vendor phase, container
+// spawn, repo clone, CLI install, then an agent error that never mentioned
+// model access, with the real explanation only in the job logs.
+func TestApplyAgentModelEnv_FailsFastWhenDiscoveryFindsNothing(t *testing.T) {
+	found := modelResolver(func(context.Context, llm_provider_enums.Model) string { return "" })
+	env := map[string]string{"MODEL": "claude-sonnet-4-6"}
+	err := applyAgentModelEnv(env, agentSpawn{
+		provider:  llm_provider_enums.AWSBedrock,
+		agentType: llm_provider_enums.ClaudeCode,
+		model:     "claude-sonnet-4-6",
+	}, found, io.Discard)
+
+	if err == nil {
+		t.Fatal("no error; an unresolvable Bedrock model must fail before the container spawns")
+	}
+	// The message is the whole point — it has to name the model and the action.
+	for _, want := range []string{"claude-sonnet-4-6", "model access"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not mention %q", err, want)
+		}
+	}
+}
+
+// ⚠️ The boundary this must not cross. The Bedrock-only lineup has NO profile
+// and declares its concrete id, so discovery legitimately finds nothing for it.
+// Guarding on the provider instead of the prefix would fail every one of these
+// — seven models that work perfectly.
+func TestApplyAgentModelEnv_DeclaredIDModelsDoNotFailFast(t *testing.T) {
+	found := modelResolver(func(context.Context, llm_provider_enums.Model) string { return "" })
+	for _, m := range []string{"qwen3-coder-480b", "glm-5", "minimax-m2.5", "grok-4.3", "deepseek-v3.2"} {
+		env := map[string]string{"MODEL": m}
+		err := applyAgentModelEnv(env, agentSpawn{
+			provider:  llm_provider_enums.AWSBedrock,
+			agentType: llm_provider_enums.Opencode,
+			model:     m,
+		}, found, io.Discard)
+		if err != nil {
+			t.Errorf("%s: unexpected error %v — this model declares its id; discovery finding nothing is correct", m, err)
+			continue
+		}
+		if env["MODEL"] == m {
+			t.Errorf("%s: MODEL is still the logical id; the declared Bedrock id was not applied", m)
+		}
+	}
+}
+
+// Credentials missing is a DIFFERENT failure from model access, and must not
+// borrow its message. Telling someone to enable model access when the runner
+// could not assume the role sends them to the wrong console page.
+func TestApplyAgentModelEnv_MissingCredentialsIsNotAModelAccessError(t *testing.T) {
+	env := map[string]string{"MODEL": "claude-sonnet-4-6"}
+	if err := applyAgentModelEnv(env, agentSpawn{
+		provider:  llm_provider_enums.AWSBedrock,
+		agentType: llm_provider_enums.ClaudeCode,
+		model:     "claude-sonnet-4-6",
+	}, nil, io.Discard); err != nil {
+		t.Errorf("nil resolver produced %v; a credential failure must degrade and let the agent name it", err)
 	}
 }

--- a/jobs/commands/run_agent_step.go
+++ b/jobs/commands/run_agent_step.go
@@ -423,7 +423,13 @@ func buildAgentSpawnEnvVars(parameters map[string]interface{}, logsWriter io.Wri
 	// Whatever this provider needs at spawn — credentials, discovery — is its
 	// own business; the call site does not know which provider it is.
 	resolve := prepareProvider(env, provider, logsWriter)
-	applyAgentModelEnv(env, spawn, resolve, logsWriter)
+	// Returns an error only when the model CANNOT be resolved and the run is
+	// therefore already lost — see applyAgentModelEnv. Propagated rather than
+	// logged so the Task's error names the cause, instead of the agent failing
+	// later on something that never mentions model access.
+	if err := applyAgentModelEnv(env, spawn, resolve, logsWriter); err != nil {
+		return nil, err
+	}
 	// Optionally swap the injected ANTHROPIC_API_KEY for a Claude Code
 	// subscription OAuth token read from this runner's own AWS Secrets Manager.
 	// OrganizationIDNamespace is best-effort here: it only enables the


### PR DESCRIPTION
Follow-up to the live opencode failure, whose Task error read only `opencode opencode reported an error` while the actual cause sat in the job logs.

## Why this is safe to fail on

A model with a `BedrockProfilePrefix` can **only** get its concrete id from discovery — the catalogue enforces a prefix *or* a declared id, never both. An empty discovery result therefore leaves the logical id (`claude-opus-5`), which no provider accepts. The run is already lost; the only question is whether it is lost now or several minutes later.

It used to be later: log the reason, run the vendor phase, spawn the container, clone the repo, install the CLI, then fail on an agent error that never mentioned model access.

## Two boundaries, both tested

**Guarded on the prefix, not the provider.** The Bedrock-only lineup (Qwen, DeepSeek, GLM, MiniMax, Grok) has no profile and declares its id, so discovery finding nothing is *correct* for them. Guarding on provider would fail all seven — models that work perfectly.

**Credentials-unavailable still degrades.** That is a different failure with a different fix, and the code already carried a comment warning against collapsing the two. My first draft collapsed them anyway and would have told a user to enable model access when the runner could not assume the role — two existing tests caught it. Now pinned by a third.

## Scope

Fails at env-build time, which is *after* the vendor phase — so it saves the agent container and CLI install, not the entire run. Moving validation ahead of vendoring would save more but reorders credential assumption against a multi-minute phase; not worth it for the saving.

This is the failure mode Opus 5 will produce on any Bedrock account that has not enabled it, so it should land before that becomes common.