### PR TITLE
Bump drk for the Novita and OpenRouter providers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.31.1
 	github.com/aws/aws-sdk-go-v2/service/sts v1.28.6
 	github.com/aws/smithy-go v1.27.6
-	github.com/deployment-io/deployment-runner-kit v0.0.0-20260810162459-83a3943d34a4
+	github.com/deployment-io/deployment-runner-kit v0.0.0-20260812082457-5827e3191627
 	github.com/deployment-io/team-ai v0.0.0-20250917084912-bdbad6a834e1
 	github.com/docker/docker v27.3.0+incompatible
 	github.com/go-git/go-git/v5 v5.12.0

--- a/go.sum
+++ b/go.sum
@@ -153,8 +153,8 @@ github.com/cyphar/filepath-securejoin v0.2.5/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxG
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deployment-io/deployment-runner-kit v0.0.0-20260810162459-83a3943d34a4 h1:K+zUvNb5PLTFqtTgGTaSfpUdNEGZ8g2YReMZZt3tPxA=
-github.com/deployment-io/deployment-runner-kit v0.0.0-20260810162459-83a3943d34a4/go.mod h1:wKTz63GqLOHVXT173zlW/zJFRLi9krn7dqXoDm/BXFI=
+github.com/deployment-io/deployment-runner-kit v0.0.0-20260812082457-5827e3191627 h1:dzf7QECiXcmu5Qil96T392vsgJX2ZcO1GVHq5VX4ln4=
+github.com/deployment-io/deployment-runner-kit v0.0.0-20260812082457-5827e3191627/go.mod h1:wKTz63GqLOHVXT173zlW/zJFRLi9krn7dqXoDm/BXFI=
 github.com/deployment-io/team-ai v0.0.0-20250917084912-bdbad6a834e1 h1:gfeNqym19IiO38sQ84WPMmZXrdDisu64qQP3Xs0N2RM=
 github.com/deployment-io/team-ai v0.0.0-20250917084912-bdbad6a834e1/go.mod h1:B0fxmLJICi0qP2R2m3I2tR1uRIKQxn4ekK67lyBRHjw=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=


### PR DESCRIPTION
Dependency alignment for deployment-io/deployment-runner-kit#64.

drk #64 adds provider values 6 and 7. The runner resolves the provider from a job parameter and looks it up, so without this bump it cannot recognise either and a Novita-configured org cannot dispatch a Task.

**No code change needed.** `providerSetups` is for **cloud-role** providers that need credentials assumed and model ids discovered at runtime. Novita and OpenRouter are API-key providers: their credentials arrive in the injected bundle from kit, and their model ids are declared in the catalogue — so they take the same path as Anthropic Direct and OpenAI Direct, which also have no setup entry.

`go build ./jobs/...` and `./jobs/commands/` pass.