### PR TITLE
Bump drk to the current catalogue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.31.1
 	github.com/aws/aws-sdk-go-v2/service/sts v1.28.6
 	github.com/aws/smithy-go v1.27.6
-	github.com/deployment-io/deployment-runner-kit v0.0.0-20260812082457-5827e3191627
+	github.com/deployment-io/deployment-runner-kit v0.0.0-20260821060539-0235ff6d4832
 	github.com/deployment-io/team-ai v0.0.0-20250917084912-bdbad6a834e1
 	github.com/docker/docker v27.3.0+incompatible
 	github.com/go-git/go-git/v5 v5.12.0

--- a/go.sum
+++ b/go.sum
@@ -153,8 +153,8 @@ github.com/cyphar/filepath-securejoin v0.2.5/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxG
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deployment-io/deployment-runner-kit v0.0.0-20260812082457-5827e3191627 h1:dzf7QECiXcmu5Qil96T392vsgJX2ZcO1GVHq5VX4ln4=
-github.com/deployment-io/deployment-runner-kit v0.0.0-20260812082457-5827e3191627/go.mod h1:wKTz63GqLOHVXT173zlW/zJFRLi9krn7dqXoDm/BXFI=
+github.com/deployment-io/deployment-runner-kit v0.0.0-20260821060539-0235ff6d4832 h1:2ealskBvTUZhQCsgzg7NpvpuPoNjuV+TbnBS+iA2Tm8=
+github.com/deployment-io/deployment-runner-kit v0.0.0-20260821060539-0235ff6d4832/go.mod h1:wKTz63GqLOHVXT173zlW/zJFRLi9krn7dqXoDm/BXFI=
 github.com/deployment-io/team-ai v0.0.0-20250917084912-bdbad6a834e1 h1:gfeNqym19IiO38sQ84WPMmZXrdDisu64qQP3Xs0N2RM=
 github.com/deployment-io/team-ai v0.0.0-20250917084912-bdbad6a834e1/go.mod h1:B0fxmLJICi0qP2R2m3I2tR1uRIKQxn4ekK67lyBRHjw=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=


### PR DESCRIPTION
## Why

The runner was on drk `5827e31` (**#64**, Aug 12) — four releases back, and older than either control-plane service was.

The gap is **latent, not active**. Nothing currently broken depends on it:

- **#66** changed `PreferredProvider` from two args to three — the runner never calls it (provider selection is control-plane side), so the signature change doesn't reach it.
- **#65** (provider display order) and **#68** (model labels) are presentation concerns the runner has no use for.
- What the runner actually reads — provider slugs, `IDFor`, `BedrockProfilePrefix`, `OpencodeModelID`, `ApplyModelEnv`, `Vendor` — is unchanged since #64.

Bumping anyway so the runner resolves ids against the same catalogue the control plane routes with. A runner one catalogue behind cannot resolve a model the control plane has just begun dispatching, and that surfaces as `Unknown agent provider` or a passed-through logical id at spawn — a long way from its cause, as the last few days demonstrated.

## What

| | before | after |
|---|---|---|
| drk | `5827e31` (#64) | `0235ff6` (#68) |

The runner doesn't import kit, so drk is the only module here.

## No code changes

`go build ./...` clean. `jobs/commands` and every other suite green.

One `FAIL` — a non-constant-format-string vet finding in `agent/tools/code_tools/query_code` — **reproduces identically on unbumped master**. Unrelated to this change; flagged separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)