### PR TITLE
Log the agent route on the way through, not only when it breaks

### DIFF
--- a/jobs/commands/agent_providers.go
+++ b/jobs/commands/agent_providers.go
@@ -215,9 +215,38 @@ func applyAgentModelEnv(env map[string]string, spawn agentSpawn, resolve modelRe
 			// id. Deliberately not an error like the discovery case above:
 			// this is a catalogue contradiction, not an account problem, so
 			// there is nothing the user could act on.
+			//
+			// Still SAID OUT LOUD. "Nothing to act on" is a reason not to fail
+			// the Step, not a reason to leave no trace: the agent then fails on
+			// a bare logical id, and without this line the job log gives no
+			// hint that a routing decision was involved at all.
+			io.WriteString(logsWriter, fmt.Sprintf("opencode cannot reach %s; leaving %q unrendered.\n", provider, logical))
 			return nil
 		}
 		id = rendered
+	}
+	// ANNOUNCE THE ROUTE ON THE WAY THROUGH, not only when something breaks.
+	//
+	// Every other write in this file is on a failure path, and provider setups
+	// log for themselves — but only Bedrock HAS a setup, because the API-key
+	// providers have nothing to prepare. So Bedrock was the one provider that
+	// announced itself and every other route ran silently, which is precisely
+	// inverted: a Task that quietly went somewhere unintended is the case that
+	// needs a trace, and a Task on Bedrock is the one that already had it.
+	//
+	// That inversion cost a real debugging session. A Task pinned to Novita ran
+	// on Bedrock and failed; the only reason the provider was visible at all is
+	// that Bedrock happens to log when it assumes its role. Pinned to OpenRouter
+	// instead, the same bug would have left nothing in the log to see.
+	//
+	// Prints the LOGICAL id beside the rendered one whenever they differ, since
+	// the substitution is itself a decision worth reading — a Bedrock discovery
+	// can resolve to a neighbouring version, and "what I asked for → what will
+	// run" is the shape that makes that legible.
+	if id != logical {
+		io.WriteString(logsWriter, fmt.Sprintf("Agent: %s via %s — %s → %s\n", spawn.agentType, provider, logical, id))
+	} else {
+		io.WriteString(logsWriter, fmt.Sprintf("Agent: %s via %s — %s\n", spawn.agentType, provider, id))
 	}
 	// WHERE the model goes is the catalogue's call, not ours: it is the same
 	// fact as claude-code's Bedrock switch, and the two must agree — an agent in

--- a/jobs/commands/agent_providers_test.go
+++ b/jobs/commands/agent_providers_test.go
@@ -367,3 +367,61 @@ func TestApplyAgentModelEnv_MissingCredentialsIsNotAModelAccessError(t *testing.
 		t.Errorf("nil resolver produced %v; a credential failure must degrade and let the agent name it", err)
 	}
 }
+
+// EVERY route announces itself, not just the ones that break.
+//
+// Bedrock logs because it has a providerSetup; the API-key providers have none
+// and so logged nothing at all. That left the only self-announcing provider as
+// the one a Task lands on by ACCIDENT, and a Task that silently ran somewhere
+// unintended looking identical in the log to one that ran where it was told.
+// Asserted per provider rather than once, because the gap was never in the
+// shared code — it was in which providers happened to have a setup.
+func TestApplyAgentModelEnv_LogsTheRouteForEveryProvider(t *testing.T) {
+	for _, c := range []struct {
+		provider llm_provider_enums.Provider
+		model    string
+		want     string
+	}{
+		{llm_provider_enums.Novita, "qwen3-coder-next", "novita-ai/qwen/qwen3-coder-next"},
+		{llm_provider_enums.OpenRouter, "grok-4.3", "openrouter/x-ai/grok-4.3"},
+		{llm_provider_enums.AnthropicDirect, "claude-sonnet-4-6", "anthropic/claude-sonnet-4-6"},
+		{llm_provider_enums.OpenAIDirect, "gpt-5.5", "openai/gpt-5.5"},
+	} {
+		var logs strings.Builder
+		applyAgentModelEnv(map[string]string{}, agentSpawn{
+			provider:  c.provider,
+			agentType: llm_provider_enums.Opencode,
+			model:     c.model,
+		}, nil, &logs)
+
+		got := logs.String()
+		if !strings.Contains(got, c.provider.String()) {
+			t.Errorf("%s: log %q does not name the provider — the routing decision is invisible", c.provider, got)
+		}
+		if !strings.Contains(got, c.want) {
+			t.Errorf("%s: log %q does not carry the rendered model %q", c.provider, got, c.want)
+		}
+	}
+}
+
+// The logical id survives beside the rendered one when they differ. A Bedrock
+// discovery can resolve to a neighbouring version, so "asked for → will run" is
+// the only shape that makes such a substitution readable.
+func TestApplyAgentModelEnv_LogShowsTheSubstitution(t *testing.T) {
+	resolve := modelResolver(func(_ context.Context, _ llm_provider_enums.Model) string {
+		return "eu.anthropic.claude-sonnet-4-5-20250929-v1:0"
+	})
+	var logs strings.Builder
+	applyAgentModelEnv(map[string]string{}, agentSpawn{
+		provider:  llm_provider_enums.AWSBedrock,
+		agentType: llm_provider_enums.ClaudeCode,
+		model:     "claude-sonnet-4-5",
+	}, resolve, &logs)
+
+	got := logs.String()
+	for _, want := range []string{"claude-sonnet-4-5", "eu.anthropic.claude-sonnet-4-5-20250929-v1:0", "→"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("log %q is missing %q; a silent substitution is how the wrong version runs unnoticed", got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Why

Every `io.WriteString` in `agent_providers.go` sits on a **failure** path. Provider setups log for themselves — but only Bedrock *has* a setup, since `providerSetups` is `[]providerSetup{bedrockSetup{}}` and the API-key providers have nothing to prepare.

So Bedrock was the one provider that announced itself, and Novita, OpenRouter, Anthropic and OpenAI all ran silently.

That's inverted. A Task that quietly ran somewhere unintended is the case that needs a trace; a Task on Bedrock is the one that already had it.

It cost a real session this week: a Task pinned to Novita ran on Bedrock and failed, and the only reason the provider was visible at all is that Bedrock happens to log when it assumes its role. Pinned to **OpenRouter** instead, the identical bug would have left nothing in the log to see.

## What

One line per spawn, every agent and every provider:

```
Agent: opencode via Novita — qwen3-coder-next → novita-ai/qwen/qwen3-coder-next
Agent: claude-code via Anthropic — claude-opus-5
Agent: claude-code via AWS Bedrock — claude-sonnet-4-5 → eu.anthropic.claude-sonnet-4-5-20250929-v1:0
```

The logical id stays beside the rendered one **when they differ**, because the substitution is itself a decision worth reading — a Bedrock discovery can land on a neighbouring version, and `asked for → will run` is the shape that makes that legible.

Also gives the opencode-unroutable branch a line. "Nothing the user can act on" is a reason not to fail the Step, not a reason to leave no trace.

## Tests

Two new cases. The per-provider one asserts **per provider rather than once** — the gap was never in the shared code, it was in which providers happened to have a setup, so a single-provider assertion would have passed throughout.

All 19 `agent_providers` tests green; full suite green except the pre-existing `query_code` vet failure, which is being fixed separately.

## Not included

The runner only receives the resolved slug, so it can't say *why* a provider won — pin, org order, or default. Stamping that reason control-plane side would make the log fully self-explaining, but it's a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)