### PR TITLE
Log the prune's no-op, so silence never means two things

### DIFF
--- a/utils/aws_utils/static_site.go
+++ b/utils/aws_utils/static_site.go
@@ -140,6 +140,12 @@ func PruneStaleS3Files(s3Client *s3.Client, bucketName string, keep map[string]b
 	}
 	stale := staleS3Objects(allS3Objects, keep)
 	if len(stale) == 0 {
+		// SAY SO. This branch was silent, and the first live deploy after the
+		// prune shipped happened to be an unchanged redeploy — every hash
+		// identical, nothing stale — so the log looked exactly like a runner
+		// still on the old delete-then-upload code. "Ran, nothing to remove"
+		// and "didn't run" must not read the same to the person checking.
+		io.WriteString(logsWriter, "No files left over from the previous build.\n")
 		return nil
 	}
 	io.WriteString(logsWriter, fmt.Sprintf("Removing %d file(s) left over from the previous build\n", len(stale)))


### PR DESCRIPTION
## Why

`PruneStaleS3Files` said nothing when the set difference was empty. The first live deploy after #103 shipped happened to be an **unchanged redeploy** — every hashed filename identical, nothing stale — so the log looked exactly like a runner still running the old delete-then-upload code. "Ran, nothing to remove" and "didn't run" were indistinguishable, and answering "is #103 live?" required comparing runner versions instead of reading a line.

## What

One line on the empty branch:

```
No files left over from the previous build.
```

The prune now always reports — `Removing N file(s)…`, `No files left over…`, or `Could not remove…` — so its presence in the log is unconditional on a #103+ runner.

Build clean, `utils/aws_utils` tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)