### PR TITLE
Bump drk for the GPT-5.6 family

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.31.1
 	github.com/aws/aws-sdk-go-v2/service/sts v1.28.6
 	github.com/aws/smithy-go v1.27.6
-	github.com/deployment-io/deployment-runner-kit v0.0.0-20260821060539-0235ff6d4832
+	github.com/deployment-io/deployment-runner-kit v0.0.0-20260826071108-1dd349d606fd
 	github.com/deployment-io/team-ai v0.0.0-20250917084912-bdbad6a834e1
 	github.com/docker/docker v27.3.0+incompatible
 	github.com/go-git/go-git/v5 v5.12.0

--- a/go.sum
+++ b/go.sum
@@ -153,8 +153,8 @@ github.com/cyphar/filepath-securejoin v0.2.5/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxG
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deployment-io/deployment-runner-kit v0.0.0-20260821060539-0235ff6d4832 h1:2ealskBvTUZhQCsgzg7NpvpuPoNjuV+TbnBS+iA2Tm8=
-github.com/deployment-io/deployment-runner-kit v0.0.0-20260821060539-0235ff6d4832/go.mod h1:wKTz63GqLOHVXT173zlW/zJFRLi9krn7dqXoDm/BXFI=
+github.com/deployment-io/deployment-runner-kit v0.0.0-20260826071108-1dd349d606fd h1:FsNcBOiluBN/9F1dDRApLiJVvKTHSdUXfw/dzZjtXc8=
+github.com/deployment-io/deployment-runner-kit v0.0.0-20260826071108-1dd349d606fd/go.mod h1:wKTz63GqLOHVXT173zlW/zJFRLi9krn7dqXoDm/BXFI=
 github.com/deployment-io/team-ai v0.0.0-20250917084912-bdbad6a834e1 h1:gfeNqym19IiO38sQ84WPMmZXrdDisu64qQP3Xs0N2RM=
 github.com/deployment-io/team-ai v0.0.0-20250917084912-bdbad6a834e1/go.mod h1:B0fxmLJICi0qP2R2m3I2tR1uRIKQxn4ekK67lyBRHjw=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=


### PR DESCRIPTION
## What

Picks up [drk#69](https://github.com/deployment-io/deployment-runner-kit/pull/69) on top of the upload worker pool (#106): `gpt-5.6-sol` / `-terra` / `-luna`, Sol as the codex default, `gpt-5.4` and `gpt-5.3-codex` legacy.

**No source changes.** The runner reads the catalogue for provider slugs, `IDFor`, `OpencodeModelID`, `ApplyModelEnv` and `RateFor` — all of which resolve the new models without new code.

`RateFor` is the one that matters at runtime: it prices the recorded cost for runs where the agent doesn't self-report a figure, so a runner left on the older catalogue would record **no cost** for a GPT-5.6 codex Task. That's the reason this bump isn't optional.

`go build ./...` clean; `utils`, `jobs/commands`, `agenttools` and `entrypoints/common` all green. `go mod tidy` run.

## Completes the chain

`drk#69` → `kit#222` → `app-server#233` + `deployment-server#56` (deploy as a pair) → here.

## Ships alongside

This release also carries #106 (bounded upload concurrency, ~4 minutes off every static deploy) and #105 (stale-asset TTL + incomplete-multipart cleanup). Worth watching the first deploy after it for the upload phase collapsing and the `Marked N file(s)…` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)