### PR TITLE
Share one S3 client across a directory upload

### DIFF
--- a/utils/uploads/aws-s3/lib.go
+++ b/utils/uploads/aws-s3/lib.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"io"
@@ -252,19 +251,30 @@ func (u *Uploader) uploadByteStreamToS3(filePath, outputS3ObjectKey string, data
 	fileDoneStream := make(chan uploadFileDoneDTO)
 	go func() {
 		defer close(fileDoneStream)
-		cfg, err := config.LoadDefaultConfig(context.TODO())
-		if err != nil {
-			fileDoneStream <- uploadFileDoneDTO{
-				err:       err,
-				done:      false,
-				objectKey: outputS3ObjectKey,
-			}
-			return
-		}
-
-		client := s3.NewFromConfig(cfg, func(o *s3.Options) {
-			o.Region = u.s3Region
-		})
+		// The Uploader's shared client, NOT a per-file one.
+		//
+		// This used to call config.LoadDefaultConfig + s3.NewFromConfig here,
+		// once per file. Each LoadDefaultConfig builds its own credentials
+		// provider with its own aws.CredentialsCache, so nothing was shared:
+		// every file resolved credentials from scratch. On EC2 that means a
+		// fresh IMDS round trip per file.
+		//
+		// It survived while uploads were effectively serialized (a
+		// time.Sleep every 10 files). Raising the pool to uploadConcurrency
+		// turned a slow trickle into a burst, and IMDS rate-limits hard:
+		//
+		//   operation error S3: CreateMultipartUpload, get identity: get
+		//   credentials: failed to refresh cached credentials, failed to load
+		//   credentials, exceeded maximum number of attempts, 3, : You have
+		//   reached maximum request limit.
+		//
+		// One shared client means one credentials cache for the whole
+		// directory: credentials are fetched once, reused by every worker,
+		// and concurrent refreshes coalesce instead of stampeding. The client
+		// is safe for concurrent use and already carries this region — the
+		// caller builds it from the same region_enums value passed as
+		// u.s3Region.
+		client := u.s3Client
 
 		f, err := os.Open(filePath)
 		if err != nil {

--- a/utils/uploads/aws-s3/s3.go
+++ b/utils/uploads/aws-s3/s3.go
@@ -18,7 +18,16 @@ type Uploader struct {
 	uploadFile func(string, string, chan interface{}) <-chan uploadFileDoneDTO
 }
 
+// NewUploader builds an Uploader around a caller-supplied S3 client. The
+// client is REQUIRED: every file in a directory upload goes through it, so
+// that one client's credentials cache is what keeps a concurrent upload from
+// resolving credentials once per file and rate-limiting IMDS. It used to be
+// possible to pass nil and have the per-file path build its own — that is the
+// bug, so nil is now an error rather than a silent fallback.
 func NewUploader(s3Region, s3Bucket string, s3Client *s3.Client) (*Uploader, error) {
+	if s3Client == nil {
+		return nil, fmt.Errorf("s3 client is required to upload to %s", s3Bucket)
+	}
 	uploader := &Uploader{
 		s3Client: s3Client,
 		s3Region: s3Region,

--- a/utils/uploads/aws-s3/s3_test.go
+++ b/utils/uploads/aws-s3/s3_test.go
@@ -10,7 +10,21 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
 )
+
+// These tests replace uploader.uploadFile, so the client is never dialed —
+// but it must be non-nil, because every real upload now goes through the
+// Uploader's single shared client. That sharing is the whole point: a client
+// per file means a credentials cache per file, which rate-limits IMDS the
+// moment uploads run concurrently.
+func TestNewUploaderRequiresAClient(t *testing.T) {
+	if _, err := NewUploader("region", "bucket", nil); err == nil {
+		t.Error("NewUploader(nil client) must error — a nil client would have " +
+			"each file build its own, which is the IMDS-throttling bug")
+	}
+}
 
 // The uploaded-key set is what the caller prunes the bucket down to, so a file
 // walked but not listed is a live file put on the expiry clock. Check that the
@@ -78,7 +92,7 @@ func testFiles(count int) []fileToUpload {
 
 func TestUploadFilesLimitsConcurrencyAndUploadsEveryFileOnce(t *testing.T) {
 	files := testFiles(uploadConcurrency * 3)
-	uploader, err := NewUploader("region", "bucket", nil)
+	uploader, err := NewUploader("region", "bucket", &s3.Client{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -160,7 +174,7 @@ func (w *notifyingWriter) WriteString(s string) (int, error) {
 
 func TestUploadFilesReturnsFirstErrorAndDrainsRemainingUploads(t *testing.T) {
 	files := testFiles(uploadConcurrency + 5)
-	uploader, err := NewUploader("region", "bucket", nil)
+	uploader, err := NewUploader("region", "bucket", &s3.Client{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -222,7 +236,7 @@ func TestUploadFilesReturnsFirstErrorAndDrainsRemainingUploads(t *testing.T) {
 func TestUploadFilesHandlesDegenerateInputs(t *testing.T) {
 	for _, count := range []int{0, uploadConcurrency - 1} {
 		t.Run(fmt.Sprintf("files=%d", count), func(t *testing.T) {
-			uploader, err := NewUploader("region", "bucket", nil)
+			uploader, err := NewUploader("region", "bucket", &s3.Client{})
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
Fixes static-site deploys failing at the upload step.

```
Error uploading site to S3 bucket: 64e59bd5…-690b1495…
operation error S3: CreateMultipartUpload, get identity: get credentials:
failed to refresh cached credentials, failed to load credentials, exceeded
maximum number of attempts, 3, : You have reached maximum request limit.
```

## Cause

"You have reached maximum request limit" is **EC2 IMDS rate-limiting**, not S3 — the throttled call is credential resolution, before the request is even signed.

`uploadByteStreamToS3` called `config.LoadDefaultConfig` + `s3.NewFromConfig` **once per file**. Each `LoadDefaultConfig` builds its own credentials provider with its own `aws.CredentialsCache`, so nothing was shared: every file resolved credentials from scratch over IMDS.

That was survivable while uploads were effectively serialized — the old code slept 10s every 10 files, so IMDS saw a slow trickle. Raising the pool to `uploadConcurrency` (#106) turned it into a burst of concurrent IMDS fetches, and IMDS refuses. **A latent bug that the concurrency change promoted to a live one.**

## Fix

The `Uploader` already held a shared `*s3.Client` — passed in by `NewUploader`, used elsewhere in the package. This path just ignored it.

```go
-cfg, err := config.LoadDefaultConfig(context.TODO())
-client := s3.NewFromConfig(cfg, func(o *s3.Options) { o.Region = u.s3Region })
+client := u.s3Client
```

One credentials cache for the whole directory: fetched once, reused by every worker, concurrent refreshes coalescing instead of stampeding.

**Same region either way.** The caller builds the client via `GetS3Client`, which sets `o.Region = region_enums.Type(region).String()` — the identical value it passes as `s3Region` into `UploadToS3`. Drop-in.

**Concurrency is unchanged at 12.** It was the amplifier, not the defect; serializing again would just re-hide this.

`NewUploader` now rejects a nil client rather than letting the per-file path quietly build its own, since the whole upload's correctness now rests on that one client being real.

## Verification

- `GOWORK=off go build ./...` clean
- `go test -race ./utils/uploads/...` — 6 pass, including a new `TestNewUploaderRequiresAClient`
- The three pool tests previously passed `nil`; they stub `uploader.uploadFile` and never dial, so they now take a zero client

Pre-existing and untouched: `agent/tools/code_tools/query_code` fails `go vet` on master (`non-constant format string in call to fmt.Sprintf`), which blocks a full `go test ./...` there. Verified identical on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)