### PR TITLE
Move container scratch off the 512 MB tmpfs

### DIFF
--- a/jobs/commands/run_agent_step.go
+++ b/jobs/commands/run_agent_step.go
@@ -111,6 +111,31 @@ const (
 	agentboxResultFile      = "result.json"
 	agentboxResultPathInCtr = agentboxWorkDirInContainer + "/" + agentboxResultDirRel + "/" + agentboxResultFile
 
+	// agentboxTmpDirRel backs TMPDIR/GOTMPDIR inside the container, moving
+	// scratch off /tmp — a 512 MB RAM-backed tmpfs (tmpfsTmpOpts) — and onto
+	// the bind-mounted work dir, which sits on the host's 30 GB root volume.
+	//
+	// 512 MB is not enough for real installs and builds. Measured: a `yarn
+	// install` of one ordinary Next.js repo PEAKS at 504.8 MB of TMPDIR while
+	// Yarn extracts and re-zips a patched dependency — a 7 MB margin before
+	// anything else in the container touches /tmp. It ENOSPC'd in production
+	// on 2026-08-28. `go build` without -p 1 fails the same way, from the
+	// linker, and that is the long-standing GOTMPDIR failure too.
+	//
+	// Not /tmp-made-bigger: tmpfs is RAM, and it would be competing with the
+	// build that needs it. Not /cache either, though it is disk-backed and
+	// roomier — it is a fresh Docker volume per Step with no host path the
+	// runner can pre-create a directory in, whereas the work dir is already
+	// ours and already prepared here.
+	//
+	// Dot-prefixed for the same reason as .agentbox-output: agentbox's repo
+	// discovery skips dot-dirs at both levels (BuildPlan in
+	// internal/vendoring/plan.go), and CommitAndPush iterates
+	// /work/<idx>-<name>/ subdirs, so scratch can never be mistaken for a
+	// repo or staged into a Task's commit.
+	agentboxTmpDirRel   = ".agentbox-tmp"
+	agentboxTmpDirInCtr = agentboxWorkDirInContainer + "/" + agentboxTmpDirRel
+
 	// agentboxMCPSocketInContainer is where the per-task MCP tool socket is
 	// bind-mounted inside the agent container; agentbox reads its path from
 	// MCP_TOOL_RPC_SOCKET and bridges the agent's stdio MCP client to it. Tools
@@ -232,8 +257,8 @@ func (rs *RunAgentStep) Run(parameters map[string]interface{}, logsWriter io.Wri
 		return parameters, fmt.Errorf("error pulling agentbox image: %s", err)
 	}
 	workDirHost := commandUtils.GetTaskRepositoriesBaseDir(ctx.OrganizationID, ctx.TaskID)
-	if err := prepareAgentboxResultDir(workDirHost); err != nil {
-		return parameters, fmt.Errorf("error preparing agent result dir: %s", err)
+	if err := prepareAgentboxHostDirs(workDirHost); err != nil {
+		return parameters, fmt.Errorf("error preparing agentbox host dirs: %s", err)
 	}
 	// Two-phase model: a vendor container pre-fetches dependencies into a
 	// shared cache volume using the git token, then the credential-less
@@ -331,23 +356,30 @@ func pullAgentboxImage(imageRef string) error {
 	return nil
 }
 
-// prepareAgentboxResultDir creates the on-host directory that agentbox
-// writes /result.json into (via the bind mount). Pre-creating ensures the
-// directory exists and is writable before the container starts.
+// prepareAgentboxHostDirs creates the on-host directories agentbox writes
+// into through the bind mount: the result dir for /result.json, and the tmp
+// dir backing TMPDIR/GOTMPDIR (see agentboxTmpDirRel). Both must exist and be
+// writable before the container starts — TMPDIR pointing at a missing
+// directory fails every write with ENOENT rather than falling back to /tmp.
 //
-// Chowns both the work base and the result dir to the agentbox `agent`
-// user so the spawned container (UID 1000) can write through the bind
-// mount. CheckoutRepository chowns the cloned repo subtrees; this
-// function covers the result dir and the base it sits in.
-func prepareAgentboxResultDir(workDirHost string) error {
-	resultDir := filepath.Join(workDirHost, agentboxResultDirRel)
-	if err := os.MkdirAll(resultDir, 0755); err != nil {
-		return err
-	}
+// Chowns the work base and both dirs to the agentbox `agent` user so the
+// spawned container (UID 1000) can write through the bind mount.
+// CheckoutRepository chowns the cloned repo subtrees; this function covers
+// these two and the base they sit in.
+func prepareAgentboxHostDirs(workDirHost string) error {
 	if err := os.Chown(workDirHost, commandUtils.AgentboxUID, commandUtils.AgentboxGID); err != nil {
 		return err
 	}
-	return os.Chown(resultDir, commandUtils.AgentboxUID, commandUtils.AgentboxGID)
+	for _, rel := range []string{agentboxResultDirRel, agentboxTmpDirRel} {
+		dir := filepath.Join(workDirHost, rel)
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return err
+		}
+		if err := os.Chown(dir, commandUtils.AgentboxUID, commandUtils.AgentboxGID); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // buildAgentSpawnEnvVars assembles the env vars passed to the agentbox
@@ -362,6 +394,11 @@ func buildAgentSpawnEnvVars(parameters map[string]interface{}, logsWriter io.Wri
 		// The shared cache mount. agentbox maps it per language (GOMODCACHE,
 		// etc.) — the runner stays language-agnostic.
 		"AGENTBOX_CACHE_DIR": agentboxCacheDirInContainer,
+		// Scratch off the 512 MB tmpfs — see agentboxTmpDirRel. GOTMPDIR is
+		// set alongside TMPDIR because the Go toolchain reads it in
+		// preference, and the linker is the loudest victim of a small /tmp.
+		"TMPDIR":   agentboxTmpDirInCtr,
+		"GOTMPDIR": agentboxTmpDirInCtr,
 	}
 	if creds, err := jobs.GetParameterValue[map[string]string](parameters, parameters_enums.AgentEnvVars); err == nil {
 		for k, v := range creds {
@@ -1311,6 +1348,11 @@ func buildVendorSpec(imageRef, workDirHost, cacheVolume string, ctx commandUtils
 	env := map[string]string{
 		"WORK_DIR":           agentboxWorkDirInContainer,
 		"AGENTBOX_CACHE_DIR": agentboxCacheDirInContainer,
+		// The vendor phase is where a small /tmp actually bites: `yarn
+		// install` on one ordinary repo peaks at ~505 MB of scratch against a
+		// 512 MB tmpfs. See agentboxTmpDirRel.
+		"TMPDIR":   agentboxTmpDirInCtr,
+		"GOTMPDIR": agentboxTmpDirInCtr,
 	}
 	if token != "" {
 		env["GIT_TOKEN"] = token

--- a/jobs/commands/run_agent_step_test.go
+++ b/jobs/commands/run_agent_step_test.go
@@ -289,3 +289,33 @@ func TestIsAccessDenied(t *testing.T) {
 		})
 	}
 }
+
+// TestAgentboxTmpDirIsOffTheTmpfsAndInvisibleToAgentbox pins the two
+// properties the TMPDIR redirect depends on, both of which are silent when
+// broken.
+//
+// Off the tmpfs: /tmp in the container is 512 MB of RAM (tmpfsTmpOpts), and a
+// `yarn install` of one ordinary repo peaks at ~505 MB of scratch. Pointing
+// TMPDIR back at /tmp — or anywhere not under the bind-mounted work dir —
+// reinstates an ENOSPC that surfaces as an unrelated-looking tool error.
+//
+// Invisible to agentbox: the dir sits inside /work, which agentbox scans for
+// repos and CommitAndPush iterates. The dot prefix is the only thing keeping
+// scratch from being treated as a repo or staged into a Task's commit —
+// agentbox's BuildPlan skips dot-prefixed entries at both levels.
+func TestAgentboxTmpDirIsOffTheTmpfsAndInvisibleToAgentbox(t *testing.T) {
+	if !strings.HasPrefix(agentboxTmpDirInCtr, agentboxWorkDirInContainer+"/") {
+		t.Errorf("tmp dir %q must live under the bind-mounted work dir %q — "+
+			"anywhere else lands on the 512 MB tmpfs", agentboxTmpDirInCtr, agentboxWorkDirInContainer)
+	}
+	if !strings.HasPrefix(agentboxTmpDirRel, ".") {
+		t.Errorf("tmp dir %q must be dot-prefixed or agentbox's repo discovery "+
+			"treats it as an owner dir and CommitAndPush may stage it", agentboxTmpDirRel)
+	}
+	if strings.HasPrefix(agentboxTmpDirInCtr, "/tmp") {
+		t.Errorf("tmp dir %q is on the tmpfs this redirect exists to avoid", agentboxTmpDirInCtr)
+	}
+	if agentboxTmpDirRel == agentboxResultDirRel {
+		t.Error("tmp dir and result dir must be distinct; scratch would collide with result.json")
+	}
+}

--- a/jobs/commands/run_assistant_session.go
+++ b/jobs/commands/run_assistant_session.go
@@ -117,7 +117,11 @@ func (rs *RunAssistantSession) Run(parameters map[string]interface{}, logsWriter
 func prepareSessionDirs(workDirHost string) error {
 	outDir := filepath.Join(workDirHost, ".agentbox-output", "messages")
 	inDir := filepath.Join(workDirHost, ".agentbox-input", "messages")
-	for _, d := range []string{outDir, inDir} {
+	// tmpDir backs TMPDIR/GOTMPDIR for the session container, exactly as the
+	// Step path does — buildSessionSpawnEnvVars points at it, and TMPDIR
+	// naming a missing directory fails every write with ENOENT.
+	tmpDir := filepath.Join(workDirHost, agentboxTmpDirRel)
+	for _, d := range []string{outDir, inDir, tmpDir} {
 		if err := os.MkdirAll(d, 0755); err != nil {
 			return err
 		}
@@ -129,6 +133,7 @@ func prepareSessionDirs(workDirHost string) error {
 	for _, p := range []string{
 		filepath.Join(workDirHost, ".agentbox-output"),
 		filepath.Join(workDirHost, ".agentbox-input"),
+		tmpDir,
 	} {
 		if err := chownTreeToAgentbox(p); err != nil {
 			return err
@@ -155,6 +160,11 @@ func buildSessionSpawnEnvVars(parameters map[string]interface{}, logsWriter io.W
 		// session whenever the user pauses longer than its timeout to think.
 		// The server-side idle cron (user-message-based) is the idle-killer.
 		"NO_ACTIVITY_TIMEOUT": "0",
+		// Scratch off the 512 MB tmpfs, same as the Step paths — a session
+		// spawns the same container with the same mounts, and its agent runs
+		// the same installs and builds. See agentboxTmpDirRel.
+		"TMPDIR":   agentboxTmpDirInCtr,
+		"GOTMPDIR": agentboxTmpDirInCtr,
 	}
 	if creds, err := jobs.GetParameterValue[map[string]string](parameters, parameters_enums.AgentEnvVars); err == nil {
 		for k, v := range creds {


### PR DESCRIPTION
Fixes the ENOSPC that has been killing Tasks on website-svc, and the recurring `GOTMPDIR` build failures, which are the same bug.

## Cause

`/tmp` inside the agentbox container is a **512 MB RAM-backed tmpfs** (`tmpfsTmpOpts`, `run_agent_step.go:209`). That is not enough for real installs and builds, and the ENOSPC never names the tmpfs — it surfaces as whatever tool happened to be writing.

Measured on deployment-io/website-svc, an ordinary Next.js repo:

```
peak TMPDIR during one `yarn install`:  504.8 MB
container /tmp:                         512   MB
```

A **7 MB margin** before anything else in the container touches `/tmp`. In production:

```
ENOSPC: no space left on device, write
  at eP.patchPackage (.../yarn-4.9.4.cjs)
```

Yarn extracts and re-zips a patched dependency through temp files. An earlier fix moved Yarn's global *cache* to `/cache` — correct, but insufficient: the cache is where the finished zip lands, not where it is built. That is why the failure survived it unchanged.

Same root cause as `go build` dying in the linker with `mapping output file failed: no space left on device` unless run with `-p 1` — which happened to the agent *writing this very PR* — and the same as the long-standing `GOTMPDIR` failures.

**It was never a disk-space problem.** The host had **24 GB free** throughout.

## Fix

`TMPDIR` and `GOTMPDIR` now point at `/work/.agentbox-tmp`, on the bind-mounted work dir — the host's 30 GB root volume.

**Not a bigger tmpfs:** that is RAM, and it would compete with the build that needs it.
**Not `/cache`:** disk-backed and roomier, but a fresh Docker volume per Step with no host path the runner can pre-create a directory in. The work dir is already ours and already prepared here.

Dot-prefixed for the same reason as `.agentbox-output`: agentbox's `BuildPlan` skips dot-prefixed entries at both levels, and `CommitAndPush` iterates `/work/<idx>-<name>/`. So scratch can never be mistaken for a repo or staged into a Task's commit.

Applied to **all three** spawn paths that get this tmpfs — the vendor phase (where the failure happened), the Step agent, and Assistant sessions. Each pre-creates the directory: `TMPDIR` naming a missing directory fails every write with `ENOENT` rather than falling back to `/tmp`.

`prepareAgentboxResultDir` → `prepareAgentboxHostDirs`, since it now prepares both.

## Verification

`GOWORK=off` — `go build ./...`, `go vet`, `go test ./jobs/... ./utils/... ./entrypoints/...` all clean.

New `TestAgentboxTmpDirIsOffTheTmpfsAndInvisibleToAgentbox` pins both properties, since each is silent when broken: scratch must be under `/work` (not back on the tmpfs), and it must stay dot-prefixed (or agentbox treats it as a repo and it can ride into a commit).

⚠️ **Not verifiable in-repo** — it needs a real container with the real mounts. On the first Task after this ships, the vendor step should complete instead of ENOSPC'ing, and `.agentbox-tmp` should appear under the work dir and be gone with it at `MarkStepDone`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)