### PR TITLE
Point COREPACK_HOME at a writable path

### DIFF
--- a/jobs/commands/run_agent_step.go
+++ b/jobs/commands/run_agent_step.go
@@ -136,6 +136,33 @@ const (
 	agentboxTmpDirRel   = ".agentbox-tmp"
 	agentboxTmpDirInCtr = agentboxWorkDirInContainer + "/" + agentboxTmpDirRel
 
+	// agentboxCorepackHomeInCtr overrides the image's COREPACK_HOME
+	// (/opt/corepack), which the container cannot write to: we spawn with
+	// ReadonlyRootfs, so every path outside the mounts is read-only.
+	//
+	// corepack creates a scratch directory under COREPACK_HOME whenever it
+	// installs a package-manager version it hasn't cached, so any repo whose
+	// packageManager names something other than the image's pre-warmed Yarn
+	// Classic dies on the first `yarn` call:
+	//
+	//   EROFS: read-only file system, mkdir '/opt/corepack/v1/corepack-...'
+	//
+	// EROFS, not EACCES — the Dockerfile chowns /opt/corepack to the agent
+	// user correctly; the filesystem itself is the problem, so no permission
+	// change in the image can fix it.
+	//
+	// Cost of moving it: the image pre-warms Yarn Classic into /opt/corepack
+	// so unpinned repos never fetch a yarn binary, and corepack reads only
+	// COREPACK_HOME, so redirecting gives that up — such a repo now downloads
+	// Classic from registry.npmjs.org once per Step. That is ~1 MB against a
+	// vendor step that already pulls hundreds, and it buys correctness for
+	// every pinned repo. Preserving both would mean mounting a named volume
+	// over /opt/corepack (Docker seeds an empty one from the image layer),
+	// which is a second per-Step volume to create and reap for the sake of a
+	// megabyte.
+	agentboxCorepackHomeRel   = agentboxTmpDirRel + "/corepack"
+	agentboxCorepackHomeInCtr = agentboxWorkDirInContainer + "/" + agentboxCorepackHomeRel
+
 	// agentboxMCPSocketInContainer is where the per-task MCP tool socket is
 	// bind-mounted inside the agent container; agentbox reads its path from
 	// MCP_TOOL_RPC_SOCKET and bridges the agent's stdio MCP client to it. Tools
@@ -370,7 +397,7 @@ func prepareAgentboxHostDirs(workDirHost string) error {
 	if err := os.Chown(workDirHost, commandUtils.AgentboxUID, commandUtils.AgentboxGID); err != nil {
 		return err
 	}
-	for _, rel := range []string{agentboxResultDirRel, agentboxTmpDirRel} {
+	for _, rel := range []string{agentboxResultDirRel, agentboxTmpDirRel, agentboxCorepackHomeRel} {
 		dir := filepath.Join(workDirHost, rel)
 		if err := os.MkdirAll(dir, 0755); err != nil {
 			return err
@@ -399,6 +426,9 @@ func buildAgentSpawnEnvVars(parameters map[string]interface{}, logsWriter io.Wri
 		// preference, and the linker is the loudest victim of a small /tmp.
 		"TMPDIR":   agentboxTmpDirInCtr,
 		"GOTMPDIR": agentboxTmpDirInCtr,
+		// corepack cannot write to the image's /opt/corepack under
+		// ReadonlyRootfs — see agentboxCorepackHomeInCtr.
+		"COREPACK_HOME": agentboxCorepackHomeInCtr,
 	}
 	if creds, err := jobs.GetParameterValue[map[string]string](parameters, parameters_enums.AgentEnvVars); err == nil {
 		for k, v := range creds {
@@ -1353,6 +1383,9 @@ func buildVendorSpec(imageRef, workDirHost, cacheVolume string, ctx commandUtils
 		// 512 MB tmpfs. See agentboxTmpDirRel.
 		"TMPDIR":   agentboxTmpDirInCtr,
 		"GOTMPDIR": agentboxTmpDirInCtr,
+		// corepack cannot write to the image's /opt/corepack under
+		// ReadonlyRootfs — see agentboxCorepackHomeInCtr.
+		"COREPACK_HOME": agentboxCorepackHomeInCtr,
 	}
 	if token != "" {
 		env["GIT_TOKEN"] = token

--- a/jobs/commands/run_agent_step_test.go
+++ b/jobs/commands/run_agent_step_test.go
@@ -319,3 +319,25 @@ func TestAgentboxTmpDirIsOffTheTmpfsAndInvisibleToAgentbox(t *testing.T) {
 		t.Error("tmp dir and result dir must be distinct; scratch would collide with result.json")
 	}
 }
+
+// TestCorepackHomeIsWritableInTheContainer pins the override of the image's
+// COREPACK_HOME. /opt/corepack cannot be written under ReadonlyRootfs, and
+// corepack needs a scratch dir there for any version it hasn't cached — so
+// the home has to sit inside a mount. Failure mode if this regresses is
+// EROFS on the first `yarn` call in any repo pinning a packageManager, which
+// reads as a repo problem rather than a container one.
+func TestCorepackHomeIsWritableInTheContainer(t *testing.T) {
+	if !strings.HasPrefix(agentboxCorepackHomeInCtr, agentboxWorkDirInContainer+"/") {
+		t.Errorf("COREPACK_HOME %q must live under the bind-mounted work dir; "+
+			"everything outside the mounts is read-only", agentboxCorepackHomeInCtr)
+	}
+	if strings.HasPrefix(agentboxCorepackHomeInCtr, "/opt") {
+		t.Errorf("COREPACK_HOME %q is back on the read-only image filesystem", agentboxCorepackHomeInCtr)
+	}
+	// Nested under the tmp dir so one MkdirAll creates it and one RemoveAll
+	// at MarkStepDone reaps it.
+	if !strings.HasPrefix(agentboxCorepackHomeRel, agentboxTmpDirRel+"/") {
+		t.Errorf("COREPACK_HOME rel %q should nest under %q so it is created and "+
+			"cleaned up with it", agentboxCorepackHomeRel, agentboxTmpDirRel)
+	}
+}

--- a/jobs/commands/run_assistant_session.go
+++ b/jobs/commands/run_assistant_session.go
@@ -121,7 +121,11 @@ func prepareSessionDirs(workDirHost string) error {
 	// Step path does — buildSessionSpawnEnvVars points at it, and TMPDIR
 	// naming a missing directory fails every write with ENOENT.
 	tmpDir := filepath.Join(workDirHost, agentboxTmpDirRel)
-	for _, d := range []string{outDir, inDir, tmpDir} {
+	// corepackDir backs COREPACK_HOME; the image's /opt/corepack is
+	// unwritable under ReadonlyRootfs. Nested inside tmpDir, so MkdirAll
+	// covers both and the whole tree goes at cleanup.
+	corepackDir := filepath.Join(workDirHost, agentboxCorepackHomeRel)
+	for _, d := range []string{outDir, inDir, tmpDir, corepackDir} {
 		if err := os.MkdirAll(d, 0755); err != nil {
 			return err
 		}
@@ -134,6 +138,7 @@ func prepareSessionDirs(workDirHost string) error {
 		filepath.Join(workDirHost, ".agentbox-output"),
 		filepath.Join(workDirHost, ".agentbox-input"),
 		tmpDir,
+		corepackDir,
 	} {
 		if err := chownTreeToAgentbox(p); err != nil {
 			return err
@@ -165,6 +170,9 @@ func buildSessionSpawnEnvVars(parameters map[string]interface{}, logsWriter io.W
 		// the same installs and builds. See agentboxTmpDirRel.
 		"TMPDIR":   agentboxTmpDirInCtr,
 		"GOTMPDIR": agentboxTmpDirInCtr,
+		// corepack cannot write to the image's /opt/corepack under
+		// ReadonlyRootfs — see agentboxCorepackHomeInCtr.
+		"COREPACK_HOME": agentboxCorepackHomeInCtr,
 	}
 	if creds, err := jobs.GetParameterValue[map[string]string](parameters, parameters_enums.AgentEnvVars); err == nil {
 		for k, v := range creds {


### PR DESCRIPTION
Fixes `EROFS` on the first `yarn` call in any repo that pins a `packageManager`.

```
Error: EROFS: read-only file system,
  mkdir '/opt/corepack/v1/corepack-81-504ba743.d522'
```

## Cause

The agentbox image sets `COREPACK_HOME=/opt/corepack` and chowns it to the agent user — both correct. But the runner spawns with `ReadonlyRootfs: true` (`run_agent_step.go:805`), so every path outside the mounts is read-only.

corepack creates a scratch directory under `COREPACK_HOME` whenever it installs a version it hasn't cached. The image pre-warms only Yarn Classic, so **any repo pinning something else fails on its first `yarn` call**.

`EROFS`, not `EACCES` — this is the filesystem, not permissions, so no change in the image can fix it.

Hit live 2026-08-28 running `yarn typecheck` in a repo pinning `yarn@4.9.4`. The agent worked around it by hand with `COREPACK_HOME=/tmp/corepack` — not something every agent should have to rediscover.

Note the vendor phase was *unaffected* for repos that vendor a Yarn release, since that path runs `node .yarn/releases/yarn-x.y.z.cjs` directly and never touches corepack. It bites in the agent phase, and in vendoring for any Berry repo relying on a `packageManager` pin — the exact case corepack was introduced for.

## Fix

`COREPACK_HOME` → `/work/.agentbox-tmp/corepack`, nested inside the scratch dir added for `TMPDIR` in #112, so one `MkdirAll` creates it and `MarkStepDone`'s `RemoveAll` reaps it.

Applied to all three spawn paths — vendor, Step agent, Assistant session — each pre-creating the directory.

## Tradeoff, deliberate

The image pre-warms Yarn Classic into `/opt/corepack` so unpinned repos never fetch a yarn binary, and corepack reads **only** `COREPACK_HOME` — so moving it gives that up. Such a repo now downloads Classic from `registry.npmjs.org` once per Step: ~1 MB against a vendor step that already pulls hundreds, in exchange for correctness on every pinned repo.

Keeping both would mean mounting a named volume over `/opt/corepack` (Docker seeds an empty one from the image layer) — a second per-Step volume to create and reap for the sake of a megabyte. Worth revisiting only if the fetch shows up in Step latency.

## Verification

`GOWORK=off` — build, vet, and `go test ./jobs/...` clean. New `TestCorepackHomeIsWritableInTheContainer` pins that the home stays inside a mount, off `/opt`, and nested under the tmp dir so creation and cleanup stay coupled.

⚠️ **Not verifiable in-repo** — needs a real container with the real mounts. On the first Task after this ships, `yarn` in a `packageManager`-pinned repo should work without a hand-set `COREPACK_HOME`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)