### PR TITLE
Stage only what git would stage

### DIFF
--- a/jobs/commands/commit_and_push.go
+++ b/jobs/commands/commit_and_push.go
@@ -130,6 +130,14 @@ func (tcp *taskCommitPush) commitAndPushOne(repoDir string, entry tasks.Reposito
 	if err != nil {
 		return repoOutput{}, fmt.Errorf("error getting worktree: %s", err)
 	}
+	// Hand the worktree a pattern set collected with git's semantics before
+	// anything reads status or stages. go-git's own collection re-includes
+	// files under an excluded directory when something in there ships a
+	// negating .gitignore — see gitignore.go. This must precede Status(),
+	// which applies the same matcher and would otherwise report vendored
+	// files as changes.
+	worktree.Excludes = append(worktree.Excludes, gitSemanticsPatterns(worktree.Filesystem)...)
+
 	status, err := worktree.Status()
 	if err != nil {
 		return repoOutput{}, fmt.Errorf("error reading status: %s", err)

--- a/jobs/commands/gitignore.go
+++ b/jobs/commands/gitignore.go
@@ -1,0 +1,111 @@
+package commands
+
+import (
+	"bufio"
+	"os"
+	"strings"
+
+	"github.com/go-git/go-billy/v5"
+	"github.com/go-git/go-git/v5/plumbing/format/gitignore"
+)
+
+// Staging a Task's changes has to ignore exactly what `git add .` ignores.
+// go-git does not: gitignore.ReadPatterns recurses into EVERY directory and
+// collects the .gitignore of each, ignored ones included. Its matcher is
+// last-match-wins, so a deeper negation beats a shallower exclusion.
+//
+// Git's rule is the opposite, and stronger: "It is not possible to re-include
+// a file if a parent directory of that file is excluded." Git never descends
+// into an excluded directory, so it never reads the .gitignore inside one.
+//
+// The gap is not theoretical. tailwindcss ships
+// node_modules/tailwindcss/stubs/.gitignore containing `!*`. Under go-git that
+// re-includes the stubs even though the repo's own .gitignore excludes
+// node_modules/, so a Task on any tailwind repo committed ~1100 lines of
+// vendored dependency files into its PR. Real `git check-ignore` on the same
+// files reports them ignored by `.gitignore:2:node_modules/`.
+//
+// Fixed by handing the worktree a pattern set collected with git's semantics.
+// Worktree.Excludes is appended AFTER go-git's own patterns (worktree_status.go
+// excludeIgnoredChanges), and last-match-wins, so ours decides every path it
+// has an opinion on — which is every path reachable through an excluded
+// directory. Paths ours says nothing about fall through to go-git's set
+// unchanged, so this narrows behaviour to the buggy case and leaves the rest
+// alone. In particular a legitimate nested negation still works: `*.log` at the
+// root does not exclude the DIRECTORY logs/, so we descend, collect
+// `!important.log`, and it wins for us exactly as it does for git.
+
+const gitignoreFileName = ".gitignore"
+
+// gitSemanticsPatterns collects a repo's ignore patterns the way git resolves
+// them: top-down, skipping the subtree under any directory the
+// patterns-so-far already exclude.
+//
+// Order matters and is preserved — shallower patterns first, then deeper —
+// because the matcher resolves by last match.
+func gitSemanticsPatterns(fs billy.Filesystem) []gitignore.Pattern {
+	// .git/info/exclude is repo-local and applies from the root, the same
+	// place go-git reads it from.
+	patterns := readIgnoreFileAt(fs, []string{".git", "info"}, "exclude", nil)
+	return collectPatterns(fs, nil, patterns)
+}
+
+// collectPatterns walks dir and its subdirectories, returning inherited plus
+// everything found at or below dir.
+func collectPatterns(fs billy.Filesystem, dir []string, inherited []gitignore.Pattern) []gitignore.Pattern {
+	patterns := readIgnoreFileAt(fs, dir, gitignoreFileName, inherited)
+
+	entries, err := fs.ReadDir(fs.Join(dir...))
+	if err != nil {
+		// An unreadable directory contributes no patterns. Staging will fail
+		// on its own if this matters; guessing here could only ever widen
+		// what gets committed.
+		return patterns
+	}
+
+	// Rebuilt per directory rather than once, because a .gitignore deeper in
+	// the tree can legitimately re-include something a shallower one
+	// excluded, and that must be visible when deciding whether to descend.
+	matcher := gitignore.NewMatcher(patterns)
+	for _, entry := range entries {
+		if !entry.IsDir() || entry.Name() == ".git" {
+			continue
+		}
+		child := append(append([]string{}, dir...), entry.Name())
+		// The isDir=true match is the whole point: a pattern like
+		// `node_modules/` excludes the DIRECTORY, and git then never looks
+		// inside — so neither do we, and the .gitignore in there is never
+		// read.
+		if matcher.Match(child, true) {
+			continue
+		}
+		patterns = collectPatterns(fs, child, patterns)
+	}
+	return patterns
+}
+
+// readIgnoreFileAt appends the patterns in dir/name to base. Missing files are
+// normal — most directories have no .gitignore.
+func readIgnoreFileAt(fs billy.Filesystem, dir []string, name string, base []gitignore.Pattern) []gitignore.Pattern {
+	f, err := fs.Open(fs.Join(append(append([]string{}, dir...), name)...))
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return base
+		}
+		return base
+	}
+	defer f.Close()
+
+	patterns := base
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		// Blank lines and comments carry no pattern. A literal '#' has to be
+		// escaped as \#, which ParsePattern handles.
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		patterns = append(patterns, gitignore.ParsePattern(line, dir))
+	}
+	return patterns
+}

--- a/jobs/commands/gitignore_test.go
+++ b/jobs/commands/gitignore_test.go
@@ -1,0 +1,130 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/format/gitignore"
+)
+
+// writeRepoFiles lays out a worktree from a path→content map and inits a repo
+// in it. Paths are slash-separated and may nest.
+func writeRepoFiles(t *testing.T, files map[string]string) (*git.Worktree, string) {
+	t.Helper()
+	dir := t.TempDir()
+	for name, body := range files {
+		path := filepath.Join(dir, filepath.FromSlash(name))
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	repo, err := git.PlainInit(dir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wt, err := repo.Worktree()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return wt, dir
+}
+
+// ignored reports what the corrected pattern set decides for path, assembled
+// exactly as commitAndPushOne applies it: go-git's own patterns first, ours
+// appended last, resolved by last match. Asserting on the composition rather
+// than on gitSemanticsPatterns alone is the point — ours only has to WIN, not
+// to be consulted in isolation.
+func ignored(t *testing.T, wt *git.Worktree, path string) bool {
+	t.Helper()
+	base, err := gitignore.ReadPatterns(wt.Filesystem, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	all := append(base, gitSemanticsPatterns(wt.Filesystem)...)
+	return gitignore.NewMatcher(all).Match(strings.Split(path, "/"), false)
+}
+
+// TestNegatingGitignoreUnderAnExcludedDirCannotReInclude is the bug that put
+// ~1100 lines of vendored tailwind into a Task's PR. tailwindcss ships
+// node_modules/tailwindcss/stubs/.gitignore containing `!*`; go-git reads it
+// and, being last-match-wins, re-includes files the repo's own .gitignore
+// excluded. Git's rule is that a file under an excluded directory cannot be
+// re-included at all.
+func TestNegatingGitignoreUnderAnExcludedDirCannotReInclude(t *testing.T) {
+	wt, _ := writeRepoFiles(t, map[string]string{
+		".gitignore": "node_modules/\n",
+		"node_modules/tailwindcss/stubs/.gitignore":     "!*\n",
+		"node_modules/tailwindcss/stubs/config.full.js": "module.exports = {}\n",
+		"app/page.tsx": "export default function Page() {}\n",
+	})
+
+	if !ignored(t, wt, "node_modules/tailwindcss/stubs/config.full.js") {
+		t.Error("a file under an excluded directory must stay ignored — a nested " +
+			"`!*` cannot re-include it, and go-git alone says otherwise")
+	}
+	if ignored(t, wt, "app/page.tsx") {
+		t.Error("the actual source change must still be stageable")
+	}
+}
+
+// A nested negation is legitimate when no ancestor DIRECTORY is excluded:
+// `*.log` excludes files, not the logs/ directory, so git descends and honors
+// the re-inclusion. The fix must not over-correct into ignoring it.
+func TestNestedNegationStillAppliesWhenNoParentDirIsExcluded(t *testing.T) {
+	wt, _ := writeRepoFiles(t, map[string]string{
+		".gitignore":         "*.log\n",
+		"logs/.gitignore":    "!important.log\n",
+		"logs/important.log": "keep me\n",
+		"logs/verbose.log":   "drop me\n",
+	})
+
+	if ignored(t, wt, "logs/important.log") {
+		t.Error("a nested negation under a directory that is NOT excluded must " +
+			"still re-include, exactly as git does")
+	}
+	if !ignored(t, wt, "logs/verbose.log") {
+		t.Error("the shallower *.log exclusion must still apply to everything else")
+	}
+}
+
+// Nothing ignored means nothing suppressed — the ordinary repo, where this
+// machinery must be inert.
+func TestPlainRepoIgnoresNothingUnexpected(t *testing.T) {
+	wt, _ := writeRepoFiles(t, map[string]string{
+		"main.go":    "package main\n",
+		"README.md":  "# hi\n",
+		".gitignore": "\n# just a comment\n\n",
+	})
+	for _, f := range []string{"main.go", "README.md"} {
+		if ignored(t, wt, f) {
+			t.Errorf("%s must be stageable in a repo that ignores nothing", f)
+		}
+	}
+}
+
+// An excluded directory's contents stay excluded several levels down, and a
+// second excluded tree does not interfere with the first.
+func TestExclusionAppliesDeepAndAcrossSiblings(t *testing.T) {
+	wt, _ := writeRepoFiles(t, map[string]string{
+		".gitignore":                 "node_modules/\nvendor/\n",
+		"node_modules/a/b/c/deep.js": "x\n",
+		"node_modules/a/.gitignore":  "!**\n",
+		"vendor/pkg/.gitignore":      "!*\n",
+		"vendor/pkg/lib.go":          "package pkg\n",
+		"src/main.go":                "package main\n",
+	})
+	for _, f := range []string{"node_modules/a/b/c/deep.js", "vendor/pkg/lib.go"} {
+		if !ignored(t, wt, f) {
+			t.Errorf("%s is under an excluded directory and must stay ignored", f)
+		}
+	}
+	if ignored(t, wt, "src/main.go") {
+		t.Error("src/main.go must remain stageable")
+	}
+}


### PR DESCRIPTION
A Task on a tailwind repo committed **~1100 lines of vendored dependency files** into its PR ([website-svc#34](https://github.com/deployment-io/website-svc/pull/34), since stripped by hand).

## Cause

Real git ignores those files — `git check-ignore` reports `.gitignore:2:node_modules/`. The runner stages with go-git, which disagrees.

`gitignore.ReadPatterns` recurses into **every** directory and collects the `.gitignore` of each, ignored ones included ([dir.go:65](https://github.com/go-git/go-git/blob/v5.12.0/plumbing/format/gitignore/dir.go)). The matcher is last-match-wins, so a deeper negation beats a shallower exclusion. tailwindcss ships:

```
node_modules/tailwindcss/stubs/.gitignore   →   !*
```

which re-includes the stubs even though the repo's own `.gitignore` excludes `node_modules/`.

Git's rule is the opposite, and stronger: **a file cannot be re-included if a parent directory is excluded.** Git never descends into an excluded directory, so it never reads the `.gitignore` inside one.

## Fix

`gitSemanticsPatterns` collects a repo's patterns the way git resolves them — top-down, skipping the subtree under any directory the patterns-so-far exclude — and `commitAndPushOne` assigns the result to `Worktree.Excludes`.

That placement is what makes it work: go-git appends `Excludes` **after** its own patterns, and last match wins, so ours decides every path it has an opinion on — which is every path reachable through an excluded directory. Paths ours says nothing about fall through unchanged, so this narrows behaviour to the buggy case rather than replacing go-git's ignore handling.

Set before `Status()`, which applies the same matcher and would otherwise report the vendored files as changes.

**Deliberately not over-corrected.** A nested negation is legitimate when no ancestor *directory* is excluded: `*.log` at the root doesn't exclude `logs/`, so we descend, collect `!important.log`, and it wins for us exactly as it does for git.

## Verification

Four table tests, and I checked they're load-bearing by re-running them against go-git's patterns alone:

| test | fix on | fix off |
|---|---|---|
| tailwind `!*` under `node_modules/` | PASS | **FAIL** |
| deep + sibling excluded trees | PASS | **FAIL** |
| nested negation with no excluded parent | PASS | PASS |
| plain repo, nothing ignored | PASS | PASS |

The two that fail without the fix are the reproductions; the two that pass either way are guards against over-correcting — which is the way this change could do damage.

`GOWORK=off` — build, vet, `go test ./jobs/... ./utils/...` all clean.

## Why now

Latent until today. website-svc Tasks had never reached the commit step with a populated `node_modules`, because vendoring failed first — so the staging path had never been exercised on a repo with dependencies installed.

⚠️ Staging is the highest-consequence path in the runner. Worth watching the first Task after this ships: the PR diff should contain the agent's files and nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)