### PR TITLE
Say how the container died

### DIFF
--- a/jobs/commands/container_oom.go
+++ b/jobs/commands/container_oom.go
@@ -1,0 +1,83 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/moby/moby/client"
+)
+
+// A container that dies for memory says so only if someone asks. Docker
+// records it on the container's State, and the runner never looked — so an
+// OOM arrived as a bare non-zero exit or an unexplained `signal: killed`,
+// and on 2026-08-28 that cost an evening of guessing at causes.
+//
+// agentbox reports this from the inside now too (its cgroupmem package), and
+// the two are deliberately not the same check. Inside, agentbox reads the
+// cgroup's kill counter, which catches a CHILD being killed while agentbox
+// itself survives — the case that actually happened. Here, Docker's flag
+// describes the container as a whole, which is what we see when agentbox is
+// the process that died and there is nothing left to report from within.
+// Either one alone leaves a hole.
+
+// containerInspectTimeout bounds the post-mortem. It is a local daemon call
+// on an already-exited container, so it should be instant; the timeout only
+// exists so a wedged daemon cannot turn a diagnostic into a hang on the path
+// that reports a job's result.
+const containerInspectTimeout = 15 * time.Second
+
+// reportContainerExit writes a line about how the container died when there
+// is something worth saying: an OOM kill, or a signal exit that would
+// otherwise be a bare number.
+//
+// MUST be called before the container is removed — the deferred removal in
+// the spawn paths destroys the state this reads. Best-effort throughout: a
+// failed inspect is silence, never an error, because this runs on a path
+// that is already reporting a result and must not change it.
+func reportContainerExit(cli *client.Client, containerID string, logsWriter io.Writer) {
+	if cli == nil || containerID == "" {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), containerInspectTimeout)
+	defer cancel()
+
+	info, err := cli.ContainerInspect(ctx, containerID)
+	if err != nil || info.State == nil {
+		return
+	}
+	if msg := describeContainerExit(info.State.OOMKilled, info.State.ExitCode); msg != "" {
+		io.WriteString(logsWriter, msg+"\n")
+	}
+}
+
+// describeContainerExit renders the exit for a human reading a job log, or ""
+// when the exit speaks for itself. Split from the Docker call so the wording
+// can be tested without a daemon.
+func describeContainerExit(oomKilled bool, exitCode int) string {
+	switch {
+	case oomKilled:
+		// Docker's own flag, so this is stated as fact. It names the knob
+		// because the next question is always "what do I do about it", and
+		// AGENTBOX_MEMORY_BYTES is a runner env var — not something anyone
+		// would guess from an exit code.
+		return fmt.Sprintf("Container was OOM-killed by the kernel (exit %d). "+
+			"Raise AGENTBOX_MEMORY_BYTES on the runner, or reduce the work's parallelism.", exitCode)
+	case exitCode == 137:
+		// 128+9: SIGKILL, without Docker attributing it to memory. That is
+		// the ambiguous case — a cgroup can kill a CHILD without the
+		// container being flagged — so it points at the limit as a
+		// possibility rather than asserting it.
+		return "Container exited 137 (SIGKILL) without Docker reporting an OOM. " +
+			"A memory limit is still the likeliest cause — the kernel can kill a process " +
+			"inside the container without the container itself being flagged."
+	case exitCode == 143:
+		// 128+15: SIGTERM. Normal for our own stop paths, which already say
+		// why, so this only matters when nothing else explained it.
+		return "Container exited 143 (SIGTERM) — terminated rather than exiting on its own."
+	case exitCode > 128:
+		return fmt.Sprintf("Container was killed by signal %d (exit %d).", exitCode-128, exitCode)
+	}
+	return ""
+}

--- a/jobs/commands/container_oom_test.go
+++ b/jobs/commands/container_oom_test.go
@@ -1,0 +1,95 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestDescribeContainerExit pins what each death is allowed to claim.
+//
+// The distinction that matters is certainty. Docker's OOMKilled flag is a
+// fact and is stated as one; a bare 137 is a strong suspicion and must be
+// worded as one, because the kernel can kill a process INSIDE the container
+// without flagging the container — which is exactly the case that went
+// undiagnosed on 2026-08-28.
+func TestDescribeContainerExit(t *testing.T) {
+	cases := []struct {
+		name       string
+		oomKilled  bool
+		exitCode   int
+		wantEmpty  bool
+		wantHas    []string
+		wantNotHas []string
+	}{
+		{
+			name: "ordinary success says nothing", exitCode: 0, wantEmpty: true,
+		},
+		{
+			// A normal failure explains itself elsewhere; narrating it here
+			// would bury the real error under noise.
+			name: "ordinary failure says nothing", exitCode: 1, wantEmpty: true,
+		},
+		{
+			name: "docker flagged an OOM", oomKilled: true, exitCode: 137,
+			wantHas:    []string{"OOM-killed by the kernel", "AGENTBOX_MEMORY_BYTES"},
+			wantNotHas: []string{"likeliest"}, // a flag is proof, not a guess
+		},
+		{
+			name: "SIGKILL with no OOM flag", exitCode: 137,
+			wantHas:    []string{"137", "SIGKILL", "likeliest cause", "without the container itself being flagged"},
+			wantNotHas: []string{"was OOM-killed by the kernel"}, // must not assert what Docker did not
+		},
+		{
+			name:     "SIGTERM",
+			exitCode: 143,
+			wantHas:  []string{"143", "SIGTERM"},
+		},
+		{
+			name:     "some other signal is named numerically",
+			exitCode: 139, // 128+11, SIGSEGV
+			wantHas:  []string{"signal 11", "139"},
+		},
+		{
+			// OOMKilled outranks the exit code: a container OOM-killed but
+			// reporting a plain code must still be reported as an OOM.
+			name: "oom flag wins over an unremarkable code", oomKilled: true, exitCode: 1,
+			wantHas: []string{"OOM-killed"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := describeContainerExit(tc.oomKilled, tc.exitCode)
+			if tc.wantEmpty {
+				if got != "" {
+					t.Fatalf("got %q, want silence — an exit that explains itself needs no narration", got)
+				}
+				return
+			}
+			if got == "" {
+				t.Fatal("got silence, want an explanation")
+			}
+			for _, want := range tc.wantHas {
+				if !strings.Contains(got, want) {
+					t.Errorf("message %q is missing %q", got, want)
+				}
+			}
+			for _, notWant := range tc.wantNotHas {
+				if strings.Contains(got, notWant) {
+					t.Errorf("message %q must not contain %q", got, notWant)
+				}
+			}
+		})
+	}
+}
+
+// A nil client or empty id must not panic on the path that reports a job's
+// result — this is a diagnostic, and a diagnostic that can crash the reporter
+// is worse than no diagnostic.
+func TestReportContainerExitIsSafeWithNoClient(t *testing.T) {
+	var sb strings.Builder
+	reportContainerExit(nil, "abc", &sb)
+	reportContainerExit(nil, "", &sb)
+	if sb.String() != "" {
+		t.Errorf("wrote %q with no daemon to ask", sb.String())
+	}
+}

--- a/jobs/commands/run_agent_step.go
+++ b/jobs/commands/run_agent_step.go
@@ -761,7 +761,7 @@ func (rs *RunAgentStep) spawnAgentboxAndWait(spec agentboxSpawnSpec, logsWriter 
 	}
 	waitCtx, cancelWait := context.WithTimeout(dockerCtx, defaultWallClockTimeout)
 	defer cancelWait()
-	_, waitErr := waitForContainerExit(waitCtx, cli, containerID, rs.stopSignal)
+	_, waitErr := waitForContainerExit(waitCtx, cli, containerID, rs.stopSignal, logsWriter)
 	// On user-stop, return the partial result (caller merges into
 	// JobOutput) plus the stop sentinel error so the caller can route
 	// to the stop UX path. On other errors, propagate as-is.
@@ -977,7 +977,7 @@ func streamContainerLogs(ctx context.Context, cli *client.Client, containerID st
 //
 // stopSignal can be nil — a nil channel never fires in select, so the
 // stop branch is silently skipped. Pre-Phase-5.5 behavior matches.
-func waitForContainerExit(ctx context.Context, cli *client.Client, containerID string, stopSignal <-chan struct{}) (int, error) {
+func waitForContainerExit(ctx context.Context, cli *client.Client, containerID string, stopSignal <-chan struct{}, logsWriter io.Writer) (int, error) {
 	statusCh, errCh := cli.ContainerWait(ctx, containerID, container.WaitConditionNotRunning)
 	select {
 	case err := <-errCh:
@@ -998,6 +998,11 @@ func waitForContainerExit(ctx context.Context, cli *client.Client, containerID s
 		// Container exited. Agent phase: the exit code is advisory (status
 		// flows via /result.json). Vendor phase: the caller treats a
 		// non-zero code as a dependency-fetch failure.
+		//
+		// Ask Docker HOW it died before the deferred removal destroys the
+		// answer. Silent on an ordinary exit; speaks only for an OOM or a
+		// signal, which are the deaths a bare exit code fails to explain.
+		reportContainerExit(cli, containerID, logsWriter)
 		return int(status.StatusCode), nil
 	case <-stopSignal:
 		// User stopped the Job mid-run. SIGTERM the container with grace
@@ -1356,7 +1361,7 @@ func (rs *RunAgentStep) spawnVendorAndWait(spec agentboxSpawnSpec, logsWriter io
 	}()
 	waitCtx, cancelWait := context.WithTimeout(dockerCtx, defaultVendorTimeout)
 	defer cancelWait()
-	code, waitErr := waitForContainerExit(waitCtx, cli, containerID, rs.stopSignal)
+	code, waitErr := waitForContainerExit(waitCtx, cli, containerID, rs.stopSignal, logsWriter)
 	if waitErr != nil {
 		return waitErr
 	}

--- a/jobs/commands/run_assistant_session.go
+++ b/jobs/commands/run_assistant_session.go
@@ -255,7 +255,7 @@ func (rs *RunAssistantSession) runSession(orgID, jobID, imageRef, workDirHost st
 
 	waitCtx, cancelWait := context.WithTimeout(dockerCtx, sessionWallClockHardCap)
 	defer cancelWait()
-	exitCode, waitErr := waitForContainerExit(waitCtx, cli, containerID, rs.stopSignal)
+	exitCode, waitErr := waitForContainerExit(waitCtx, cli, containerID, rs.stopSignal, logsWriter)
 	close(stopBridge)
 	bridgeWg.Wait()
 	mf.tick() // final drain of any buffered output


### PR DESCRIPTION
Docker records whether a container was OOM-killed, on the container's `State`. The runner never looked — so an OOM arrived as a bare non-zero exit, or an unexplained `signal: killed`. On 2026-08-28 that cost an evening of guessing at causes, none of them right.

## What changes

`waitForContainerExit` inspects the container at its natural-exit branch — **before** the deferred removal destroys the answer — and writes a line when there is something a bare exit code fails to explain. All three spawn paths: Step agent, vendor phase, Assistant session.

## Certainty is graded

Conflating the two levels is how a diagnostic starts misleading people, so they're kept apart:

| condition | what it says |
|---|---|
| `OOMKilled` set | Docker's own flag — stated as **fact**, and names `AGENTBOX_MEMORY_BYTES`, since the next question is always what to do about it and that's a runner env var nobody would guess from an exit code |
| exit **137** | SIGKILL *without* the flag. The kernel can kill a process **inside** the container without flagging the container — exactly the case that went undiagnosed — so this points at memory as the **likeliest** cause without asserting it |
| exit 143 / >128 | named as the signal it was |
| anything else | **silence** — an ordinary failure explains itself elsewhere, and narrating it here would bury the real error |

## Overlaps with agentbox #46 on purpose

The two checks see different things, and either alone leaves a hole:

- **Inside** ([agentbox#46](https://github.com/deployment-io/agentbox/pull/46)) reads the cgroup's kill counter, which catches a **child** dying while agentbox survives — what actually happened on the 28th.
- **Here**, Docker's flag describes the container as a whole, which is what's left when agentbox *is* the process that died and there's nothing able to report from within.

## Safety

Best-effort throughout. The inspect is bounded by a 15s timeout, and a failure is silence rather than an error — this runs on the path that reports a job's result and must not change it. A nil client or empty id is a no-op, tested, because a diagnostic that can crash the reporter is worse than no diagnostic.

## Verification

8 subtests over the wording, pinning what each death is allowed to claim — including that a bare 137 must **not** assert what Docker didn't, and that the OOM flag outranks an unremarkable exit code.

`GOWORK=off` build, vet, and `go test ./jobs/... ./utils/... ./entrypoints/...` all clean.

⚠️ Not verifiable in-repo — needs a real daemon and a real OOM. The way to exercise it deliberately is a Task with `AGENTBOX_MEMORY_BYTES` set low; on an ordinary run this should add no output at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)