### PR TITLE
Fix the vet failure that blocks every agent Task on this repo

### DIFF
--- a/agent/tools/code_tools/query_code/query_code.go
+++ b/agent/tools/code_tools/query_code/query_code.go
@@ -66,10 +66,15 @@ func (t *Tool) Name() string {
 }
 
 func (t *Tool) Description() string {
-	description := `Queries the source code, and returns the answer to the input query. The tool has access to the source code and checks out the source code from GitHub, GitLab, or Bitbucket.
+	// Returned directly. This used to round-trip through fmt.Sprintf with no
+	// arguments, which formatted nothing — the string carries no verbs — but
+	// tripped vet's non-constant-format-string check, and `go vet ./...`
+	// failing on master blocked EVERY agent Task on this repo: the Task
+	// self-verification gate runs build + vet + test over ./..., so no agent
+	// could pass it regardless of its own work. One such Task lost 23 minutes
+	// on 2026-08-29.
+	return `Queries the source code, and returns the answer to the input query. The tool has access to the source code and checks out the source code from GitHub, GitLab, or Bitbucket.
 	The tool requires the following inputs: query (the input query).`
-	description = fmt.Sprintf(description)
-	return description
 }
 
 func addEdges(dir, moduleName string, graph *types.CodeGraph, queryContent string) error {


### PR DESCRIPTION
`Tool.Description` round-tripped its string through `fmt.Sprintf` with no arguments:

```go
description = fmt.Sprintf(description)
```

It formatted nothing — the string carries no verbs — but vet flags a non-constant format string, so **`go vet ./...` has been failing on master**.

## Why this is not cosmetic

The agent Task self-verification gate runs, over the whole module:

```
GOWORK=off go build ./... && go vet ./... && go test ./...
```

So **no agent Task on this repo could pass verification**, regardless of its own work. `go test ./...` fails identically, since it runs vet.

One Task lost 23 minutes on 2026-08-29: it finished successfully (`status=ok`, 64 turns), then the gate failed on this line and nothing was pushed.

## Verification

Ran that exact command on this branch — it passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)