### PR TITLE
Put the failure output in the verify failure

### DIFF
--- a/jobs/commands/run_agent_step.go
+++ b/jobs/commands/run_agent_step.go
@@ -1070,13 +1070,21 @@ type agentResult struct {
 }
 
 // verifyResult mirrors the fields of agentbox's result.json verify_result
-// that the runner consumes for the commit gate. agentbox also emits
-// duration/stdout/stderr tails; the runner doesn't need them here.
+// that the runner consumes for the commit gate.
+//
+// The tails are here because their absence made a failing Step
+// undiagnosable: this struct used to declare only the first four fields,
+// so anything else in the JSON was dropped silently at decode, and the
+// failure message could name nothing but the command. The comment that
+// used to sit here said the runner "doesn't need them", which was the
+// assumption that cost a Task 23 minutes of finished work on 2026-08-29.
 type verifyResult struct {
 	Ran           bool   `json:"ran"`
 	Passed        bool   `json:"passed"`
 	Command       string `json:"command,omitempty"`
 	SkippedReason string `json:"skipped_reason,omitempty"`
+	StdoutTail    string `json:"stdout_tail,omitempty"`
+	StderrTail    string `json:"stderr_tail,omitempty"`
 }
 
 // tokenUsage mirrors agentbox's /result.json token_usage object. Agentbox
@@ -1115,16 +1123,54 @@ func formatAgentFailure(result agentResult) error {
 	)
 }
 
+// verifyTailMaxBytes caps the failure output carried into the Step error.
+// The error is surfaced in the dashboard and fed to Re-run-with-feedback,
+// so it has to stay readable; agentbox is asked for a few lines, and this
+// only guards against an agent that ignores that.
+const verifyTailMaxBytes = 2000
+
 // formatVerifyFailure is returned when the agent's self-verification ran and
 // failed — failing the Step before CommitAndPush so broken code never lands.
-// The agent's changes_summary (already merged into JobOutput) carries the
-// narrative; this names the command for the Re-run-with-feedback signal.
+//
+// Carries the failure OUTPUT, not just the command. Naming only the command
+// describes the ritual rather than the cause, and leaves the reader to
+// reproduce the failure themselves to find out what it was: on 2026-08-29 a
+// Step reported `agent self-verification failed: GOWORK=off go build ./...
+// && go vet ./... && go test ./...` and the actual reason was a single
+// pre-existing vet warning in a package the agent never touched.
+//
+// stderr is preferred because that is where build and test failures land;
+// stdout is the fallback for tools that report failures there instead.
+// Empty when the agent reported no tail at all, which is every agentbox
+// older than the release that started asking for one — hence the graceful
+// degradation to today's message rather than an empty separator.
 func formatVerifyFailure(vr *verifyResult) error {
 	cmd := vr.Command
 	if cmd == "" {
 		cmd = "(unspecified command)"
 	}
+	if tail := verifyFailureTail(vr); tail != "" {
+		return fmt.Errorf("agent self-verification failed: %s — %s", cmd, tail)
+	}
 	return fmt.Errorf("agent self-verification failed: %s", cmd)
+}
+
+// verifyFailureTail picks the most useful output the agent reported and
+// bounds it.
+func verifyFailureTail(vr *verifyResult) string {
+	tail := strings.TrimSpace(vr.StderrTail)
+	if tail == "" {
+		tail = strings.TrimSpace(vr.StdoutTail)
+	}
+	if tail == "" {
+		return ""
+	}
+	if len(tail) > verifyTailMaxBytes {
+		// Keep the END: a compiler or test runner puts the failure last,
+		// and the head is usually progress output.
+		tail = "…" + tail[len(tail)-verifyTailMaxBytes:]
+	}
+	return tail
 }
 
 func readAgentResult(workDirHost string) (agentResult, error) {

--- a/jobs/commands/verify_failure_test.go
+++ b/jobs/commands/verify_failure_test.go
@@ -1,0 +1,111 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestFormatVerifyFailure pins that the error carries the CAUSE, not just the
+// command that produced it.
+//
+// The regression this guards is the exact message a Step produced on
+// 2026-08-29 — `agent self-verification failed: GOWORK=off go build ./... &&
+// go vet ./... && go test ./...` — which named the ritual and nothing else.
+// The reason turned out to be one pre-existing vet warning in a package the
+// agent never opened, and finding that out required reproducing the failure
+// by hand.
+func TestFormatVerifyFailure(t *testing.T) {
+	cases := []struct {
+		name       string
+		vr         verifyResult
+		wantHas    []string
+		wantNotHas []string
+	}{
+		{
+			name: "stderr tail is carried",
+			vr: verifyResult{
+				Command:    "go test ./...",
+				StderrTail: "pkg/auth/token.go:42:9: undefined: ParseJWT",
+			},
+			wantHas: []string{"go test ./...", "undefined: ParseJWT"},
+		},
+		{
+			// Some tools report failures on stdout; the message must not go
+			// blank just because stderr happened to be empty.
+			name: "stdout is the fallback",
+			vr: verifyResult{
+				Command:    "npm test",
+				StdoutTail: "1 failing\n  AssertionError: expected 200 to equal 404",
+			},
+			wantHas: []string{"npm test", "AssertionError"},
+		},
+		{
+			name: "stderr wins when both are present",
+			vr: verifyResult{
+				Command:    "go test ./...",
+				StdoutTail: "ok  	example/pkg	0.1s",
+				StderrTail: "FAIL	example/pkg [build failed]",
+			},
+			wantHas:    []string{"build failed"},
+			wantNotHas: []string{"0.1s"},
+		},
+		{
+			// Every agentbox older than the release that started asking for a
+			// tail reports none. That must degrade to the previous message,
+			// not to a dangling separator.
+			name:       "no tail degrades to the command alone",
+			vr:         verifyResult{Command: "go build ./..."},
+			wantHas:    []string{"go build ./..."},
+			wantNotHas: []string{"—"},
+		},
+		{
+			name:       "whitespace-only tail counts as none",
+			vr:         verifyResult{Command: "make check", StderrTail: "  \n\t "},
+			wantHas:    []string{"make check"},
+			wantNotHas: []string{"—"},
+		},
+		{
+			name:    "missing command still says something",
+			vr:      verifyResult{StderrTail: "boom"},
+			wantHas: []string{"(unspecified command)", "boom"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := formatVerifyFailure(&tc.vr).Error()
+			if !strings.HasPrefix(got, "agent self-verification failed: ") {
+				t.Errorf("prefix changed: %q", got)
+			}
+			for _, want := range tc.wantHas {
+				if !strings.Contains(got, want) {
+					t.Errorf("message %q is missing %q", got, want)
+				}
+			}
+			for _, notWant := range tc.wantNotHas {
+				if strings.Contains(got, notWant) {
+					t.Errorf("message %q must not contain %q", got, notWant)
+				}
+			}
+		})
+	}
+}
+
+// The error reaches the dashboard and feeds Re-run-with-feedback, so a
+// runaway tail has to be bounded — and bounded from the END, because a
+// compiler or test runner puts the failure last and the head is progress
+// noise. Truncating the wrong end would keep the useless half.
+func TestVerifyFailureTailIsBoundedKeepingTheEnd(t *testing.T) {
+	noise := strings.Repeat("compiling package blah blah\n", 500)
+	vr := verifyResult{Command: "go test ./...", StderrTail: noise + "FAIL: the actual reason"}
+
+	tail := verifyFailureTail(&vr)
+	if len(tail) > verifyTailMaxBytes+len("…") {
+		t.Errorf("tail is %d bytes, want it bounded near %d", len(tail), verifyTailMaxBytes)
+	}
+	if !strings.Contains(tail, "FAIL: the actual reason") {
+		t.Error("truncation dropped the end, which is where the failure is")
+	}
+	if !strings.HasPrefix(tail, "…") {
+		t.Error("a truncated tail should say it was truncated")
+	}
+}


### PR DESCRIPTION
A failing Step reported only the command it ran:

```
agent self-verification failed: GOWORK=off go build ./... && go vet ./... && go test ./...
```

That names the ritual, not the cause. On 2026-08-29 the actual reason was **a single pre-existing vet warning in a package the agent never opened** — and finding that out took reproducing the failure by hand, after the Step had already discarded 23 minutes of finished work.

## Two independent gaps

Neither fix does anything alone:

1. **The runner dropped the data.** `verifyResult` declared only `Ran`/`Passed`/`Command`/`SkippedReason`, so any tail in the JSON was discarded silently at decode. The comment above it said the runner *"doesn't need them"* — that was the assumption at fault. **(this PR)**
2. **Nothing populated the tails anyway.** `result.VerifyResult` has carried `StdoutTail`/`StderrTail` since it was written, but agentbox's prompt never asked the agent for them. **([agentbox#47](https://github.com/deployment-io/agentbox/pull/47))**

## What it says now

```
agent self-verification failed: go test ./... — pkg/auth/token.go:42:9: undefined: ParseJWT
```

**stderr is preferred**, since that's where build and test failures land; **stdout is the fallback** for tools that report failures there instead.

**Bounded at 2000 bytes, truncating from the front.** A compiler or test runner puts the failure last and the head is progress noise, so cutting the other end would keep the useless half. The error surfaces in the dashboard and feeds Re-run-with-feedback, so it has to stay readable.

**Degrades to exactly today's message** when no tail is reported — which is every agentbox older than the release that starts sending one, so this is safe to merge and deploy ahead of agentbox#47.

## Verification

7 subtests: stderr carried, stdout fallback, stderr wins over stdout, no-tail degradation, whitespace-only treated as none, missing command, and truncation keeping the end rather than the start.

`GOWORK=off go build ./... && go vet ./... && go test ./...` — the full gate, clean (now that #117 unblocked vet on master).

🤖 Generated with [Claude Code](https://claude.com/claude-code)