### PR TITLE
Size container limits from the host, and bound concurrent jobs by memory

### DIFF
--- a/client/ping_operations.go
+++ b/client/ping_operations.go
@@ -2,8 +2,10 @@ package client
 
 import (
 	"fmt"
-	"github.com/deployment-io/deployment-runner-kit/ping"
 	"runtime"
+
+	"github.com/deployment-io/deployment-runner-kit/ping"
+	"github.com/deployment-io/deployment-runner/utils/hostinfo"
 )
 
 func (r *RunnerClient) GetComputedOrganizationID(organizationID string) string {
@@ -25,6 +27,17 @@ func (r *RunnerClient) Ping(firstPing bool, organizationID string) error {
 	args.RunnerRegion = r.runnerRegion
 	args.CloudAccountID = r.cloudAccountID
 	args.DockerImage = r.currentDockerImage
+	// Host specs of the EC2 instance this runner is on. Only the runner
+	// can report these -- the aws-controller is a Fargate task with no
+	// view of the EC2 host -- and the runner scales to zero between jobs,
+	// so these ride the ping that happens when it boots.
+	//
+	// InstanceType may block for up to the IMDS timeout on its first call
+	// only; it is cached thereafter and returns empty rather than erroring
+	// off EC2.
+	args.HostMemoryBytes = hostinfo.MemoryBytes()
+	args.HostCPUCores = hostinfo.CPUCores()
+	args.InstanceType = hostinfo.InstanceType()
 	var reply ping.ReplyV1
 	err := r.c.Call("Ping.SendV2", args, &reply)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.31.1
 	github.com/aws/aws-sdk-go-v2/service/sts v1.28.6
 	github.com/aws/smithy-go v1.27.6
-	github.com/deployment-io/deployment-runner-kit v0.0.0-20260826071108-1dd349d606fd
+	github.com/deployment-io/deployment-runner-kit v0.0.0-20260831155440-b084a56aeeb8
 	github.com/deployment-io/team-ai v0.0.0-20250917084912-bdbad6a834e1
 	github.com/docker/docker v27.3.0+incompatible
 	github.com/go-git/go-billy/v5 v5.6.0

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.43.3
 	github.com/aws/aws-sdk-go-v2/config v1.27.11
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.11
+	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.1
 	github.com/aws/aws-sdk-go-v2/service/acm v1.25.4
 	github.com/aws/aws-sdk-go-v2/service/bedrock v1.66.3
 	github.com/aws/aws-sdk-go-v2/service/cloudfront v1.36.0
@@ -31,6 +32,7 @@ require (
 	github.com/deployment-io/deployment-runner-kit v0.0.0-20260826071108-1dd349d606fd
 	github.com/deployment-io/team-ai v0.0.0-20250917084912-bdbad6a834e1
 	github.com/docker/docker v27.3.0+incompatible
+	github.com/go-git/go-billy/v5 v5.6.0
 	github.com/go-git/go-git/v5 v5.12.0
 	github.com/go-playground/validator/v10 v10.23.0
 	github.com/joho/godotenv v1.5.1
@@ -39,6 +41,7 @@ require (
 	github.com/tree-sitter/tree-sitter-go v0.23.4
 	go.mongodb.org/mongo-driver v1.14.0
 	golang.org/x/net v0.47.0
+	golang.org/x/sync v0.19.0
 	gonum.org/v1/gonum v0.16.0
 )
 
@@ -52,7 +55,6 @@ require (
 	github.com/ProtonMail/go-crypto v1.0.0 // indirect
 	github.com/ankit-arora/bitset v0.0.0-20250212073004-6a047aa1a9a0 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.7 // indirect
-	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.1 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.34 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.34 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.0 // indirect
@@ -77,7 +79,6 @@ require (
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
-	github.com/go-git/go-billy/v5 v5.6.0 // indirect
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
@@ -139,7 +140,6 @@ require (
 	golang.org/x/crypto v0.46.0 // indirect
 	golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c // indirect
 	golang.org/x/mod v0.30.0 // indirect
-	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.39.0 // indirect
 	golang.org/x/text v0.32.0 // indirect
 	golang.org/x/tools v0.39.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -155,6 +155,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/deployment-io/deployment-runner-kit v0.0.0-20260826071108-1dd349d606fd h1:FsNcBOiluBN/9F1dDRApLiJVvKTHSdUXfw/dzZjtXc8=
 github.com/deployment-io/deployment-runner-kit v0.0.0-20260826071108-1dd349d606fd/go.mod h1:wKTz63GqLOHVXT173zlW/zJFRLi9krn7dqXoDm/BXFI=
+github.com/deployment-io/deployment-runner-kit v0.0.0-20260831155440-b084a56aeeb8 h1:QvaX2Lb9sj7SHKcuH7TUfdTlWupb7yxt46sb3+fYkDU=
+github.com/deployment-io/deployment-runner-kit v0.0.0-20260831155440-b084a56aeeb8/go.mod h1:wKTz63GqLOHVXT173zlW/zJFRLi9krn7dqXoDm/BXFI=
 github.com/deployment-io/team-ai v0.0.0-20250917084912-bdbad6a834e1 h1:gfeNqym19IiO38sQ84WPMmZXrdDisu64qQP3Xs0N2RM=
 github.com/deployment-io/team-ai v0.0.0-20250917084912-bdbad6a834e1/go.mod h1:B0fxmLJICi0qP2R2m3I2tR1uRIKQxn4ekK67lyBRHjw=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=

--- a/jobs/commands/admission.go
+++ b/jobs/commands/admission.go
@@ -1,0 +1,150 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+
+	"golang.org/x/sync/semaphore"
+)
+
+// Memory admission control for container-spawning jobs.
+//
+// WHY THIS EXISTS
+//
+// Sizing each container from the host (host_resources.go) bounds any
+// SINGLE container, but says nothing about what happens when several run
+// at once — and the runner is built to run several at once. The job
+// dispatcher is a 3-lane concurrent pipeline where each lane runs a
+// 5-worker pool (entrypoints/common/common.go), so up to 15 jobs can be
+// in flight, and nothing in that path is aware of memory. Fifteen jobs
+// that each create a container sized for the whole host is fifteen times
+// the host.
+//
+// The naive fix — make the worker count a function of RAM — is wrong,
+// because job footprints differ by three orders of magnitude. Of the 32
+// command types the runner implements, most are AWS API calls that need
+// essentially no memory (CreateAwsVpc, VerifyAcmCertificate,
+// GetDeploymentLogsAws, ...). Throttling those to protect against an
+// agentbox container would tank deploy latency for no reason at all.
+//
+// So concurrency is gated by WEIGHT rather than by count: only the jobs
+// that actually create a container acquire memory, and they acquire the
+// amount they were sized for. Everything else runs unimpeded. The
+// practical effect on the shipped m6a.large (2 vCPU, 8 GB) is that one
+// agentbox Task or one image build runs at a time, while several
+// static-site builds still run in parallel — and on a larger instance
+// the same code admits proportionally more, with no retuning.
+//
+// This is also what makes the generous per-container sizing safe. Giving
+// agentbox the whole budget would be reckless if two could overlap;
+// admission control is the guarantee that they can't.
+
+const (
+	// admissionWaitTimeout bounds how long a job waits for memory before
+	// giving up. Generous, because waiting is the CORRECT behaviour here:
+	// a queued job that starts three minutes late is a far better outcome
+	// than two jobs that start immediately and are both OOM-killed. It
+	// exists only so a leaked slot can't wedge a worker forever.
+	//
+	// Comfortably longer than a typical agentbox Step but well short of
+	// the runner's 4h job wall-clock, so a job that can't be admitted
+	// fails with a clear message rather than consuming its whole budget
+	// sitting in a queue.
+	admissionWaitTimeout = 30 * time.Minute
+)
+
+var (
+	admissionOnce sync.Once
+	admissionSem  *semaphore.Weighted
+	// admissionCapacity is the semaphore's size, kept so acquire can clamp
+	// oversized requests. semaphore.Weighted.Acquire blocks FOREVER when
+	// asked for more than the total capacity rather than returning an
+	// error, so an unclamped oversized weight would deadlock the job.
+	admissionCapacity int64
+)
+
+// admissionUnitBytes is the granularity of the semaphore. Weights are
+// expressed in units rather than raw bytes purely to keep the numbers
+// small and readable in logs; the ratio is what matters.
+const admissionUnitBytes = 64 * 1024 * 1024 // 64 MB
+
+func admissionSemaphore() (*semaphore.Weighted, int64) {
+	admissionOnce.Do(func() {
+		admissionCapacity = memoryBudget() / admissionUnitBytes
+		if admissionCapacity < 1 {
+			admissionCapacity = 1
+		}
+		admissionSem = semaphore.NewWeighted(admissionCapacity)
+	})
+	return admissionSem, admissionCapacity
+}
+
+// admissionWeight converts a byte figure into semaphore units, rounding
+// UP so a container is never admitted against less memory than it may
+// actually use, and clamping to the total capacity.
+//
+// The clamp is what keeps an operator-supplied override from wedging the
+// runner: someone who sets AGENTBOX_MEMORY_BYTES above what the host can
+// back gets a job that runs alone (weight == whole capacity) rather than
+// a job that blocks forever waiting for memory that will never exist.
+func admissionWeight(memoryBytes int64) int64 {
+	_, capacity := admissionSemaphore()
+	units := (memoryBytes + admissionUnitBytes - 1) / admissionUnitBytes
+	if units < 1 {
+		units = 1
+	}
+	if units > capacity {
+		units = capacity
+	}
+	return units
+}
+
+// acquireMemory reserves memoryBytes worth of host memory for a
+// container that is about to be created, blocking until the host has
+// room. Returns a release function the caller MUST call — via defer at
+// the call site, so it runs on every exit path including panics.
+//
+// ctx is the job's context, so a cancelled or stopped job stops waiting
+// immediately instead of holding a worker.
+//
+// logsWriter gets a line only when the job actually has to wait. On an
+// idle runner this is silent; when it does print, "waiting for memory"
+// is exactly the explanation a user staring at a stalled job needs, and
+// the alternative (staying quiet) is what makes queueing feel like a
+// hang.
+func acquireMemory(ctx context.Context, memoryBytes int64, label string, logsWriter io.Writer) (release func(), err error) {
+	sem, _ := admissionSemaphore()
+	weight := admissionWeight(memoryBytes)
+
+	// Fast path: if there's room right now, take it without announcing
+	// anything. TryAcquire never blocks.
+	if sem.TryAcquire(weight) {
+		return func() { sem.Release(weight) }, nil
+	}
+
+	if logsWriter != nil {
+		_, _ = io.WriteString(logsWriter,
+			fmt.Sprintf("Waiting for memory on the runner before starting %s (needs %d MB)...\n",
+				label, memoryBytes/(1024*1024)))
+	}
+
+	waitCtx, cancel := context.WithTimeout(ctx, admissionWaitTimeout)
+	defer cancel()
+	if err := sem.Acquire(waitCtx, weight); err != nil {
+		// Distinguish "the job was cancelled" from "we gave up waiting" —
+		// they need different responses from whoever reads the log.
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		return nil, fmt.Errorf("timed out after %s waiting for memory on the runner to start %s "+
+			"(needs %d MB of a %d MB budget); other jobs on this runner are holding it",
+			admissionWaitTimeout, label, memoryBytes/(1024*1024), memoryBudget()/(1024*1024))
+	}
+	if logsWriter != nil {
+		_, _ = io.WriteString(logsWriter, fmt.Sprintf("Memory available, starting %s.\n", label))
+	}
+	return func() { sem.Release(weight) }, nil
+}

--- a/jobs/commands/admission.go
+++ b/jobs/commands/admission.go
@@ -41,19 +41,45 @@ import (
 // This is also what makes the generous per-container sizing safe. Giving
 // agentbox the whole budget would be reckless if two could overlap;
 // admission control is the guarantee that they can't.
+//
+// TWO CONSEQUENCES WORTH KNOWING, both deliberate:
+//
+//  1. On the smallest instance we ship (m6a.large, ~7.7 GB) an agent
+//     container is sized to the ENTIRE budget, so its weight is 100% of
+//     capacity and nothing runs beside it. That is not an accident of the
+//     arithmetic — it is what "the agent may use all the memory the host
+//     can spare" means, and on a host that size the alternative is to
+//     shrink the agent back below the 4 GB that was already OOM-killing
+//     Tasks. Concurrency on a small runner is the thing being traded
+//     away; a larger instance buys it back with no code change, because
+//     both the caps and the capacity scale with the host.
+//
+//  2. golang.org/x/sync/semaphore is strict FIFO and deliberately leaves
+//     every waiter blocked behind one that does not fit (see the comment
+//     in its notifyWaiters). So a queued full-budget agent request stalls
+//     a small build that would otherwise fit. This is the RIGHT tradeoff
+//     and is not worked around: allowing small jobs to barge ahead would
+//     starve the large one indefinitely on a busy runner, turning a
+//     bounded delay into a job that never runs at all. It does mean the
+//     admission wait must be long enough to outlast the job in front —
+//     see admissionWaitTimeout.
 
 const (
 	// admissionWaitTimeout bounds how long a job waits for memory before
-	// giving up. Generous, because waiting is the CORRECT behaviour here:
-	// a queued job that starts three minutes late is a far better outcome
-	// than two jobs that start immediately and are both OOM-killed. It
-	// exists only so a leaked slot can't wedge a worker forever.
+	// giving up. Waiting is the CORRECT behaviour here: a deployment that
+	// starts late is a far better outcome than one that fails, or than two
+	// jobs that start at once and are both OOM-killed.
 	//
-	// Comfortably longer than a typical agentbox Step but well short of
-	// the runner's 4h job wall-clock, so a job that can't be admitted
-	// fails with a clear message rather than consuming its whole budget
-	// sitting in a queue.
-	admissionWaitTimeout = 30 * time.Minute
+	// Sized to outlast a realistic agentbox Task rather than a "typical"
+	// one. On the smallest instance we ship, an agent container is sized
+	// to the whole budget (see host_resources.go), so a build genuinely
+	// cannot start until the Task finishes — and at the previous 30m this
+	// turned every deploy dispatched during a longer Task into a HARD
+	// FAILURE rather than a delay. 2h covers essentially every Task while
+	// staying under the runner's 4h job wall-clock, so a job that truly
+	// cannot be admitted still fails with a clear message instead of
+	// wedging a worker forever.
+	admissionWaitTimeout = 2 * time.Hour
 )
 
 var (
@@ -107,15 +133,33 @@ func admissionWeight(memoryBytes int64) int64 {
 // room. Returns a release function the caller MUST call — via defer at
 // the call site, so it runs on every exit path including panics.
 //
-// ctx is the job's context, so a cancelled or stopped job stops waiting
-// immediately instead of holding a worker.
+// It takes the job's STOP CHANNEL rather than a context, deliberately.
+// An earlier version took the caller's context, which was wrong in both
+// directions:
+//
+//   - Callers passed context.Background(), so a user pressing Stop on a
+//     queued job could not interrupt the wait. The job sat holding a
+//     worker until the timeout and then failed with a resource error
+//     instead of reporting as cancelled.
+//
+//   - The one caller that did pass a real context (imageBuild) passed one
+//     already carrying the BUILD's 30-minute deadline, so time spent
+//     queueing was silently deducted from the build's own wall-clock. A
+//     25-minute wait left a 5-minute build, which then died mid-layer
+//     with a bare "context deadline exceeded" that named neither memory
+//     nor the build timeout.
+//
+// Taking the stop channel gets cancellation without importing anyone
+// else's deadline: the admission timeout is applied here and here only.
+// A nil channel is fine and means "not stoppable" — a nil channel never
+// fires in select.
 //
 // logsWriter gets a line only when the job actually has to wait. On an
 // idle runner this is silent; when it does print, "waiting for memory"
 // is exactly the explanation a user staring at a stalled job needs, and
 // the alternative (staying quiet) is what makes queueing feel like a
 // hang.
-func acquireMemory(ctx context.Context, memoryBytes int64, label string, logsWriter io.Writer) (release func(), err error) {
+func acquireMemory(stop <-chan struct{}, memoryBytes int64, label string, logsWriter io.Writer) (release func(), err error) {
 	sem, _ := admissionSemaphore()
 	weight := admissionWeight(memoryBytes)
 
@@ -127,20 +171,36 @@ func acquireMemory(ctx context.Context, memoryBytes int64, label string, logsWri
 
 	if logsWriter != nil {
 		_, _ = io.WriteString(logsWriter,
-			fmt.Sprintf("Waiting for memory on the runner before starting %s (needs %d MB)...\n",
-				label, memoryBytes/(1024*1024)))
+			fmt.Sprintf("Waiting for memory on the runner before starting %s (needs %d MB of a %d MB budget). "+
+				"Another job is using it; this job will start when that one finishes.\n",
+				label, memoryBytes/(1024*1024), memoryBudget()/(1024*1024)))
 	}
 
-	waitCtx, cancel := context.WithTimeout(ctx, admissionWaitTimeout)
+	waitCtx, cancel := context.WithTimeout(context.Background(), admissionWaitTimeout)
 	defer cancel()
+	// Translate the stop channel into cancellation of the wait. The
+	// goroutine exits via the deferred cancel on every return path, so it
+	// cannot outlive this call.
+	go func() {
+		select {
+		case <-stop:
+			cancel()
+		case <-waitCtx.Done():
+		}
+	}()
+
 	if err := sem.Acquire(waitCtx, weight); err != nil {
-		// Distinguish "the job was cancelled" from "we gave up waiting" —
-		// they need different responses from whoever reads the log.
-		if ctx.Err() != nil {
-			return nil, ctx.Err()
+		// Distinguish "the user stopped this job" from "we gave up
+		// waiting" — they need different responses from whoever reads the
+		// log, and only the latter is a resource problem.
+		select {
+		case <-stop:
+			return nil, fmt.Errorf("stopped while waiting for memory on the runner to start %s", label)
+		default:
 		}
 		return nil, fmt.Errorf("timed out after %s waiting for memory on the runner to start %s "+
-			"(needs %d MB of a %d MB budget); other jobs on this runner are holding it",
+			"(needs %d MB of a %d MB budget). Another job held it for longer than that; "+
+			"a larger runner instance would let them run at the same time",
 			admissionWaitTimeout, label, memoryBytes/(1024*1024), memoryBudget()/(1024*1024))
 	}
 	if logsWriter != nil {

--- a/jobs/commands/admission.go
+++ b/jobs/commands/admission.go
@@ -32,11 +32,16 @@ import (
 //
 // So concurrency is gated by WEIGHT rather than by count: only the jobs
 // that actually create a container acquire memory, and they acquire the
-// amount they were sized for. Everything else runs unimpeded. The
-// practical effect on the shipped m6a.large (2 vCPU, 8 GB) is that one
-// agentbox Task or one image build runs at a time, while several
-// static-site builds still run in parallel — and on a larger instance
-// the same code admits proportionally more, with no retuning.
+// amount they were sized for. Everything else runs unimpeded, and on a
+// larger instance the same code admits proportionally more with no
+// retuning.
+//
+// What that means concretely on the shipped m6a.large (2 vCPU, 8 GB):
+// two static-site builds fit together, but an agent container or an
+// image build is sized to the whole budget and so runs strictly alone.
+// See consequence 1 below — this was originally described here as "one
+// Task at a time while several builds still run in parallel", which was
+// wrong: the arithmetic leaves zero units beside an agent job.
 //
 // This is also what makes the generous per-container sizing safe. Giving
 // agentbox the whole budget would be reckless if two could overlap;
@@ -75,10 +80,16 @@ const (
 	// to the whole budget (see host_resources.go), so a build genuinely
 	// cannot start until the Task finishes — and at the previous 30m this
 	// turned every deploy dispatched during a longer Task into a HARD
-	// FAILURE rather than a delay. 2h covers essentially every Task while
-	// staying under the runner's 4h job wall-clock, so a job that truly
-	// cannot be admitted still fails with a clear message instead of
-	// wedging a worker forever.
+	// FAILURE rather than a delay.
+	//
+	// Note this does NOT sit inside some larger per-job envelope: there is
+	// no runner-wide job wall-clock. The 4h defaultWallClockTimeout in
+	// run_agent_step.go bounds the agent CONTAINER once it starts, and
+	// defaultBuildTimeout bounds a build the same way, both AFTER
+	// admission. So this timeout adds to a job's total time rather than
+	// fitting within it, which is the reason it is 2h and not longer: it
+	// has to outlast the job in front without letting a job that will
+	// never be admitted wedge a worker indefinitely.
 	admissionWaitTimeout = 2 * time.Hour
 )
 
@@ -86,9 +97,12 @@ var (
 	admissionOnce sync.Once
 	admissionSem  *semaphore.Weighted
 	// admissionCapacity is the semaphore's size, kept so acquire can clamp
-	// oversized requests. semaphore.Weighted.Acquire blocks FOREVER when
-	// asked for more than the total capacity rather than returning an
-	// error, so an unclamped oversized weight would deadlock the job.
+	// oversized requests. semaphore.Weighted.Acquire has an explicit
+	// `n > s.size` branch that parks on the context and returns its error
+	// — so an unclamped oversized weight would not deadlock, but it WOULD
+	// be doomed from the start: the job would sit for the whole admission
+	// timeout and then fail, having never been satisfiable. Clamping turns
+	// that guaranteed slow failure into a job that simply runs alone.
 	admissionCapacity int64
 )
 
@@ -112,10 +126,12 @@ func admissionSemaphore() (*semaphore.Weighted, int64) {
 // UP so a container is never admitted against less memory than it may
 // actually use, and clamping to the total capacity.
 //
-// The clamp is what keeps an operator-supplied override from wedging the
-// runner: someone who sets AGENTBOX_MEMORY_BYTES above what the host can
-// back gets a job that runs alone (weight == whole capacity) rather than
-// a job that blocks forever waiting for memory that will never exist.
+// The clamp is what keeps an operator-supplied override from producing a
+// doomed job: someone who sets AGENTBOX_MEMORY_BYTES above what the host
+// can back gets a job that runs alone (weight == whole capacity) rather
+// than one that parks for the full admission timeout and then fails,
+// having never been satisfiable (Acquire's `n > s.size` branch waits on
+// the context rather than returning immediately).
 func admissionWeight(memoryBytes int64) int64 {
 	_, capacity := admissionSemaphore()
 	units := (memoryBytes + admissionUnitBytes - 1) / admissionUnitBytes

--- a/jobs/commands/build_docker_image.go
+++ b/jobs/commands/build_docker_image.go
@@ -77,11 +77,38 @@ func imageBuild(parameters map[string]interface{}, dockerClient *client.Client, 
 		return err
 	}
 
+	// Memory / CPU caps on the image build. Until these were added the
+	// build was the ONLY heavy workload on the runner with no limit at
+	// all: agentbox and the static-site build container were both capped,
+	// while `docker build` ran unbounded. That matters more than it looks
+	// because an image build executes inside DOCKERD, not in the runner's
+	// cgroup — so it is invisible to ECS accounting and to every
+	// runner-side limit, and a heavy build could consume the whole host
+	// and let the kernel OOM-killer pick a victim (potentially dockerd or
+	// the runner itself, killing every in-flight job with no useful
+	// error).
+	//
+	// Sized from the host and deliberately generous: this path has been
+	// unbounded for a long time, so a cap that is too tight turns builds
+	// that succeed today into failures. BUILD_IMAGE_MEMORY_BYTES is the
+	// escape hatch for a build that legitimately needs more.
+	buildMemoryBytes, buildCores := resolveImageBuildLimits()
 	opts := types.ImageBuildOptions{
 		Dockerfile: dockerFile,
 		Tags:       []string{dockerImageNameAndTag},
 		Remove:     true,
 		BuildArgs:  buildArgs,
+		Memory:     buildMemoryBytes,
+		// MemorySwap == Memory disables swap for the build. Without this
+		// Docker grants swap equal to twice Memory, which turns a memory
+		// overrun into minutes of thrashing instead of a fast, clearly
+		// attributed failure.
+		MemorySwap: buildMemoryBytes,
+		// ImageBuildOptions expresses CPU as a CFS quota/period pair in
+		// MICROSECONDS, unlike the NanoCPUs used by ContainerCreate
+		// elsewhere in this package. quota = cores * period.
+		CPUPeriod: cpuPeriodMicroseconds,
+		CPUQuota:  buildCores * cpuPeriodMicroseconds,
 	}
 	res, err := dockerClient.ImageBuild(ctx, tar, opts)
 	if err != nil {

--- a/jobs/commands/build_docker_image.go
+++ b/jobs/commands/build_docker_image.go
@@ -18,7 +18,21 @@ import (
 )
 
 type BuildDockerImage struct {
+	// stopSignal closes when the server reports the Job moved to Stopping.
+	// Used to cancel the admission wait so a user can stop a build that is
+	// queued behind another job's memory; see BuildStaticSite.stopSignal
+	// for the full rationale.
+	stopSignal <-chan struct{}
 }
+
+// SetStopSignal satisfies jobs.StoppableCommand.
+func (b *BuildDockerImage) SetStopSignal(stop <-chan struct{}) {
+	b.stopSignal = stop
+}
+
+// See the note on BuildStaticSite: the dispatcher finds the stop signal
+// by type-asserting the POINTER, and a silent failure means stop stops working.
+var _ jobs.StoppableCommand = (*BuildDockerImage)(nil)
 
 type ErrorLine struct {
 	Error       string      `json:"error"`
@@ -94,17 +108,6 @@ func imageBuild(parameters map[string]interface{}, dockerClient *client.Client, 
 	// escape hatch for a build that legitimately needs more.
 	buildMemoryBytes, buildCores := resolveImageBuildLimits()
 
-	// Reserve the memory before handing the build to dockerd, and hold it
-	// until the build finishes. Without this the cap above bounds one
-	// build but not several: the dispatcher can have many jobs in flight,
-	// and concurrent uncoordinated builds would each be individually
-	// within their cap while collectively exceeding the host.
-	releaseMemory, err := acquireMemory(ctx, buildMemoryBytes, "docker image build", logsWriter)
-	if err != nil {
-		return err
-	}
-	defer releaseMemory()
-
 	opts := types.ImageBuildOptions{
 		Dockerfile: dockerFile,
 		Tags:       []string{dockerImageNameAndTag},
@@ -121,6 +124,15 @@ func imageBuild(parameters map[string]interface{}, dockerClient *client.Client, 
 		// elsewhere in this package. quota = cores * period.
 		CPUPeriod: cpuPeriodMicroseconds,
 		CPUQuota:  buildCores * cpuPeriodMicroseconds,
+		// Pin the classic builder EXPLICITLY. Memory, MemorySwap, CPUPeriod
+		// and CPUQuota above are honoured only by the v1 builder; BuildKit
+		// silently ignores them. Left unset, the builder is chosen by the
+		// daemon, so a host with `features: {"buildkit": true}` in
+		// daemon.json would run this build completely unbounded while every
+		// comment here, and admission control, assumed it was capped -- the
+		// exact host-OOM path this cap exists to close, in the one place
+		// nobody would look for it.
+		Version: types.BuilderV1,
 	}
 	res, err := dockerClient.ImageBuild(ctx, tar, opts)
 	if err != nil {
@@ -162,6 +174,26 @@ func (b *BuildDockerImage) Run(parameters map[string]interface{}, logsWriter io.
 	if err != nil {
 		return parameters, err
 	}
+	// Reserve host memory before starting the build, held until it
+	// finishes. The cap inside imageBuild bounds ONE build; this is what
+	// stops several concurrent ones from each being individually within
+	// their cap while collectively exceeding the host.
+	//
+	// Acquired HERE rather than inside imageBuild on purpose. imageBuild
+	// opens with a 30-minute build deadline, and acquiring under that
+	// context made the queue wait eat the build's own wall-clock: a
+	// 25-minute wait left a 5-minute build that then died mid-layer with a
+	// bare "context deadline exceeded" naming neither memory nor the
+	// timeout. Out here the wait has only its own timeout, and the build
+	// gets its full 30 minutes once admitted. It also puts the acquire
+	// where b.stopSignal is in scope, so a user can cancel a queued build.
+	buildMemoryBytes, _ := resolveImageBuildLimits()
+	releaseMemory, err := acquireMemory(b.stopSignal, buildMemoryBytes, "the docker image build", logsWriter)
+	if err != nil {
+		return parameters, err
+	}
+	defer releaseMemory()
+
 	io.WriteString(logsWriter, fmt.Sprintf("Building docker image\n"))
 	err = imageBuild(parameters, cli, repoDirectoryPath, dockerImageNameAndTag, dockerFile, logsWriter)
 	if err != nil {

--- a/jobs/commands/build_docker_image.go
+++ b/jobs/commands/build_docker_image.go
@@ -93,6 +93,18 @@ func imageBuild(parameters map[string]interface{}, dockerClient *client.Client, 
 	// that succeed today into failures. BUILD_IMAGE_MEMORY_BYTES is the
 	// escape hatch for a build that legitimately needs more.
 	buildMemoryBytes, buildCores := resolveImageBuildLimits()
+
+	// Reserve the memory before handing the build to dockerd, and hold it
+	// until the build finishes. Without this the cap above bounds one
+	// build but not several: the dispatcher can have many jobs in flight,
+	// and concurrent uncoordinated builds would each be individually
+	// within their cap while collectively exceeding the host.
+	releaseMemory, err := acquireMemory(ctx, buildMemoryBytes, "docker image build", logsWriter)
+	if err != nil {
+		return err
+	}
+	defer releaseMemory()
+
 	opts := types.ImageBuildOptions{
 		Dockerfile: dockerFile,
 		Tags:       []string{dockerImageNameAndTag},

--- a/jobs/commands/build_nixpacks_image.go
+++ b/jobs/commands/build_nixpacks_image.go
@@ -77,6 +77,23 @@ func (b *BuildNixPacksImage) Run(parameters map[string]interface{}, logsWriter i
 		return parameters, err
 	}
 
+	// KNOWN GAP: this build is NOT memory-capped and is NOT counted by
+	// admission control, unlike every other container the runner spawns.
+	//
+	// nixpacks-go's BuildOptions exposes no memory or CPU fields, and it
+	// shells out to the `nixpacks` CLI binary, which runs its own
+	// `docker build` internally — there is no seam to pass --memory
+	// through. So a nixpacks build can still consume the whole host, and
+	// because it executes inside dockerd rather than in the runner's
+	// cgroup, nothing here can observe it either.
+	//
+	// The fix is to stop letting nixpacks do the build: BuildOptions.Output
+	// makes it emit a Dockerfile instead of an image, which we could then
+	// build through imageBuild() in build_docker_image.go and inherit both
+	// the cap and the admission weight. That is a larger change than
+	// adding a limit, so it is called out here rather than done silently.
+	// Until then, a runner that uses nixpacks keeps the old unbounded
+	// behaviour on this path only.
 	buildOptions := nixpacks.BuildOptions{
 		Path:       repoDirectoryPath,
 		Name:       dockerImageNameAndTag,

--- a/jobs/commands/build_nixpacks_image.go
+++ b/jobs/commands/build_nixpacks_image.go
@@ -13,7 +13,18 @@ import (
 )
 
 type BuildNixPacksImage struct {
+	// stopSignal closes when the server reports the Job moved to Stopping.
+	// Used to cancel the admission wait; see BuildStaticSite.stopSignal.
+	stopSignal <-chan struct{}
 }
+
+// SetStopSignal satisfies jobs.StoppableCommand.
+func (b *BuildNixPacksImage) SetStopSignal(stop <-chan struct{}) {
+	b.stopSignal = stop
+}
+
+// See the note on BuildStaticSite.
+var _ jobs.StoppableCommand = (*BuildNixPacksImage)(nil)
 
 func (b *BuildNixPacksImage) Run(parameters map[string]interface{}, logsWriter io.Writer) (newParameters map[string]interface{}, err error) {
 	defer func() {
@@ -77,23 +88,37 @@ func (b *BuildNixPacksImage) Run(parameters map[string]interface{}, logsWriter i
 		return parameters, err
 	}
 
-	// KNOWN GAP: this build is NOT memory-capped and is NOT counted by
-	// admission control, unlike every other container the runner spawns.
+	// PARTIAL GAP: this build is COUNTED by admission control but is not
+	// memory-CAPPED, unlike every other container the runner spawns.
 	//
 	// nixpacks-go's BuildOptions exposes no memory or CPU fields, and it
 	// shells out to the `nixpacks` CLI binary, which runs its own
 	// `docker build` internally — there is no seam to pass --memory
-	// through. So a nixpacks build can still consume the whole host, and
-	// because it executes inside dockerd rather than in the runner's
-	// cgroup, nothing here can observe it either.
+	// through. So the build itself is unbounded, and because it executes
+	// inside dockerd rather than in the runner's cgroup, nothing here can
+	// observe its usage either.
 	//
-	// The fix is to stop letting nixpacks do the build: BuildOptions.Output
-	// makes it emit a Dockerfile instead of an image, which we could then
-	// build through imageBuild() in build_docker_image.go and inherit both
-	// the cap and the admission weight. That is a larger change than
-	// adding a limit, so it is called out here rather than done silently.
-	// Until then, a runner that uses nixpacks keeps the old unbounded
-	// behaviour on this path only.
+	// Reserving the weight anyway is worth doing even without a cap. It
+	// does not stop this build from overrunning, but it does stop it
+	// running CONCURRENTLY with an agent container or another build that
+	// have already been promised that memory. Without the reservation,
+	// admission control would believe the host was free while an unbounded
+	// build was consuming it — the budget would not be authoritative and
+	// the host OOM this whole mechanism exists to prevent would stay
+	// reachable via this one path.
+	//
+	// The real fix is to stop letting nixpacks do the build:
+	// BuildOptions.Output makes it emit a Dockerfile instead of an image,
+	// which we could then build through imageBuild() in
+	// build_docker_image.go and inherit the cap too. That is a larger
+	// change, so it is called out here rather than done silently.
+	nixpacksMemoryBytes, _ := resolveImageBuildLimits()
+	releaseMemory, err := acquireMemory(b.stopSignal, nixpacksMemoryBytes, "the nixpacks image build", logsWriter)
+	if err != nil {
+		return parameters, err
+	}
+	defer releaseMemory()
+
 	buildOptions := nixpacks.BuildOptions{
 		Path:       repoDirectoryPath,
 		Name:       dockerImageNameAndTag,

--- a/jobs/commands/build_static_site.go
+++ b/jobs/commands/build_static_site.go
@@ -11,20 +11,20 @@ import (
 	"github.com/moby/moby/client"
 	"io"
 	"os"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
 )
 
 // Defaults applied when the runner spawns a static-site build
-// container. All four are env-var-overridable so different runner
-// instance sizes can dial up/down without a runner redeploy.
+// container. Memory and CPU are derived from the host (see
+// resolveBuildLimits / host_resources.go) and remain env-var-overridable.
 //
-// Memory + CPU sized for typical npm/webpack workloads on m6a.large
-// (2 vCPU, 8 GB host) running alongside other Tasks/build containers.
-// Lower than the headroom of the ECS task to leave room for the runner
-// itself + concurrent jobs.
+// Builds are sized to a SHARE of the host budget rather than all of it,
+// because builds are the workload that legitimately runs in parallel — a
+// push can fan out across several deployments at once. Handing each
+// build the whole budget would make admission control serialize
+// deployments that run concurrently today.
 //
 // PidsLimit defends against fork-bomb-style npm scripts (malicious or
 // accidental) — webpack with parallel workers usually peaks around
@@ -36,10 +36,8 @@ import (
 // timeout as an error is preferable to indefinitely tying up a
 // runner slot.
 const (
-	defaultBuildMemoryBytes = 2 * 1024 * 1024 * 1024 // 2 GB
-	defaultBuildCPUCores    = int64(2)
-	defaultBuildPidsLimit   = int64(1024)
-	defaultBuildTimeout     = 1 * time.Hour
+	defaultBuildPidsLimit = int64(1024)
+	defaultBuildTimeout   = 1 * time.Hour
 	// defaultBuildImagePullTimeout bounds how long pullDockerImageFor-
 	// Building waits on Docker Hub before failing the build. Same
 	// rationale as defaultImagePullTimeout in run_agent_step.go: the
@@ -250,30 +248,25 @@ func startBuildContainer(imageId, repoDir string) (string, error) {
 }
 
 // resolveBuildLimits returns the memory (bytes) and CPU (NanoCPUs)
-// caps for the build container. Reads per-runner env-var overrides
-// before falling back to the defaults — different EC2 instance sizes
-// need different limits without redeploying the runner. Invalid env
-// values fall back silently (logging from a const-style helper would
-// obscure the actual runner logs).
+// caps for the build container, sized from the host. An explicit
+// BUILD_MEMORY_BYTES / BUILD_CPU_CORES wins; invalid env values are
+// ignored silently (logging from a const-style helper would obscure the
+// actual runner logs) and the derived value applies.
 //
 // 1 CPU core = 1e9 NanoCPUs in Docker's accounting.
 //
-// Mirrors resolveContainerLimits in run_agent_step.go but reads
-// BUILD_* env vars instead — keeps the build and Tasks knobs
-// independent so ops can tune them separately when concurrent
-// build/agentbox jobs need different resource shapes.
+// Mirrors resolveContainerLimits in run_agent_step.go but takes a SHARE
+// of the budget rather than all of it, and reads BUILD_* env vars — the
+// build and Tasks knobs stay independent so ops can tune them separately
+// when concurrent build/agentbox jobs need different resource shapes.
 func resolveBuildLimits() (memoryBytes int64, nanoCPUs int64) {
-	memoryBytes = defaultBuildMemoryBytes
-	if v := os.Getenv(buildMemoryBytesEnvVar); v != "" {
-		if parsed, err := strconv.ParseInt(v, 10, 64); err == nil && parsed > 0 {
-			memoryBytes = parsed
-		}
+	memoryBytes = clampMemory(memoryBudget()/buildBudgetDivisor, buildMemoryFloorBytes, buildMemoryCeilingBytes)
+	if override := envMemoryOverride(buildMemoryBytesEnvVar); override > 0 {
+		memoryBytes = override
 	}
-	cores := defaultBuildCPUCores
-	if v := os.Getenv(buildCPUCoresEnvVar); v != "" {
-		if parsed, err := strconv.ParseInt(v, 10, 64); err == nil && parsed > 0 {
-			cores = parsed
-		}
+	cores := hostCPUCores()
+	if override := envCoresOverride(buildCPUCoresEnvVar); override > 0 {
+		cores = override
 	}
 	nanoCPUs = cores * 1_000_000_000
 	return memoryBytes, nanoCPUs

--- a/jobs/commands/build_static_site.go
+++ b/jobs/commands/build_static_site.go
@@ -407,6 +407,19 @@ func (b *BuildStaticSite) Run(parameters map[string]interface{}, logsWriter io.W
 		return parameters, err
 	}
 
+	// Reserve host memory before the container exists, released after it
+	// is removed (registered before the removal defer so LIFO ordering
+	// puts the release last). Static-site builds are sized to a share of
+	// the budget rather than all of it, so several are normally admitted
+	// concurrently — this bounds how many, instead of letting the
+	// dispatcher start as many as it has workers.
+	buildMemoryBytes, _ := resolveBuildLimits()
+	releaseMemory, err := acquireMemory(context.Background(), buildMemoryBytes, "the build container", logsWriter)
+	if err != nil {
+		return parameters, err
+	}
+	defer releaseMemory()
+
 	containerID, err := startBuildContainer(imageId, repoDirectoryPath)
 	if err != nil {
 		return parameters, err

--- a/jobs/commands/build_static_site.go
+++ b/jobs/commands/build_static_site.go
@@ -52,7 +52,30 @@ const (
 )
 
 type BuildStaticSite struct {
+	// stopSignal closes when the server reports the Job moved to Stopping.
+	// Implemented so a build QUEUED behind another job's memory can be
+	// cancelled by the user: without it a stopped build sat in
+	// acquireMemory holding a worker until the admission timeout and then
+	// failed with a resource error instead of reporting as stopped.
+	//
+	// Scope is deliberately limited to the admission wait. Aborting a
+	// build already in flight is a separate change; the runner's outer
+	// loop still checks the signal between commands as before.
+	stopSignal <-chan struct{}
 }
+
+// SetStopSignal satisfies jobs.StoppableCommand.
+func (b *BuildStaticSite) SetStopSignal(stop <-chan struct{}) {
+	b.stopSignal = stop
+}
+
+// Compile-time proof that the POINTER satisfies StoppableCommand. The
+// runner's dispatcher discovers the stop signal through a type assertion
+// (`command.(jobs.StoppableCommand)`), which fails silently if the
+// registered value ever stops being a pointer -- stop would simply never
+// be delivered, with nothing to notice it. commands.go registers
+// &BuildStaticSite{}; this keeps that a compile error to change.
+var _ jobs.StoppableCommand = (*BuildStaticSite)(nil)
 
 // decodes envVariables map to key=value slice
 func decodeEnvironmentVariablesToSlice(envVariables string) ([]string, error) {
@@ -414,7 +437,7 @@ func (b *BuildStaticSite) Run(parameters map[string]interface{}, logsWriter io.W
 	// concurrently — this bounds how many, instead of letting the
 	// dispatcher start as many as it has workers.
 	buildMemoryBytes, _ := resolveBuildLimits()
-	releaseMemory, err := acquireMemory(context.Background(), buildMemoryBytes, "the build container", logsWriter)
+	releaseMemory, err := acquireMemory(b.stopSignal, buildMemoryBytes, "the build container", logsWriter)
 	if err != nil {
 		return parameters, err
 	}

--- a/jobs/commands/host_resources.go
+++ b/jobs/commands/host_resources.go
@@ -66,10 +66,14 @@ const (
 
 	// agentboxMemoryCeilingBytes stops a very large host from sizing a
 	// single agent container so big that admission control can't fit
-	// anything beside it. Past ~8 GB an agent's own working set stops
-	// growing (it's the production BUILD inside the container that
-	// consumes memory, not the agent), so the extra would be reserved and
+	// anything beside it — past this point the extra is reserved but
 	// unused while blocking concurrent jobs.
+	//
+	// 8 GB is a CHOSEN bound, not a measured one: we have an observed
+	// lower bound (a real Go build hit the old 4 GB cap) but no data on
+	// where a Task's demand actually plateaus. It is set at twice the
+	// known-insufficient figure and should be revisited once cgroup peak
+	// reporting from agentbox gives real numbers.
 	agentboxMemoryCeilingBytes = 8 * 1024 * 1024 * 1024 // 8 GB
 
 	// buildMemoryFloorBytes is the pre-host-sizing static-site build
@@ -80,11 +84,16 @@ const (
 	buildMemoryCeilingBytes = 8 * 1024 * 1024 * 1024 // 8 GB
 
 	// buildBudgetDivisor keeps static-site builds small enough to still run
-	// several at once. They are the parallel workload (a push can fan out
-	// across several deployments) and are comparatively light —
-	// npm/webpack peaked well inside the previous 2 GB cap. Handing them
-	// the full budget would silently serialize deployments that run
-	// concurrently today.
+	// several at once. They are the workload that legitimately fans out —
+	// a push can trigger several deployments — so handing each the full
+	// budget would silently serialize deploys that run concurrently today.
+	//
+	// This is a CONCURRENCY choice, not a claim that builds are light.
+	// They are not: run_agent_step.go records a real Vite/webpack build
+	// (the dashboard) being OOM-killed at exactly 2 GB. A third of the
+	// budget is more than the old flat 2 GB on every host we ship and
+	// grows with the instance, but a genuinely heavy single build is
+	// still the case BUILD_MEMORY_BYTES exists for.
 	buildBudgetDivisor = 3
 
 	// Image builds (docker / nixpacks) get the WHOLE budget rather than a

--- a/jobs/commands/host_resources.go
+++ b/jobs/commands/host_resources.go
@@ -1,12 +1,10 @@
 package commands
 
 import (
-	"bufio"
 	"os"
-	"runtime"
 	"strconv"
-	"strings"
-	"sync"
+
+	"github.com/deployment-io/deployment-runner/utils/hostinfo"
 )
 
 // Host resource detection and the container memory budget derived from it.
@@ -53,15 +51,6 @@ const (
 	// The effective reserve is the larger of the two — a flat 1.5 GB is
 	// right on an 8 GB box and too thin on a 64 GB one.
 	hostMemoryReserveFraction = 0.12
-
-	// fallbackHostMemoryBytes is used when /proc/meminfo can't be read
-	// (non-Linux dev machines, an unexpectedly restricted procfs). It is
-	// deliberately the size of the smallest instance we ship, so the
-	// derived caps land on today's known-safe values rather than on
-	// something optimistic that a small host can't honor.
-	fallbackHostMemoryBytes = 8 * 1024 * 1024 * 1024 // 8 GB
-
-	procMeminfoPath = "/proc/meminfo"
 
 	// minContainerMemoryBytes is the absolute floor for any container cap
 	// and for the budget itself. Below roughly this, nothing we run is
@@ -143,88 +132,14 @@ func resolveImageBuildLimits() (memoryBytes int64, cores int64) {
 	return memoryBytes, cores
 }
 
-var (
-	hostMemoryOnce  sync.Once
-	hostMemoryCache int64
-)
+// hostMemoryBytes and hostCPUCores delegate to the hostinfo package.
+// The detection lives there rather than here because the ping client
+// also needs it to report host specs to the control plane, and
+// jobs/commands already imports client — so keeping it in this package
+// would make that a cycle.
+func hostMemoryBytes() int64 { return hostinfo.MemoryBytes() }
 
-// hostMemoryBytes returns the TOTAL physical memory of the machine the
-// runner container is running on — deliberately the host's memory, not
-// the runner's own cgroup limit.
-//
-// The distinction matters and is easy to get backwards. The runner runs
-// as an ECS task with a 6 GB task-level limit, so reading its own cgroup
-// would report 6 GB on an 8 GB box. But the containers we're sizing are
-// NOT children of the runner: they're siblings created through the
-// mounted Docker socket, so they draw from host memory and are capped
-// independently. The number we need to divide up is the host's.
-//
-// /proc/meminfo is not namespaced by Docker, so MemTotal read from
-// inside the container is the host's MemTotal. That is exactly what we
-// want here, and is the reason this reads procfs directly rather than
-// using a cgroup-aware memory library.
-//
-// Cached: the value cannot change while the process lives, and this is
-// called on every container create.
-func hostMemoryBytes() int64 {
-	hostMemoryOnce.Do(func() {
-		hostMemoryCache = readMemTotalBytes(procMeminfoPath)
-		if hostMemoryCache <= 0 {
-			hostMemoryCache = fallbackHostMemoryBytes
-		}
-	})
-	return hostMemoryCache
-}
-
-// readMemTotalBytes parses the MemTotal line out of a meminfo-formatted
-// file and returns it in bytes. Returns 0 on any failure so the caller
-// applies its fallback — this runs on the container-create path and a
-// missing procfs must never fail a job.
-//
-// The line looks like "MemTotal:       16116496 kB" — the unit is always
-// kB in practice, but the suffix is checked rather than assumed so a
-// unitless or differently-suffixed value degrades to the fallback
-// instead of being silently misread by three orders of magnitude.
-func readMemTotalBytes(path string) int64 {
-	f, err := os.Open(path)
-	if err != nil {
-		return 0
-	}
-	defer f.Close()
-
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		line := scanner.Text()
-		if !strings.HasPrefix(line, "MemTotal:") {
-			continue
-		}
-		fields := strings.Fields(line)
-		// Expect exactly: ["MemTotal:", "<number>", "kB"]
-		if len(fields) != 3 || !strings.EqualFold(fields[2], "kB") {
-			return 0
-		}
-		kb, err := strconv.ParseInt(fields[1], 10, 64)
-		if err != nil || kb <= 0 {
-			return 0
-		}
-		return kb * 1024
-	}
-	return 0
-}
-
-// hostCPUCores returns the number of logical CPUs available to the
-// runner process.
-//
-// runtime.NumCPU respects CPU affinity but not cgroup CPU quota, and the
-// runner's task definition sets no task-level or container-level Cpu, so
-// on ECS this is the host's vCPU count — which is what we want for the
-// same sibling-container reason as hostMemoryBytes.
-func hostCPUCores() int64 {
-	if n := runtime.NumCPU(); n > 0 {
-		return int64(n)
-	}
-	return 1
-}
+func hostCPUCores() int64 { return hostinfo.CPUCores() }
 
 // memoryBudget returns the total bytes that may be handed out across ALL
 // concurrently running job containers. This is the number admission

--- a/jobs/commands/host_resources.go
+++ b/jobs/commands/host_resources.go
@@ -1,0 +1,306 @@
+package commands
+
+import (
+	"bufio"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// Host resource detection and the container memory budget derived from it.
+//
+// WHY THIS EXISTS
+//
+// Every container the runner spawns (agentbox for Tasks and Assistant
+// sessions, the static-site build container, docker/nixpacks image
+// builds) used to carry a hardcoded memory cap that had no relationship
+// to the machine underneath. That was wrong in both directions:
+//
+//   - Too small on a big host. A customer who upgrades their runner EC2
+//     instance got exactly zero extra room, because the agentbox cap
+//     stayed at a constant 4 GB no matter how much RAM the box had.
+//     Real Task builds hit that ceiling: agentbox reported "memory ran
+//     close to the limit — peak 4.0 GiB of a 4.0 GiB limit", and an
+//     earlier run died with an unexplained "signal: killed" (an OOM
+//     kill inside the cgroup).
+//
+//   - Too large in aggregate. The caps were never checked against the
+//     host. On the shipped m6a.large (2 vCPU, 8 GB) the runner's own ECS
+//     task limit is 6 GB and a 4 GB agentbox container spawns ALONGSIDE
+//     it as a sibling through the mounted Docker socket — outside ECS
+//     accounting entirely. 6 + 4 = 10 GB of caps on a ~7.7 GB machine.
+//     It only survived because the runner process itself uses a few
+//     hundred MB and heavy jobs rarely overlapped.
+//
+// Sizing from the host fixes both: caps grow when the instance grows,
+// and the total is bounded by what actually exists. See memoryBudget for
+// the aggregate side and admission.go for the enforcement that keeps
+// concurrent containers inside it.
+const (
+	// hostMemoryReserveBytes is the floor held back for everything that
+	// is NOT a job container: the kernel, dockerd (which is where an
+	// image build actually runs — it is not in the runner's cgroup), the
+	// runner process, and the ECS agent. Undersizing this is what turns a
+	// cgroup OOM kill (one job dies, cleanly attributed) into a HOST OOM
+	// kill (the kernel picks a victim, which can be dockerd or the runner
+	// itself, and every in-flight job dies with no useful error).
+	hostMemoryReserveBytes = 1536 * 1024 * 1024 // 1.5 GB
+
+	// hostMemoryReserveFraction scales the reserve on larger hosts, where
+	// dockerd's own footprint during a big build grows with the image.
+	// The effective reserve is the larger of the two — a flat 1.5 GB is
+	// right on an 8 GB box and too thin on a 64 GB one.
+	hostMemoryReserveFraction = 0.12
+
+	// fallbackHostMemoryBytes is used when /proc/meminfo can't be read
+	// (non-Linux dev machines, an unexpectedly restricted procfs). It is
+	// deliberately the size of the smallest instance we ship, so the
+	// derived caps land on today's known-safe values rather than on
+	// something optimistic that a small host can't honor.
+	fallbackHostMemoryBytes = 8 * 1024 * 1024 * 1024 // 8 GB
+
+	procMeminfoPath = "/proc/meminfo"
+
+	// minContainerMemoryBytes is the absolute floor for any container cap
+	// and for the budget itself. Below roughly this, nothing we run is
+	// viable, so a host this small should fail loudly at the job rather
+	// than quietly hand out a cap of zero (Docker reads 0 as "unlimited",
+	// which is the opposite of what a tiny host wants).
+	minContainerMemoryBytes = 1 * 1024 * 1024 * 1024 // 1 GB
+
+	// agentboxMemoryFloorBytes is the pre-host-sizing default. Deriving
+	// from the host must never hand a Task LESS than it got before, so
+	// this is a floor rather than a starting point.
+	agentboxMemoryFloorBytes = 4 * 1024 * 1024 * 1024 // 4 GB
+
+	// agentboxMemoryCeilingBytes stops a very large host from sizing a
+	// single agent container so big that admission control can't fit
+	// anything beside it. Past ~8 GB an agent's own working set stops
+	// growing (it's the production BUILD inside the container that
+	// consumes memory, not the agent), so the extra would be reserved and
+	// unused while blocking concurrent jobs.
+	agentboxMemoryCeilingBytes = 8 * 1024 * 1024 * 1024 // 8 GB
+
+	// buildMemoryFloorBytes is the pre-host-sizing static-site build
+	// default, kept as a floor for the same no-regression reason.
+	buildMemoryFloorBytes = 2 * 1024 * 1024 * 1024 // 2 GB
+
+	// buildMemoryCeilingBytes bounds a single build container.
+	buildMemoryCeilingBytes = 8 * 1024 * 1024 * 1024 // 8 GB
+
+	// buildBudgetDivisor keeps static-site builds small enough to still run
+	// several at once. They are the parallel workload (a push can fan out
+	// across several deployments) and are comparatively light —
+	// npm/webpack peaked well inside the previous 2 GB cap. Handing them
+	// the full budget would silently serialize deployments that run
+	// concurrently today.
+	buildBudgetDivisor = 3
+
+	// Image builds (docker / nixpacks) get the WHOLE budget rather than a
+	// share, unlike static-site builds. Two reasons:
+	//
+	//  1. This path was completely UNBOUNDED until now — a `docker build`
+	//     could use the entire host. Any cap is a new constraint, so it is
+	//     set generously to avoid turning builds that succeed today into
+	//     failures. A share (~2 GB on the shipped m6a.large) would be well
+	//     inside what a real Node or Java image build uses.
+	//  2. An image build is normally the single heavy thing happening
+	//     during a deploy, so serializing two of them on a small host is
+	//     the correct outcome rather than a regression.
+	imageBuildMemoryFloorBytes   = 4 * 1024 * 1024 * 1024 // 4 GB
+	imageBuildMemoryCeilingBytes = 8 * 1024 * 1024 * 1024 // 8 GB
+
+	// cpuPeriodMicroseconds is Docker's default CFS scheduling period.
+	// The image-build API takes a quota/period pair in microseconds
+	// instead of the NanoCPUs used by ContainerCreate.
+	cpuPeriodMicroseconds = int64(100000) // 100ms
+
+	imageBuildMemoryBytesEnvVar = "BUILD_IMAGE_MEMORY_BYTES"
+	imageBuildCPUCoresEnvVar    = "BUILD_IMAGE_CPU_CORES"
+)
+
+// resolveImageBuildLimits returns the memory cap (bytes) and CPU core
+// count for a docker/nixpacks image build. Returns CORES, not NanoCPUs,
+// because ImageBuildOptions wants a CFS quota/period pair — the caller
+// multiplies by cpuPeriodMicroseconds.
+//
+// BUILD_IMAGE_MEMORY_BYTES / BUILD_IMAGE_CPU_CORES override the derived
+// values. They exist specifically so a customer whose build legitimately
+// needs more than the derived cap can be unblocked by an operator
+// without waiting for a runner release — this path was unbounded for a
+// long time and some build somewhere will be sized accordingly.
+func resolveImageBuildLimits() (memoryBytes int64, cores int64) {
+	memoryBytes = clampMemory(memoryBudget(), imageBuildMemoryFloorBytes, imageBuildMemoryCeilingBytes)
+	if override := envMemoryOverride(imageBuildMemoryBytesEnvVar); override > 0 {
+		memoryBytes = override
+	}
+	cores = hostCPUCores()
+	if override := envCoresOverride(imageBuildCPUCoresEnvVar); override > 0 {
+		cores = override
+	}
+	return memoryBytes, cores
+}
+
+var (
+	hostMemoryOnce  sync.Once
+	hostMemoryCache int64
+)
+
+// hostMemoryBytes returns the TOTAL physical memory of the machine the
+// runner container is running on — deliberately the host's memory, not
+// the runner's own cgroup limit.
+//
+// The distinction matters and is easy to get backwards. The runner runs
+// as an ECS task with a 6 GB task-level limit, so reading its own cgroup
+// would report 6 GB on an 8 GB box. But the containers we're sizing are
+// NOT children of the runner: they're siblings created through the
+// mounted Docker socket, so they draw from host memory and are capped
+// independently. The number we need to divide up is the host's.
+//
+// /proc/meminfo is not namespaced by Docker, so MemTotal read from
+// inside the container is the host's MemTotal. That is exactly what we
+// want here, and is the reason this reads procfs directly rather than
+// using a cgroup-aware memory library.
+//
+// Cached: the value cannot change while the process lives, and this is
+// called on every container create.
+func hostMemoryBytes() int64 {
+	hostMemoryOnce.Do(func() {
+		hostMemoryCache = readMemTotalBytes(procMeminfoPath)
+		if hostMemoryCache <= 0 {
+			hostMemoryCache = fallbackHostMemoryBytes
+		}
+	})
+	return hostMemoryCache
+}
+
+// readMemTotalBytes parses the MemTotal line out of a meminfo-formatted
+// file and returns it in bytes. Returns 0 on any failure so the caller
+// applies its fallback — this runs on the container-create path and a
+// missing procfs must never fail a job.
+//
+// The line looks like "MemTotal:       16116496 kB" — the unit is always
+// kB in practice, but the suffix is checked rather than assumed so a
+// unitless or differently-suffixed value degrades to the fallback
+// instead of being silently misread by three orders of magnitude.
+func readMemTotalBytes(path string) int64 {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "MemTotal:") {
+			continue
+		}
+		fields := strings.Fields(line)
+		// Expect exactly: ["MemTotal:", "<number>", "kB"]
+		if len(fields) != 3 || !strings.EqualFold(fields[2], "kB") {
+			return 0
+		}
+		kb, err := strconv.ParseInt(fields[1], 10, 64)
+		if err != nil || kb <= 0 {
+			return 0
+		}
+		return kb * 1024
+	}
+	return 0
+}
+
+// hostCPUCores returns the number of logical CPUs available to the
+// runner process.
+//
+// runtime.NumCPU respects CPU affinity but not cgroup CPU quota, and the
+// runner's task definition sets no task-level or container-level Cpu, so
+// on ECS this is the host's vCPU count — which is what we want for the
+// same sibling-container reason as hostMemoryBytes.
+func hostCPUCores() int64 {
+	if n := runtime.NumCPU(); n > 0 {
+		return int64(n)
+	}
+	return 1
+}
+
+// memoryBudget returns the total bytes that may be handed out across ALL
+// concurrently running job containers. This is the number admission
+// control hands out slices of, and the ceiling any single container cap
+// is clamped to.
+//
+// Host memory minus the reserve. Everything the runner spawns has to fit
+// in here together.
+func memoryBudget() int64 {
+	host := hostMemoryBytes()
+	reserve := int64(float64(host) * hostMemoryReserveFraction)
+	if reserve < hostMemoryReserveBytes {
+		reserve = hostMemoryReserveBytes
+	}
+	budget := host - reserve
+	// Degenerate hosts (a tiny dev box, or a fallback that somehow went
+	// negative) still need a workable number rather than a zero or
+	// negative budget that would deadlock admission control.
+	if budget < minContainerMemoryBytes {
+		return minContainerMemoryBytes
+	}
+	return budget
+}
+
+// clampMemory bounds a computed cap between a floor and a ceiling, and
+// additionally to the whole budget — no single container may be sized
+// larger than the total the host can support.
+func clampMemory(want, floor, ceiling int64) int64 {
+	if budget := memoryBudget(); ceiling > budget {
+		ceiling = budget
+	}
+	if ceiling < floor {
+		// A host too small to honor the floor gets the ceiling. Better a
+		// cap the machine can actually back than a floor it can't.
+		return ceiling
+	}
+	if want < floor {
+		return floor
+	}
+	if want > ceiling {
+		return ceiling
+	}
+	return want
+}
+
+// envMemoryOverride reads an explicit operator override in bytes.
+// Returns 0 when unset or invalid, meaning "use the derived value".
+//
+// These overrides are kept from the pre-host-sizing implementation on
+// purpose: they are the escape hatch for a workload whose real needs
+// don't match what we derive, and they can be set without a code change.
+// A caller applying one is opting out of the host-derived sizing
+// deliberately, so it is NOT clamped to the budget — but it IS still
+// counted at its full value by admission control, so an operator who
+// oversizes it serializes their own jobs rather than OOMing the host.
+func envMemoryOverride(key string) int64 {
+	v := os.Getenv(key)
+	if v == "" {
+		return 0
+	}
+	parsed, err := strconv.ParseInt(v, 10, 64)
+	if err != nil || parsed <= 0 {
+		return 0
+	}
+	return parsed
+}
+
+// envCoresOverride mirrors envMemoryOverride for CPU core counts.
+func envCoresOverride(key string) int64 {
+	v := os.Getenv(key)
+	if v == "" {
+		return 0
+	}
+	parsed, err := strconv.ParseInt(v, 10, 64)
+	if err != nil || parsed <= 0 {
+		return 0
+	}
+	return parsed
+}

--- a/jobs/commands/host_resources_test.go
+++ b/jobs/commands/host_resources_test.go
@@ -1,0 +1,168 @@
+package commands
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestReadMemTotalBytes covers the parse that everything else is built
+// on. A misread here would silently mis-size every container on the
+// runner by orders of magnitude, so malformed input must return 0 (which
+// makes the caller apply its 8 GB fallback) rather than a wrong number.
+func TestReadMemTotalBytes(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    int64
+	}{
+		{
+			name:    "typical meminfo",
+			content: "MemTotal:       16116496 kB\nMemFree:         1234 kB\n",
+			want:    16116496 * 1024,
+		},
+		{
+			name:    "MemTotal not first line",
+			content: "SwapTotal:      0 kB\nMemTotal:       8046736 kB\n",
+			want:    8046736 * 1024,
+		},
+		{
+			name: "missing MemTotal",
+			// A procfs without the line at all must not be guessed at.
+			content: "MemFree:         1234 kB\n",
+			want:    0,
+		},
+		{
+			name: "unexpected unit",
+			// Refusing an unknown unit is the whole point: silently
+			// treating an mB value as kB would be a 1000x error.
+			content: "MemTotal:       16116496 mB\n",
+			want:    0,
+		},
+		{
+			name:    "no unit suffix",
+			content: "MemTotal:       16116496\n",
+			want:    0,
+		},
+		{
+			name:    "non-numeric value",
+			content: "MemTotal:       lots kB\n",
+			want:    0,
+		},
+		{
+			name:    "zero value",
+			content: "MemTotal:       0 kB\n",
+			want:    0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "meminfo")
+			if err := os.WriteFile(path, []byte(tc.content), 0o600); err != nil {
+				t.Fatalf("write meminfo: %v", err)
+			}
+			if got := readMemTotalBytes(path); got != tc.want {
+				t.Errorf("readMemTotalBytes() = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestReadMemTotalBytes_MissingFile(t *testing.T) {
+	if got := readMemTotalBytes(filepath.Join(t.TempDir(), "does-not-exist")); got != 0 {
+		t.Errorf("readMemTotalBytes(missing) = %d, want 0 so the caller falls back", got)
+	}
+}
+
+// TestMemoryBudgetLeavesReserve is the invariant that separates a clean
+// per-job cgroup OOM kill from a host OOM kill that can take out dockerd
+// or the runner itself: the budget must never be the whole machine.
+func TestMemoryBudgetLeavesReserve(t *testing.T) {
+	host := hostMemoryBytes()
+	budget := memoryBudget()
+	if budget >= host {
+		t.Fatalf("budget %d does not leave a reserve out of host %d", budget, host)
+	}
+	if reserve := host - budget; reserve < hostMemoryReserveBytes {
+		t.Errorf("reserve %d is below the %d floor", reserve, hostMemoryReserveBytes)
+	}
+}
+
+func TestClampMemory(t *testing.T) {
+	budget := memoryBudget()
+
+	// Within the band, the requested value passes through.
+	if got := clampMemory(budget, minContainerMemoryBytes, budget); got != budget {
+		t.Errorf("clampMemory(budget) = %d, want %d", got, budget)
+	}
+	// Below the floor is raised to it.
+	if got := clampMemory(1, minContainerMemoryBytes, budget); got != minContainerMemoryBytes {
+		t.Errorf("clampMemory(tiny) = %d, want floor %d", got, minContainerMemoryBytes)
+	}
+	// A ceiling above the budget is itself clamped to the budget, so an
+	// absurd request can never be sized past what the host has.
+	if got := clampMemory(1<<62, minContainerMemoryBytes, 1<<62); got != budget {
+		t.Errorf("clampMemory(huge) = %d, want budget %d", got, budget)
+	}
+}
+
+// TestAdmissionWeightClampedToCapacity guards against a deadlock rather
+// than a sizing error. semaphore.Weighted.Acquire blocks forever when
+// asked for more than the total capacity, so an operator who sets
+// AGENTBOX_MEMORY_BYTES larger than the host must get a job that runs
+// alone, not a job that waits for memory that will never exist.
+func TestAdmissionWeightClampedToCapacity(t *testing.T) {
+	_, capacity := admissionSemaphore()
+	if got := admissionWeight(1 << 62); got != capacity {
+		t.Errorf("admissionWeight(absurd) = %d, want capacity %d", got, capacity)
+	}
+	if got := admissionWeight(1); got < 1 {
+		t.Errorf("admissionWeight(1 byte) = %d, want at least 1 unit", got)
+	}
+	// Rounds UP, so a container is never admitted against less memory
+	// than it may actually use.
+	if got := admissionWeight(admissionUnitBytes + 1); got != 2 {
+		t.Errorf("admissionWeight(one unit + 1 byte) = %d, want 2", got)
+	}
+}
+
+// TestAcquireMemoryReleasesCapacity checks the acquire/release cycle
+// actually returns memory to the pool. A leaked slot would progressively
+// starve the runner until it could admit nothing at all.
+func TestAcquireMemoryReleasesCapacity(t *testing.T) {
+	sem, capacity := admissionSemaphore()
+
+	release, err := acquireMemory(context.Background(), memoryBudget(), "test container", nil)
+	if err != nil {
+		t.Fatalf("acquireMemory: %v", err)
+	}
+	// Whole budget held: nothing else of that size fits.
+	if sem.TryAcquire(capacity) {
+		t.Error("acquired the full capacity while it was already held")
+	}
+	release()
+	if !sem.TryAcquire(capacity) {
+		t.Error("capacity was not returned to the pool after release")
+	}
+	sem.Release(capacity)
+}
+
+// TestAcquireMemoryHonoursCancelledContext ensures a stopped or
+// cancelled job stops queueing immediately instead of holding a worker
+// for the full admission timeout.
+func TestAcquireMemoryHonoursCancelledContext(t *testing.T) {
+	sem, capacity := admissionSemaphore()
+	if !sem.TryAcquire(capacity) {
+		t.Fatal("could not drain the semaphore for the test")
+	}
+	defer sem.Release(capacity)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, err := acquireMemory(ctx, memoryBudget(), "test container", nil); err == nil {
+		t.Error("acquireMemory succeeded on a cancelled context")
+	}
+}

--- a/jobs/commands/host_resources_test.go
+++ b/jobs/commands/host_resources_test.go
@@ -2,79 +2,8 @@ package commands
 
 import (
 	"context"
-	"os"
-	"path/filepath"
 	"testing"
 )
-
-// TestReadMemTotalBytes covers the parse that everything else is built
-// on. A misread here would silently mis-size every container on the
-// runner by orders of magnitude, so malformed input must return 0 (which
-// makes the caller apply its 8 GB fallback) rather than a wrong number.
-func TestReadMemTotalBytes(t *testing.T) {
-	tests := []struct {
-		name    string
-		content string
-		want    int64
-	}{
-		{
-			name:    "typical meminfo",
-			content: "MemTotal:       16116496 kB\nMemFree:         1234 kB\n",
-			want:    16116496 * 1024,
-		},
-		{
-			name:    "MemTotal not first line",
-			content: "SwapTotal:      0 kB\nMemTotal:       8046736 kB\n",
-			want:    8046736 * 1024,
-		},
-		{
-			name: "missing MemTotal",
-			// A procfs without the line at all must not be guessed at.
-			content: "MemFree:         1234 kB\n",
-			want:    0,
-		},
-		{
-			name: "unexpected unit",
-			// Refusing an unknown unit is the whole point: silently
-			// treating an mB value as kB would be a 1000x error.
-			content: "MemTotal:       16116496 mB\n",
-			want:    0,
-		},
-		{
-			name:    "no unit suffix",
-			content: "MemTotal:       16116496\n",
-			want:    0,
-		},
-		{
-			name:    "non-numeric value",
-			content: "MemTotal:       lots kB\n",
-			want:    0,
-		},
-		{
-			name:    "zero value",
-			content: "MemTotal:       0 kB\n",
-			want:    0,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			path := filepath.Join(t.TempDir(), "meminfo")
-			if err := os.WriteFile(path, []byte(tc.content), 0o600); err != nil {
-				t.Fatalf("write meminfo: %v", err)
-			}
-			if got := readMemTotalBytes(path); got != tc.want {
-				t.Errorf("readMemTotalBytes() = %d, want %d", got, tc.want)
-			}
-		})
-	}
-}
-
-func TestReadMemTotalBytes_MissingFile(t *testing.T) {
-	if got := readMemTotalBytes(filepath.Join(t.TempDir(), "does-not-exist")); got != 0 {
-		t.Errorf("readMemTotalBytes(missing) = %d, want 0 so the caller falls back", got)
-	}
-}
 
 // TestMemoryBudgetLeavesReserve is the invariant that separates a clean
 // per-job cgroup OOM kill from a host OOM kill that can take out dockerd

--- a/jobs/commands/host_resources_test.go
+++ b/jobs/commands/host_resources_test.go
@@ -38,11 +38,12 @@ func TestClampMemory(t *testing.T) {
 	}
 }
 
-// TestAdmissionWeightClampedToCapacity guards against a deadlock rather
-// than a sizing error. semaphore.Weighted.Acquire blocks forever when
-// asked for more than the total capacity, so an operator who sets
-// AGENTBOX_MEMORY_BYTES larger than the host must get a job that runs
-// alone, not a job that waits for memory that will never exist.
+// TestAdmissionWeightClampedToCapacity guards a liveness property rather
+// than a sizing one. Acquire does not deadlock on an oversized request —
+// its `n > s.size` branch parks on the context — but it can never be
+// satisfied either, so an operator who sets AGENTBOX_MEMORY_BYTES larger
+// than the host would get a job that waits out the whole admission
+// timeout and then fails. Clamping makes it run alone instead.
 func TestAdmissionWeightClampedToCapacity(t *testing.T) {
 	_, capacity := admissionSemaphore()
 	if got := admissionWeight(1 << 62); got != capacity {
@@ -86,11 +87,15 @@ func TestAcquireMemoryReleasesCapacity(t *testing.T) {
 // a single Task silently serialized the entire runner.
 //
 // It asserts the real, intended shape rather than a number, so it stays
-// meaningful on any host: the two heavy workloads are expected to take
-// the whole pool (that IS what "may use all the memory the host can
-// spare" means), while static-site builds must remain small enough that
-// at least two run together — they are the workload that legitimately
-// fans out across concurrent deployments.
+// meaningful on any host. Note the heavy workloads take the WHOLE pool
+// only while the budget is under their 8 GB ceiling, which is the case on
+// every instance we ship today but not on a large one: at a 56 GB budget
+// an 8 GB agent is a seventh of capacity and plenty runs beside it. So
+// the assertions here are the host-independent ones — nothing exceeds
+// capacity, and static-site builds stay small enough that at least two
+// run together, since they are the workload that legitimately fans out
+// across concurrent deployments. The actual split is logged, not
+// asserted.
 func TestAdmissionWeightsAgainstCapacity(t *testing.T) {
 	t.Setenv(memoryBytesEnvVar, "")
 	t.Setenv(cpuCoresEnvVar, "")

--- a/jobs/commands/host_resources_test.go
+++ b/jobs/commands/host_resources_test.go
@@ -1,8 +1,9 @@
 package commands
 
 import (
-	"context"
+	"strings"
 	"testing"
+	"time"
 )
 
 // TestMemoryBudgetLeavesReserve is the invariant that separates a clean
@@ -63,7 +64,7 @@ func TestAdmissionWeightClampedToCapacity(t *testing.T) {
 func TestAcquireMemoryReleasesCapacity(t *testing.T) {
 	sem, capacity := admissionSemaphore()
 
-	release, err := acquireMemory(context.Background(), memoryBudget(), "test container", nil)
+	release, err := acquireMemory(nil, memoryBudget(), "test container", nil)
 	if err != nil {
 		t.Fatalf("acquireMemory: %v", err)
 	}
@@ -78,20 +79,108 @@ func TestAcquireMemoryReleasesCapacity(t *testing.T) {
 	sem.Release(capacity)
 }
 
-// TestAcquireMemoryHonoursCancelledContext ensures a stopped or
-// cancelled job stops queueing immediately instead of holding a worker
-// for the full admission timeout.
-func TestAcquireMemoryHonoursCancelledContext(t *testing.T) {
+// TestAdmissionWeightsAgainstCapacity is the test that was missing when
+// the sizing landed. The original suite only checked each CAP against the
+// budget, which passes trivially, and so never noticed that the derived
+// caps convert into admission WEIGHTS equal to 100% of capacity — meaning
+// a single Task silently serialized the entire runner.
+//
+// It asserts the real, intended shape rather than a number, so it stays
+// meaningful on any host: the two heavy workloads are expected to take
+// the whole pool (that IS what "may use all the memory the host can
+// spare" means), while static-site builds must remain small enough that
+// at least two run together — they are the workload that legitimately
+// fans out across concurrent deployments.
+func TestAdmissionWeightsAgainstCapacity(t *testing.T) {
+	t.Setenv(memoryBytesEnvVar, "")
+	t.Setenv(cpuCoresEnvVar, "")
+	t.Setenv(buildMemoryBytesEnvVar, "")
+	t.Setenv(imageBuildMemoryBytesEnvVar, "")
+
+	_, capacity := admissionSemaphore()
+
+	agentMem, _ := resolveContainerLimits()
+	imageMem, _ := resolveImageBuildLimits()
+	staticMem, _ := resolveBuildLimits()
+
+	agentWeight := admissionWeight(agentMem)
+	imageWeight := admissionWeight(imageMem)
+	staticWeight := admissionWeight(staticMem)
+
+	// No weight may exceed the pool, or Acquire would block forever.
+	for _, tc := range []struct {
+		name   string
+		weight int64
+	}{
+		{"agentbox", agentWeight},
+		{"image build", imageWeight},
+		{"static build", staticWeight},
+	} {
+		if tc.weight > capacity {
+			t.Errorf("%s weight %d exceeds capacity %d — Acquire would never be satisfied",
+				tc.name, tc.weight, capacity)
+		}
+		if tc.weight < 1 {
+			t.Errorf("%s weight %d must be at least one unit", tc.name, tc.weight)
+		}
+	}
+
+	// Static-site builds are the parallel workload; if they ever grow to
+	// more than half the pool, concurrent deployments silently serialize.
+	if staticWeight*2 > capacity {
+		t.Errorf("static build weight %d is more than half of capacity %d — two concurrent "+
+			"deployments would no longer fit", staticWeight, capacity)
+	}
+
+	// Documents the accepted trade-off rather than asserting against it:
+	// on a host whose whole budget goes to one agent container, nothing
+	// runs beside it. If this ever stops being true the comments in
+	// admission.go and the PR description need revisiting.
+	t.Logf("capacity=%d units; agentbox=%d image=%d static=%d; room beside an agent job: %d units",
+		capacity, agentWeight, imageWeight, staticWeight, capacity-agentWeight)
+}
+
+// TestAcquireMemoryHonoursStopSignal is the regression test for the
+// admission wait ignoring cancellation. Every call site used to pass
+// context.Background(), so a user pressing Stop on a queued job could not
+// interrupt it: the job held a worker until the admission timeout and
+// then failed with a resource error instead of reporting as stopped.
+func TestAcquireMemoryHonoursStopSignal(t *testing.T) {
 	sem, capacity := admissionSemaphore()
 	if !sem.TryAcquire(capacity) {
 		t.Fatal("could not drain the semaphore for the test")
 	}
 	defer sem.Release(capacity)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	stop := make(chan struct{})
+	close(stop)
 
-	if _, err := acquireMemory(ctx, memoryBudget(), "test container", nil); err == nil {
-		t.Error("acquireMemory succeeded on a cancelled context")
+	done := make(chan error, 1)
+	go func() {
+		_, err := acquireMemory(stop, memoryBudget(), "test container", nil)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("acquireMemory succeeded while the pool was fully held")
+		}
+		if !strings.Contains(err.Error(), "stopped") {
+			t.Errorf("error = %q, want it to report the stop rather than a resource timeout", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("acquireMemory ignored the stop signal and kept waiting")
 	}
+}
+
+// TestAcquireMemoryNilStopIsSafe guards the default for commands that
+// never opt into StoppableCommand: a nil channel must simply mean "not
+// stoppable", not panic or fire immediately.
+func TestAcquireMemoryNilStopIsSafe(t *testing.T) {
+	release, err := acquireMemory(nil, minContainerMemoryBytes, "test container", nil)
+	if err != nil {
+		t.Fatalf("acquireMemory with a nil stop channel: %v", err)
+	}
+	release()
 }

--- a/jobs/commands/run_agent_step.go
+++ b/jobs/commands/run_agent_step.go
@@ -220,21 +220,19 @@ const (
 	// ~30s, ~2-3min on constrained networks.
 	defaultImagePullTimeout = 10 * time.Minute
 
-	// Hardened HostConfig defaults. All four are env-var-overridable
-	// (see resolveContainerLimits) so different runner instance sizes
-	// can dial up/down without a runner redeploy. Phase 6 wires per-org
-	// overrides via Settings UI.
+	// Hardened HostConfig defaults. Memory and CPU are no longer
+	// constants — they are derived from the host the runner is on (see
+	// resolveContainerLimits / host_resources.go) and remain
+	// env-var-overridable. Phase 6 wires per-org overrides via Settings UI.
 	//
-	// Memory + CPU sized for typical Tasks workloads. The real ceiling is
-	// the production BUILD, not the agent's analysis working set (~1GB) or
-	// npm/pip install (~500MB): a Vite/webpack build of a real app
-	// (observed: the dashboard) gets OOM-killed at 2GB during chunk
-	// rendering — exit 137 (cgroup SIGKILL) / 134 (Node heap abort). 4GB
-	// covers typical builds; unusually heavy ones can raise it further via
-	// AGENTBOX_MEMORY_BYTES without a runner redeploy. CPU at 2 cores keeps
-	// multiple concurrent Step Jobs feasible on a 4-core runner.
-	defaultMemoryBytes = 4 * 1024 * 1024 * 1024 // 4 GB
-	defaultCPUCores    = int64(2)               // 2 cores
+	// The real memory ceiling for a Task is the production BUILD, not the
+	// agent's analysis working set (~1GB) or npm/pip install (~500MB): a
+	// Vite/webpack build of a real app (observed: the dashboard) gets
+	// OOM-killed at 2GB during chunk rendering — exit 137 (cgroup SIGKILL)
+	// / 134 (Node heap abort). The previous flat 4GB covered typical
+	// builds but was itself hit by a real Go build on the shipped
+	// m6a.large, which is why sizing now follows the host: see
+	// agentboxMemoryFloorBytes / agentboxMemoryCeilingBytes.
 
 	// Tmpfs sizes. /tmp covers general scratch (build artifacts, npm
 	// caches, etc.); /home/agent covers the agentbox runtime install
@@ -864,25 +862,33 @@ func createAgentboxContainer(ctx context.Context, cli *client.Client, spec agent
 }
 
 // resolveContainerLimits returns the memory (bytes) and CPU (NanoCPUs)
-// caps for the agentbox container. Reads per-runner env-var overrides
-// before falling back to the defaults — different EC2 instance sizes
-// need different limits without redeploying the runner. Invalid env
-// values fall back to defaults (silently — logging from a const-style
-// helper would obscure the actual runner logs).
+// caps for the agentbox container, sized from the host the runner is
+// running on. An explicit AGENTBOX_MEMORY_BYTES / AGENTBOX_CPU_CORES
+// wins over the derived value; invalid env values are ignored silently
+// (logging from a const-style helper would obscure the actual runner
+// logs) and the derived value applies.
+//
+// Deriving from the host rather than using a constant is what makes a
+// bigger runner instance actually mean bigger Tasks. Previously the cap
+// was a flat 4 GB, so upgrading the EC2 instance changed nothing at all
+// for a Task that was OOM-killed — the container stayed exactly as
+// small. The agentbox cap gets the WHOLE budget (bounded by the floor
+// and ceiling): it is the heaviest and most solitary workload, and
+// admission control is what prevents two of them overlapping.
 //
 // 1 CPU core = 1e9 NanoCPUs in Docker's accounting.
 func resolveContainerLimits() (memoryBytes int64, nanoCPUs int64) {
-	memoryBytes = defaultMemoryBytes
-	if v := os.Getenv(memoryBytesEnvVar); v != "" {
-		if parsed, err := strconv.ParseInt(v, 10, 64); err == nil && parsed > 0 {
-			memoryBytes = parsed
-		}
+	memoryBytes = clampMemory(memoryBudget(), agentboxMemoryFloorBytes, agentboxMemoryCeilingBytes)
+	if override := envMemoryOverride(memoryBytesEnvVar); override > 0 {
+		memoryBytes = override
 	}
-	cores := defaultCPUCores
-	if v := os.Getenv(cpuCoresEnvVar); v != "" {
-		if parsed, err := strconv.ParseInt(v, 10, 64); err == nil && parsed > 0 {
-			cores = parsed
-		}
+	// CPU is a throttle, not a kill: exceeding it slows the container
+	// rather than killing it, so handing the agent every core is safe
+	// even when jobs overlap. Memory gets the careful treatment above
+	// precisely because it is the one that kills.
+	cores := hostCPUCores()
+	if override := envCoresOverride(cpuCoresEnvVar); override > 0 {
+		cores = override
 	}
 	nanoCPUs = cores * 1_000_000_000
 	return memoryBytes, nanoCPUs

--- a/jobs/commands/run_agent_step.go
+++ b/jobs/commands/run_agent_step.go
@@ -722,6 +722,22 @@ func (rs *RunAgentStep) spawnAgentboxAndWait(spec agentboxSpawnSpec, logsWriter 
 		}()
 		go func() { _ = mcpSrv.ServeListener(mcpCtx, ln) }()
 	}
+	// Reserve host memory before creating the container, and hold it until
+	// the container is gone. Registered BEFORE the removeContainer defer
+	// below so LIFO ordering releases the memory AFTER the container is
+	// actually removed — releasing while it still exists would let the
+	// next job in be admitted against memory that is still in use.
+	//
+	// resolveContainerLimits is called again here rather than threaded
+	// through the spec: it is deterministic (memoized host read plus env
+	// lookups), so both call sites necessarily agree on the number.
+	agentMemoryBytes, _ := resolveContainerLimits()
+	releaseMemory, err := acquireMemory(dockerCtx, agentMemoryBytes, "the agent container", logsWriter)
+	if err != nil {
+		return agentResult{}, err
+	}
+	defer releaseMemory()
+
 	containerID, err := createAgentboxContainer(dockerCtx, cli, spec)
 	if err != nil {
 		return agentResult{}, err
@@ -1396,6 +1412,17 @@ func (rs *RunAgentStep) spawnVendorAndWait(spec agentboxSpawnSpec, logsWriter io
 		return err
 	}
 	defer cli.Close()
+	// The vendor phase gets the same cap as the agent phase (both go
+	// through createAgentboxContainer), so it must reserve the same
+	// weight. It runs BEFORE the agent container in the same Step and the
+	// two never overlap, so this does not double-count the Step.
+	vendorMemoryBytes, _ := resolveContainerLimits()
+	releaseMemory, err := acquireMemory(dockerCtx, vendorMemoryBytes, "the dependency-vendoring container", logsWriter)
+	if err != nil {
+		return err
+	}
+	defer releaseMemory()
+
 	containerID, err := createAgentboxContainer(dockerCtx, cli, spec)
 	if err != nil {
 		return err

--- a/jobs/commands/run_agent_step.go
+++ b/jobs/commands/run_agent_step.go
@@ -732,7 +732,7 @@ func (rs *RunAgentStep) spawnAgentboxAndWait(spec agentboxSpawnSpec, logsWriter 
 	// through the spec: it is deterministic (memoized host read plus env
 	// lookups), so both call sites necessarily agree on the number.
 	agentMemoryBytes, _ := resolveContainerLimits()
-	releaseMemory, err := acquireMemory(dockerCtx, agentMemoryBytes, "the agent container", logsWriter)
+	releaseMemory, err := acquireMemory(rs.stopSignal, agentMemoryBytes, "the agent container", logsWriter)
 	if err != nil {
 		return agentResult{}, err
 	}
@@ -1417,7 +1417,7 @@ func (rs *RunAgentStep) spawnVendorAndWait(spec agentboxSpawnSpec, logsWriter io
 	// weight. It runs BEFORE the agent container in the same Step and the
 	// two never overlap, so this does not double-count the Step.
 	vendorMemoryBytes, _ := resolveContainerLimits()
-	releaseMemory, err := acquireMemory(dockerCtx, vendorMemoryBytes, "the dependency-vendoring container", logsWriter)
+	releaseMemory, err := acquireMemory(rs.stopSignal, vendorMemoryBytes, "the dependency-vendoring container", logsWriter)
 	if err != nil {
 		return err
 	}

--- a/jobs/commands/run_agent_step_test.go
+++ b/jobs/commands/run_agent_step_test.go
@@ -46,15 +46,65 @@ func TestSubscriptionAuth_ClaudeCodeOnly(t *testing.T) {
 	}
 }
 
-func TestResolveContainerLimits_Defaults(t *testing.T) {
+// TestResolveContainerLimits_DerivedFromHost pins the property that
+// replaced the old flat 4 GB constant: with no override, the cap comes
+// from the host and always lands inside the floor/ceiling band. The
+// exact value is machine-dependent (CI, a laptop and an m6a.large all
+// differ), so this asserts the invariants rather than a number.
+//
+// The floor is the important half. It is the pre-existing 4 GB default,
+// and deriving from the host must never hand a Task LESS memory than it
+// had before this change.
+func TestResolveContainerLimits_DerivedFromHost(t *testing.T) {
 	t.Setenv(memoryBytesEnvVar, "")
 	t.Setenv(cpuCoresEnvVar, "")
 	mem, nano := resolveContainerLimits()
-	if mem != defaultMemoryBytes {
-		t.Errorf("memory = %d, want default %d", mem, defaultMemoryBytes)
+
+	if want := clampMemory(memoryBudget(), agentboxMemoryFloorBytes, agentboxMemoryCeilingBytes); mem != want {
+		t.Errorf("memory = %d, want host-derived %d", mem, want)
 	}
-	if nano != defaultCPUCores*1_000_000_000 {
-		t.Errorf("nanoCPUs = %d, want default %d", nano, defaultCPUCores*1_000_000_000)
+	if mem > agentboxMemoryCeilingBytes {
+		t.Errorf("memory %d exceeds ceiling %d", mem, agentboxMemoryCeilingBytes)
+	}
+	// Only assert the floor when the host can actually back it — a small
+	// dev machine legitimately lands below it (clampMemory prefers a cap
+	// the machine can honour over a floor it cannot).
+	if memoryBudget() >= agentboxMemoryFloorBytes && mem < agentboxMemoryFloorBytes {
+		t.Errorf("memory %d regressed below the previous default %d on a host with budget %d",
+			mem, agentboxMemoryFloorBytes, memoryBudget())
+	}
+	if nano != hostCPUCores()*1_000_000_000 {
+		t.Errorf("nanoCPUs = %d, want host cores %d", nano, hostCPUCores()*1_000_000_000)
+	}
+}
+
+// TestResolveContainerLimits_NeverExceedsBudget is the regression test
+// for the bug this change set out to fix: caps that summed to more than
+// the machine had. No single container may be sized above the whole
+// budget, whatever the host reports.
+func TestResolveContainerLimits_NeverExceedsBudget(t *testing.T) {
+	t.Setenv(memoryBytesEnvVar, "")
+	t.Setenv(cpuCoresEnvVar, "")
+	agentMem, _ := resolveContainerLimits()
+	buildMem, _ := resolveBuildLimits()
+	imageMem, _ := resolveImageBuildLimits()
+	budget := memoryBudget()
+
+	for _, tc := range []struct {
+		name string
+		mem  int64
+	}{
+		{"agentbox", agentMem},
+		{"static build", buildMem},
+		{"image build", imageMem},
+	} {
+		if tc.mem > budget {
+			t.Errorf("%s cap %d exceeds the host budget %d", tc.name, tc.mem, budget)
+		}
+	}
+	// The budget itself must leave the host something to run on.
+	if budget >= hostMemoryBytes() {
+		t.Errorf("budget %d leaves no reserve out of host memory %d", budget, hostMemoryBytes())
 	}
 }
 
@@ -78,11 +128,11 @@ func TestResolveContainerLimits_InvalidEnvFallsBack(t *testing.T) {
 	t.Setenv(memoryBytesEnvVar, "not-a-number")
 	t.Setenv(cpuCoresEnvVar, "abc")
 	mem, nano := resolveContainerLimits()
-	if mem != defaultMemoryBytes {
-		t.Errorf("memory with invalid env = %d, want default %d", mem, defaultMemoryBytes)
+	if want := clampMemory(memoryBudget(), agentboxMemoryFloorBytes, agentboxMemoryCeilingBytes); mem != want {
+		t.Errorf("memory with invalid env = %d, want host-derived %d", mem, want)
 	}
-	if nano != defaultCPUCores*1_000_000_000 {
-		t.Errorf("nanoCPUs with invalid env = %d, want default %d", nano, defaultCPUCores*1_000_000_000)
+	if nano != hostCPUCores()*1_000_000_000 {
+		t.Errorf("nanoCPUs with invalid env = %d, want host cores %d", nano, hostCPUCores()*1_000_000_000)
 	}
 }
 
@@ -94,11 +144,11 @@ func TestResolveContainerLimits_NegativeEnvFallsBack(t *testing.T) {
 	t.Setenv(memoryBytesEnvVar, "-1")
 	t.Setenv(cpuCoresEnvVar, "0")
 	mem, nano := resolveContainerLimits()
-	if mem != defaultMemoryBytes {
-		t.Errorf("memory with negative env = %d, want default %d", mem, defaultMemoryBytes)
+	if want := clampMemory(memoryBudget(), agentboxMemoryFloorBytes, agentboxMemoryCeilingBytes); mem != want {
+		t.Errorf("memory with negative env = %d, want host-derived %d", mem, want)
 	}
-	if nano != defaultCPUCores*1_000_000_000 {
-		t.Errorf("nanoCPUs with zero env = %d, want default %d", nano, defaultCPUCores*1_000_000_000)
+	if nano != hostCPUCores()*1_000_000_000 {
+		t.Errorf("nanoCPUs with zero env = %d, want host cores %d", nano, hostCPUCores()*1_000_000_000)
 	}
 }
 

--- a/jobs/commands/run_assistant_session.go
+++ b/jobs/commands/run_assistant_session.go
@@ -218,6 +218,17 @@ func (rs *RunAssistantSession) runSession(orgID, jobID, imageRef, workDirHost st
 		return err
 	}
 	defer cli.Close()
+	// Assistant sessions share createAgentboxContainer with Tasks, so they
+	// carry the same memory cap and must reserve the same weight. A long
+	// interactive session holding the budget is intentional: it is using
+	// that memory for as long as it is alive.
+	sessionMemoryBytes, _ := resolveContainerLimits()
+	releaseMemory, err := acquireMemory(dockerCtx, sessionMemoryBytes, "the assistant session container", logsWriter)
+	if err != nil {
+		return err
+	}
+	defer releaseMemory()
+
 	containerID, err := createAgentboxContainer(dockerCtx, cli, agentboxSpawnSpec{imageRef: imageRef, workDirHost: workDirHost, env: envVars})
 	if err != nil {
 		return err

--- a/jobs/commands/run_assistant_session.go
+++ b/jobs/commands/run_assistant_session.go
@@ -223,7 +223,7 @@ func (rs *RunAssistantSession) runSession(orgID, jobID, imageRef, workDirHost st
 	// interactive session holding the budget is intentional: it is using
 	// that memory for as long as it is alive.
 	sessionMemoryBytes, _ := resolveContainerLimits()
-	releaseMemory, err := acquireMemory(dockerCtx, sessionMemoryBytes, "the assistant session container", logsWriter)
+	releaseMemory, err := acquireMemory(rs.stopSignal, sessionMemoryBytes, "the assistant session container", logsWriter)
 	if err != nil {
 		return err
 	}

--- a/utils/hostinfo/hostinfo.go
+++ b/utils/hostinfo/hostinfo.go
@@ -1,0 +1,110 @@
+// Package hostinfo reports the physical resources of the machine the
+// runner is running on.
+//
+// It exists as its own package because two callers need it and they sit
+// on opposite sides of an existing import edge: jobs/commands sizes
+// containers from these numbers, and client reports them to the control
+// plane on ping. jobs/commands already imports client, so the detection
+// cannot live in either without creating a cycle.
+package hostinfo
+
+import (
+	"bufio"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// FallbackMemoryBytes is used when /proc/meminfo can't be read (a
+// non-Linux dev machine, an unexpectedly restricted procfs). It is
+// deliberately the size of the smallest instance we ship, so anything
+// derived from it lands on known-safe values rather than on something
+// optimistic that a small host can't honor.
+const FallbackMemoryBytes = 8 * 1024 * 1024 * 1024 // 8 GB
+
+const procMeminfoPath = "/proc/meminfo"
+
+var (
+	memoryOnce  sync.Once
+	memoryCache int64
+)
+
+// MemoryBytes returns the TOTAL physical memory of the machine the
+// runner container is running on — deliberately the host's memory, not
+// the runner's own cgroup limit.
+//
+// The distinction matters and is easy to get backwards. The runner runs
+// as an ECS task with a 6 GB task-level limit, so reading its own cgroup
+// would report 6 GB on an 8 GB box. But the containers being sized from
+// this are NOT children of the runner: they are siblings created through
+// the mounted Docker socket, so they draw from host memory and are
+// capped independently. The number we need to divide up is the host's.
+//
+// /proc/meminfo is not namespaced by Docker, so MemTotal read from
+// inside the container is the host's MemTotal. That is exactly what we
+// want, and is why this reads procfs directly rather than using a
+// cgroup-aware memory library.
+//
+// Cached: the value cannot change while the process lives, and this is
+// called on every container create.
+func MemoryBytes() int64 {
+	memoryOnce.Do(func() {
+		memoryCache = readMemTotalBytes(procMeminfoPath)
+		if memoryCache <= 0 {
+			memoryCache = FallbackMemoryBytes
+		}
+	})
+	return memoryCache
+}
+
+// readMemTotalBytes parses the MemTotal line out of a meminfo-formatted
+// file and returns it in bytes. Returns 0 on any failure so the caller
+// applies its fallback — this runs on the container-create path and a
+// missing procfs must never fail a job.
+//
+// The line looks like "MemTotal:       16116496 kB" — the unit is always
+// kB in practice, but the suffix is checked rather than assumed so a
+// unitless or differently-suffixed value degrades to the fallback
+// instead of being silently misread by three orders of magnitude.
+func readMemTotalBytes(path string) int64 {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "MemTotal:") {
+			continue
+		}
+		fields := strings.Fields(line)
+		// Expect exactly: ["MemTotal:", "<number>", "kB"]
+		if len(fields) != 3 || !strings.EqualFold(fields[2], "kB") {
+			return 0
+		}
+		kb, err := strconv.ParseInt(fields[1], 10, 64)
+		if err != nil || kb <= 0 {
+			return 0
+		}
+		return kb * 1024
+	}
+	return 0
+}
+
+// CPUCores returns the number of logical CPUs available to the runner
+// process.
+//
+// runtime.NumCPU respects CPU affinity but not cgroup CPU quota, and the
+// runner's task definition sets no task-level or container-level Cpu, so
+// on ECS this is the host's vCPU count — which is what we want for the
+// same sibling-container reason as MemoryBytes.
+func CPUCores() int64 {
+	if n := runtime.NumCPU(); n > 0 {
+		return int64(n)
+	}
+	return 1
+}

--- a/utils/hostinfo/hostinfo_test.go
+++ b/utils/hostinfo/hostinfo_test.go
@@ -1,0 +1,91 @@
+package hostinfo
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestReadMemTotalBytes covers the parse that container sizing is built
+// on. A misread here would silently mis-size every container the runner
+// spawns by orders of magnitude, so malformed input must return 0 (which
+// makes the caller apply the 8 GB fallback) rather than a wrong number.
+func TestReadMemTotalBytes(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    int64
+	}{
+		{
+			name:    "typical meminfo",
+			content: "MemTotal:       16116496 kB\nMemFree:         1234 kB\n",
+			want:    16116496 * 1024,
+		},
+		{
+			name:    "MemTotal not first line",
+			content: "SwapTotal:      0 kB\nMemTotal:       8046736 kB\n",
+			want:    8046736 * 1024,
+		},
+		{
+			name: "missing MemTotal",
+			// A procfs without the line at all must not be guessed at.
+			content: "MemFree:         1234 kB\n",
+			want:    0,
+		},
+		{
+			name: "unexpected unit",
+			// Refusing an unknown unit is the whole point: silently
+			// treating an mB value as kB would be a 1000x error.
+			content: "MemTotal:       16116496 mB\n",
+			want:    0,
+		},
+		{
+			name:    "no unit suffix",
+			content: "MemTotal:       16116496\n",
+			want:    0,
+		},
+		{
+			name:    "non-numeric value",
+			content: "MemTotal:       lots kB\n",
+			want:    0,
+		},
+		{
+			name:    "zero value",
+			content: "MemTotal:       0 kB\n",
+			want:    0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "meminfo")
+			if err := os.WriteFile(path, []byte(tc.content), 0o600); err != nil {
+				t.Fatalf("write meminfo: %v", err)
+			}
+			if got := readMemTotalBytes(path); got != tc.want {
+				t.Errorf("readMemTotalBytes() = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestReadMemTotalBytes_MissingFile(t *testing.T) {
+	if got := readMemTotalBytes(filepath.Join(t.TempDir(), "does-not-exist")); got != 0 {
+		t.Errorf("readMemTotalBytes(missing) = %d, want 0 so the caller falls back", got)
+	}
+}
+
+// TestMemoryBytesAlwaysPositive guards the fallback path: callers divide
+// by and clamp against this value, so it must never be zero even on a
+// machine with no readable procfs (every dev Mac, for instance).
+func TestMemoryBytesAlwaysPositive(t *testing.T) {
+	if got := MemoryBytes(); got <= 0 {
+		t.Errorf("MemoryBytes() = %d, want a positive value", got)
+	}
+}
+
+func TestCPUCoresAlwaysPositive(t *testing.T) {
+	if got := CPUCores(); got < 1 {
+		t.Errorf("CPUCores() = %d, want at least 1", got)
+	}
+}

--- a/utils/hostinfo/instance_type.go
+++ b/utils/hostinfo/instance_type.go
@@ -2,6 +2,8 @@ package hostinfo
 
 import (
 	"context"
+	"io"
+	"strings"
 	"sync"
 	"time"
 
@@ -15,6 +17,11 @@ import (
 // nicety and must never delay a runner's first ping to the control
 // plane, which is what marks the runner alive.
 const imdsTimeout = 2 * time.Second
+
+// maxInstanceTypeBytes bounds the metadata read. Real values are short
+// ("m6a.large"); the limit only exists so a misbehaving endpoint cannot
+// stream unbounded data into memory.
+const maxInstanceTypeBytes = 256
 
 var (
 	instanceTypeOnce  sync.Once
@@ -51,11 +58,21 @@ func InstanceType() string {
 		}
 		defer out.Content.Close()
 
-		buf := make([]byte, 64)
-		n, _ := out.Content.Read(buf)
-		if n > 0 {
-			instanceTypeCache = string(buf[:n])
+		// io.ReadAll, not a single Read into a fixed buffer. An io.Reader
+		// may return fewer bytes than are available, so one Read on an HTTP
+		// body can hand back a partial value — and because the result is
+		// memoized by sync.Once, a truncated "m6a." would be cached for the
+		// process lifetime, sent on the ping, persisted, and rendered in the
+		// dashboard with no error and no retry anywhere.
+		//
+		// The response is a short token like "m6a.large"; cap the read
+		// anyway so a misbehaving endpoint cannot stream unbounded data
+		// into memory.
+		body, err := io.ReadAll(io.LimitReader(out.Content, maxInstanceTypeBytes))
+		if err != nil {
+			return
 		}
+		instanceTypeCache = strings.TrimSpace(string(body))
 	})
 	return instanceTypeCache
 }

--- a/utils/hostinfo/instance_type.go
+++ b/utils/hostinfo/instance_type.go
@@ -1,0 +1,61 @@
+package hostinfo
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
+)
+
+// imdsTimeout bounds the metadata lookup. IMDS is a link-local address
+// that answers in single-digit milliseconds when present and hangs when
+// absent, so this is short on purpose: the instance type is a display
+// nicety and must never delay a runner's first ping to the control
+// plane, which is what marks the runner alive.
+const imdsTimeout = 2 * time.Second
+
+var (
+	instanceTypeOnce  sync.Once
+	instanceTypeCache string
+)
+
+// InstanceType returns the EC2 instance type of the host (e.g.
+// "m6a.large"), or an empty string on anything that is not an EC2
+// instance or where IMDS is unreachable.
+//
+// Best-effort by design. Every caller treats the empty string as "not
+// known" and the model field is omitempty, so a failure here degrades to
+// a blank column rather than an error.
+//
+// Note this is the RUNNER reaching IMDS, which is allowed and expected.
+// It is the agentbox and build CONTAINERS that are firewalled off from
+// 169.254.169.254 (see the ExtraHosts pins in run_agent_step.go), so
+// that untrusted agent or build code cannot reach the host's IAM
+// credentials. Nothing here is exposed to those containers.
+func InstanceType() string {
+	instanceTypeOnce.Do(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), imdsTimeout)
+		defer cancel()
+
+		cfg, err := config.LoadDefaultConfig(ctx)
+		if err != nil {
+			return
+		}
+		out, err := imds.NewFromConfig(cfg).GetMetadata(ctx, &imds.GetMetadataInput{
+			Path: "instance-type",
+		})
+		if err != nil {
+			return
+		}
+		defer out.Content.Close()
+
+		buf := make([]byte, 64)
+		n, _ := out.Content.Read(buf)
+		if n > 0 {
+			instanceTypeCache = string(buf[:n])
+		}
+	})
+	return instanceTypeCache
+}


### PR DESCRIPTION
## Why

Agent Tasks building a real Go repo were being OOM-killed. agentbox reported:

```
[agentbox] memory ran close to the limit — peak 4.0 GiB of a 4.0 GiB limit.
```

and an earlier run on the same workload died with an unexplained `claude exited with error: signal: killed` — a cgroup OOM kill.

Investigating that turned up something worse than the original bug. Every container the runner spawns carried a hardcoded memory cap with no relationship to the machine underneath, and the caps were wrong in **both** directions:

- **Too small on a big host.** The agentbox cap was a flat 4 GB regardless of instance size, so upgrading the runner EC2 instance gave Tasks *exactly zero* extra room.
- **Too large in aggregate.** On the shipped `m6a.large` (2 vCPU, 8 GB), the runner's own ECS task limit is 6 GB and a 4 GB agentbox container spawns **alongside** it as a sibling through the mounted Docker socket — outside ECS accounting entirely. That's 10 GB of caps on a ~7.7 GB machine. It only survived because the runner process itself uses a few hundred MB and heavy jobs rarely overlapped.

And a survey of all 32 command types found the biggest hole: **`docker build` was completely uncapped.** agentbox and the static-site build container were both limited; image builds were not. That path runs inside **dockerd**, not the runner's cgroup, so it was invisible to ECS accounting and every runner-side limit, and a heavy build could take the whole host and let the kernel OOM-killer pick a victim — potentially dockerd or the runner itself, killing every in-flight job with no useful error.

## What

**1. Caps derive from the host** (`utils/hostinfo` + `jobs/commands/host_resources.go`)

From `/proc/meminfo` `MemTotal` minus a reserve for the kernel, dockerd, and the runner. Deliberately the **host's** memory, not the runner's cgroup: the containers being sized are siblings via the Docker socket, not children, so the runner's own 6 GB task limit is the wrong number. `/proc/meminfo` isn't namespaced by Docker, so this reads the host from inside the container.

Floors keep it from ever regressing (agentbox floor is the previous 4 GB default). On `m6a.large` agentbox goes 4 GB → ~6 GB; on a larger instance it scales with no retuning. All existing env overrides still win.

**2. Image builds are now capped**, with `MemorySwap == Memory` so an overrun fails fast instead of thrashing. Sized generously against the previously unbounded behaviour, with `BUILD_IMAGE_MEMORY_BYTES` / `BUILD_IMAGE_CPU_CORES` as escape hatches.

**3. Concurrency is gated by weight, not count** (`jobs/commands/admission.go`)

Sizing bounds one container but says nothing about several at once, and the dispatcher is a 3-lane pipeline of 5-worker pools — up to 15 jobs in flight, none of it memory-aware.

Making the worker count a function of RAM would be the wrong fix: most of the 32 command types are AWS API calls needing essentially no memory, so throttling by count would slow deploys to protect against a workload they have nothing to do with. Instead only container-creating jobs acquire memory, for the amount they were sized for.

On `m6a.large` that means one agentbox Task or one image build at a time, while several static-site builds still run in parallel. This is also what makes the generous per-container sizing safe — giving agentbox the whole budget would be reckless if two could overlap.

Wired into all four call sites: the agent container, the vendor container, Assistant sessions (which share `createAgentboxContainer` with Tasks), and the static-site build.

**4. Reports host specs on ping** for the control plane (see `deployment-io/deployment-runner-kit#71`). Host detection lives in `utils/hostinfo` because the ping client needs it too and `jobs/commands` already imports `client` — keeping it in `jobs/commands` would be an import cycle.

## Known gap

**nixpacks builds are neither capped nor counted.** `nixpacks-go` exposes no resource fields and shells out to the `nixpacks` CLI, which runs its own `docker build` with no seam to pass `--memory` through. Documented at the call site. Closing it means having nixpacks emit a Dockerfile via `BuildOptions.Output` and building that through the now-capped path — a larger change than adding a limit, so it's called out rather than done silently.

## Risk

The image-build cap is the real risk: that path has been unbounded for a long time, so a build that legitimately uses more than the derived cap will start failing. Mitigated by sizing it to the whole budget (not a share) and by the env override. Worth watching after release.

Admission weights are clamped to total capacity, so an oversized env override serializes jobs rather than deadlocking on memory that will never exist.

## Verification

`go build ./...`, `go vet`, and the full `go test ./...` pass. New tests cover the meminfo parse (including malformed input that must fall back rather than misread by 1000x), the budget-always-leaves-a-reserve invariant, clamping, admission weight clamping, and acquire/release. Existing limit tests asserted the removed constants and now assert the host-derived contract, including that no cap can exceed the budget.

**Not yet verified on a live runner** — the sizing has only run on a dev machine. The numbers that matter come from `/proc/meminfo` on the real host, so first real confirmation is a Task on a deployed runner.

## Merge order

After `deployment-io/deployment-runner-kit#71`. Full chain is described there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)