### PR TITLE
Log runner capacity once per spell, and the budget at boot

### DIFF
--- a/entrypoints/common/capacity_log_test.go
+++ b/entrypoints/common/capacity_log_test.go
@@ -1,0 +1,81 @@
+package common
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// TestCapacitySpellLogsOncePerSpell pins the whole point of the pair: a job
+// blocked behind a long agent container is re-offered every 10s, so a runner
+// that logged every refusal would emit ~360 identical lines an hour for a
+// single queued job. One line must mark the start of a saturated spell and one
+// the end, however many refusals happen in between.
+func TestCapacitySpellLogsOncePerSpell(t *testing.T) {
+	capacityLogged.Store(false)
+
+	if !enteringCapacitySpell() {
+		t.Fatal("the first refusal must log; an operator has no other way to tell " +
+			"'runner at capacity' apart from 'job never picked up'")
+	}
+	for i := 0; i < 100; i++ {
+		if enteringCapacitySpell() {
+			t.Fatalf("refusal %d logged again mid-spell; that is the noise this exists to stop", i+2)
+		}
+	}
+
+	if !leavingCapacitySpell() {
+		t.Fatal("recovery must log once so the spell has a visible end")
+	}
+	if leavingCapacitySpell() {
+		t.Error("recovery logged twice; admissions after the first must stay quiet")
+	}
+
+	// A second spell is a genuinely new event and must be reported again,
+	// otherwise the runner goes silent for the rest of its life after one
+	// episode.
+	if !enteringCapacitySpell() {
+		t.Error("a later spell must log; the flag has to reset on recovery")
+	}
+}
+
+// TestCapacitySpellIsRaceSafe covers the reason these are compare-and-swaps
+// rather than a load followed by a store. Job workers run concurrently, and a
+// read-then-write leaves a window where two of them both see "not saturated"
+// and both conclude they were first -- producing exactly the duplicate line
+// this change removes. Note that -race alone will NOT catch that: Load and
+// Store are each atomic, so there is no data race to report, only a logic one.
+// Hence the start barrier and the repeats: the goroutines are released
+// together, which is what makes the window observable.
+func TestCapacitySpellIsRaceSafe(t *testing.T) {
+	const (
+		workers  = 64
+		attempts = 500
+	)
+
+	for attempt := 0; attempt < attempts; attempt++ {
+		capacityLogged.Store(false)
+
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		var logged atomic.Int64
+
+		for i := 0; i < workers; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				if enteringCapacitySpell() {
+					logged.Add(1)
+				}
+			}()
+		}
+		close(start)
+		wg.Wait()
+
+		if got := logged.Load(); got != 1 {
+			t.Fatalf("attempt %d: %d of %d concurrent refusals logged, want exactly 1",
+				attempt, got, workers)
+		}
+	}
+}

--- a/entrypoints/common/common.go
+++ b/entrypoints/common/common.go
@@ -24,6 +24,7 @@ import (
 	"github.com/deployment-io/deployment-runner/jobs/commands"
 	commandUtils "github.com/deployment-io/deployment-runner/jobs/commands/utils"
 	"github.com/deployment-io/deployment-runner/jobs/resources"
+	"github.com/deployment-io/deployment-runner/utils/hostinfo"
 	"github.com/deployment-io/deployment-runner/utils/loggers"
 )
 
@@ -76,6 +77,21 @@ func getJobResult(job pendingJobType, error string, parameters map[string]interf
 // record exists. Nothing else reaps a Running job. Giving up here would
 // leave a job invisible, never retried and never failed.
 var releaseJobsPipeline *goPipeline.Pipeline[string, string]
+
+// capacityLogged is true while the runner is in a saturated spell that has
+// already been reported, so the log carries one line per spell rather than one
+// per refusal. Job workers run concurrently, hence the atomic; a lost race
+// costs at most a duplicate or a skipped line, which is acceptable for a log
+// and not worth a mutex on the admission path.
+var capacityLogged atomic.Bool
+
+// enteringCapacitySpell reports true exactly once per saturated spell, and
+// leavingCapacitySpell exactly once per recovery. They are compare-and-swaps,
+// not a load followed by a store: several job workers hit this concurrently,
+// and a read-then-write would let two of them both decide they were first.
+func enteringCapacitySpell() bool { return capacityLogged.CompareAndSwap(false, true) }
+
+func leavingCapacitySpell() bool { return capacityLogged.CompareAndSwap(true, false) }
 
 func handleLogEnd(err error, jobID string, logsWriter io.Writer) {
 	if err != nil {
@@ -150,19 +166,28 @@ func executeJobs(jobsStream <-chan pendingJobType, noOfWorkers int, mode runner_
 								// resultsStream — that path marks the job
 								// complete. The job returns to pending and is
 								// offered again once capacity frees.
-								// Logged to the RUNNER's log, not the job's.
-								// The job's log has to stay clean for its
-								// eventual real run (this fires ~1440 times
-								// behind a 4h session), but going silent would
-								// leave an operator unable to tell "runner at
-								// capacity" apart from a job that was never
-								// picked up at all. The runner's log is
-								// operator-facing and ships to CloudWatch,
-								// where this cadence is unremarkable.
-								log.Printf("runner at memory capacity (%d MB needed of a %d MB budget); "+
-									"returning job %s to the pending queue",
-									requiredMemory/(1024*1024), resources.MemoryBudgetBytes()/(1024*1024),
-									pendingJob.jobID)
+								//
+								// Logged to the RUNNER's log, not the job's:
+								// the job's log has to stay clean for its
+								// eventual real run.
+								//
+								// Only the FIRST refusal of a saturated spell
+								// is logged. A blocked job is re-offered every
+								// 10s, so logging each one buries real errors
+								// under ~360 identical lines an hour per job —
+								// and on a small host, where one agent
+								// container can take the whole budget, every
+								// queued job takes this path. The operator
+								// still needs to tell "runner at capacity"
+								// apart from "never picked up", but one line
+								// per spell says that; the repeats add nothing.
+								if enteringCapacitySpell() {
+									log.Printf("runner at memory capacity (%d MB needed of a %d MB budget); "+
+										"returning job %s to the pending queue. Further jobs will be "+
+										"returned silently until capacity frees",
+										requiredMemory/(1024*1024), resources.MemoryBudgetBytes()/(1024*1024),
+										pendingJob.jobID)
+								}
 								// Handed to the pipeline rather than sent
 								// here, so releases batch per org and the
 								// retry runs off this worker.
@@ -194,6 +219,14 @@ func executeJobs(jobsStream <-chan pendingJobType, noOfWorkers int, mode runner_
 								// that rather than a new behaviour.
 								releaseJobsPipeline.Add(pendingJob.organizationID, pendingJob.jobID)
 								return
+							}
+							// Capacity exists again, so the next refusal is a
+							// new spell and gets logged. Cleared on admission
+							// rather than on release because only an admission
+							// proves a job actually fit.
+							if leavingCapacitySpell() {
+								log.Printf("runner has memory capacity again (%d MB budget); resuming normally",
+									resources.MemoryBudgetBytes()/(1024*1024))
 							}
 							defer releaseMemory()
 						}
@@ -438,6 +471,32 @@ func Init() {
 	commandUtils.Init()
 	loggers.Init()
 	jobs.RegisterGobDataTypes()
+	logResourceBudget()
+}
+
+// logResourceBudget records, once at boot, the sizing this runner derived from
+// its host. Every other signal that admission control is active only appears
+// under contention, so without this line a runner that computed a small budget
+// looks exactly like one running a build that predates admission control.
+//
+// It also surfaces a failed memory probe: a host reporting 0 MB measured is
+// sizing every container off the fallback, which is a guess, not a measurement.
+func logResourceBudget() {
+	const mb = 1024 * 1024
+	agentMemory, agentNanoCPUs := resources.LimitsForAgentContainer()
+	staticMemory, _ := resources.LimitsForStaticSiteBuild()
+	imageMemory, _ := resources.LimitsForImageBuild()
+
+	measured := "measured"
+	if hostinfo.MeasuredMemoryBytes() == 0 {
+		measured = "UNMEASURED, using fallback"
+	}
+	log.Printf("host %d MB (%s), %d vCPU; job memory budget %d MB; caps: agent %d MB/%d vCPU, "+
+		"static build %d MB, image build %d MB, assistant session %d MB",
+		hostinfo.MemoryBytes()/mb, measured, hostinfo.CPUCores(),
+		resources.MemoryBudgetBytes()/mb,
+		agentMemory/mb, agentNanoCPUs/1_000_000_000,
+		staticMemory/mb, imageMemory/mb, resources.MemoryForAssistantSession()/mb)
 }
 
 func GetRuntimeEnvironment() (cpu_architecture_enums.Type, os_enums.Type) {


### PR DESCRIPTION
Follow-up to #120, from watching it run in production.

## What prompted this

The requeue path works — confirmed live on an `m6a.large` runner:

```
19:22:31 runner at memory capacity (3113 MB needed of a 6226 MB budget); returning job 6aa1... to the pending queue
19:22:41 runner at memory capacity (3113 MB needed of a 6226 MB budget); returning job 6aa1... to the pending queue
```

The 6226 MB budget matches the computed value for that host almost exactly, and 3113 MB is precisely the static-build allocation (`budget ÷ 2`), so the sizing is right. But note the two lines are the same job, 10 seconds apart.

## The problem

A refused job is re-offered every ~10s, so each one emits ~360 lines an hour. Behind a 4h Assistant session that is ~1440 identical lines for a **single** queued job. On a small host it is not an edge case: an agentbox container takes the entire 6226 MB budget on an `m6a.large`, so *every* queued job takes this path.

Cost is not the issue — ~$0.0001 per session in CloudWatch, ~$0.21/month even in a pathological case. Signal is: real errors sit buried under repeats carrying no information the first line did not.

The existing justification for logging was that an operator must be able to tell "runner at capacity" apart from "job never picked up". That supports the *first* line. It does not support the following 1,439.

## Changes

**Log transitions, not refusals.** One line entering a saturated spell, one on recovery:

```
runner at memory capacity (3113 MB needed of a 6226 MB budget); returning job <id> to the
pending queue. Further jobs will be returned silently until capacity frees
...
runner has memory capacity again (6226 MB budget); resuming normally
```

The flag clears on **admission** rather than release, because only an admission proves a job actually fit.

**Log the derived sizing at boot:**

```
host 7680 MB (measured), 2 vCPU; job memory budget 6226 MB; caps: agent 6226 MB/2 vCPU,
static build 3113 MB, image build 4096 MB, assistant session 2075 MB
```

Until now the only evidence admission control was active appeared under contention, so a runner that computed a small budget looked identical to one running a build predating admission control. The line also flags an **unmeasured** host, which is sizing every container off the 8 GB fallback rather than a measurement — worth knowing, since a wrong budget is invisible otherwise.

## On the compare-and-swaps

`enteringCapacitySpell` / `leavingCapacitySpell` are CAS, not load-then-store: job workers hit this concurrently and a read-then-write lets two of them both conclude they were first, producing exactly the duplicate line this removes.

Worth flagging for review: **`-race` does not catch that on its own.** `Load` and `Store` are each atomic, so it is a logic race, not a data race. The first version of this test passed against a deliberately broken implementation. The test now uses a start barrier over 64 goroutines × 500 attempts, and was verified to fail 5 runs out of 5 against load-then-store while passing 5 out of 5 against the CAS version.

## Verification

- `go build ./...`, `go vet ./...`, `go test ./...` clean
- `GOWORK=off go build ./...` clean (workspace not masking anything)
- `go test -race ./entrypoints/common/...` clean, and confirmed to fail when the logic is broken

## Not changed

The 10s retry cadence itself. Removing the churn would mean the runner not asking for work it cannot run, but it cannot know a job's memory need before handout, and container-free jobs (most of the 32 command types) must keep flowing while saturated. That needs job memory metadata server-side — a larger change, and the log volume was the actual complaint.